### PR TITLE
Clarify UTF-8 normalization in sanitize_string comment

### DIFF
--- a/dettaglio.php
+++ b/dettaglio.php
@@ -33,7 +33,7 @@ while ($row = $res->fetch_assoc()) {
 }
 
 function sanitize_string($str) {
-  $str = mb_convert_encoding($str, 'UTF-8', 'UTF-8'); // fornisce una conversione robusta
+  $str = mb_convert_encoding($str, 'UTF-8', 'UTF-8'); // normalizza la stringa in UTF-8
   $str = preg_replace('/[\x00-\x1F\x7F]/u', '', $str); // rimuove caratteri di controllo
   return $str;
 }


### PR DESCRIPTION
## Summary
- clarify comment in sanitize_string to state the call normalizes input to UTF-8

## Testing
- `php -l dettaglio.php`


------
https://chatgpt.com/codex/tasks/task_e_6892f248e3bc8331bc2b135e701a7bd1