### PR TITLE
Parametrize database credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+includes/db_config.php

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Gestione Famiglia
+
+## Configurazione del database
+
+L'applicazione non utilizza più credenziali hardcoded per la connessione MySQL. I parametri vengono letti dalle variabili d'ambiente:
+
+- `DB_HOST`
+- `DB_USER`
+- `DB_PASS`
+- `DB_NAME`
+- `DB_PORT` (opzionale, predefinito `3306`)
+
+Imposta queste variabili nell'ambiente in cui gira l'applicazione oppure crea un file `includes/db_config.php` **non versionato** che ritorni un array con gli stessi parametri:
+
+```php
+<?php
+return [
+    'host' => 'localhost',
+    'port' => '3306',
+    'user' => 'utente',
+    'pass' => 'password',
+    'name' => 'database',
+];
+```
+
+Il file `includes/db_config.php` è già incluso in `.gitignore` per evitare che le credenziali finiscano nel repository.

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,13 +1,30 @@
 <?php
-$host = "89.46.111.63";
-$port = "3306";
-$user = "Sql1203781";
-$password = "127450176p";
-$database = "Sql1203781_2";
+// Try to read configuration from environment variables
+$config = [
+    'host' => getenv('DB_HOST'),
+    'port' => getenv('DB_PORT'),
+    'user' => getenv('DB_USER'),
+    'pass' => getenv('DB_PASS'),
+    'name' => getenv('DB_NAME')
+];
+
+// Optionally load configuration from an untracked file
+if (file_exists(__DIR__ . '/db_config.php')) {
+    $fileConfig = include __DIR__ . '/db_config.php';
+    if (is_array($fileConfig)) {
+        $config = array_merge($config, $fileConfig);
+    }
+}
+
+$host = $config['host'] ?? 'localhost';
+$port = $config['port'] ?? '3306';
+$user = $config['user'] ?? '';
+$password = $config['pass'] ?? '';
+$database = $config['name'] ?? '';
 
 $conn = new mysqli($host, $user, $password, $database, $port);
 
 if ($conn->connect_error) {
-    die("Connessione fallita: " . $conn->connect_error);
+    die('Connessione fallita: ' . $conn->connect_error);
 }
 ?>


### PR DESCRIPTION
## Summary
- Read database connection settings from environment variables with optional untracked fallback file.
- Document database configuration and ignore `includes/db_config.php` to keep secrets out of Git.

## Testing
- `php -l includes/db.php`


------
https://chatgpt.com/codex/tasks/task_e_6892f2c14d288331b29debd0d82f6d35