### PR TITLE
Aggiunta filtro e visualizzazione etichette inattive

### DIFF
--- a/dettaglio.php
+++ b/dettaglio.php
@@ -160,6 +160,8 @@ include 'includes/header.php';
 <script>
 const etichette = <?= json_encode($etichette, JSON_UNESCAPED_UNICODE) ?>;
 const idMovimento = <?= (int)$id ?>;
+let mostraVecchie = false;
+let filtroEtichette = '';
 
 function openModal(field, value) {
   document.getElementById('fieldName').value = field;
@@ -191,20 +193,40 @@ function openSelectModal(field, selectedId) {
   new bootstrap.Modal(document.getElementById('editModal')).show();
 }
 
-function openEtichetteModal() {
+function renderEtichetteList() {
   const list = document.getElementById('etichetteList');
+  const selected = new Set(Array.from(list.querySelectorAll('input:checked')).map(e => e.value));
   list.innerHTML = '';
   for (let e of etichette) {
-    if (!e.attivo) continue;
+    if (!mostraVecchie && !e.attivo) continue;
+    if (filtroEtichette && !e.descrizione.toLowerCase().includes(filtroEtichette)) continue;
     const div = document.createElement('div');
     div.className = 'form-check';
     div.innerHTML = `
-      <input class="form-check-input" type="checkbox" id="et_${e.id_etichetta}" value="${e.id_etichetta}">
+      <input class="form-check-input" type="checkbox" id="et_${e.id_etichetta}" value="${e.id_etichetta}" ${selected.has(String(e.id_etichetta)) ? 'checked' : ''}>
       <label class="form-check-label" for="et_${e.id_etichetta}">${e.descrizione}</label>
     `;
     list.appendChild(div);
   }
+}
+
+function openEtichetteModal() {
+  mostraVecchie = false;
+  filtroEtichette = '';
+  document.getElementById('toggleInactive').checked = false;
+  document.querySelector('#etichetteModal input[type="text"]').value = '';
+  renderEtichetteList();
   new bootstrap.Modal(document.getElementById('etichetteModal')).show();
+}
+
+function filterEtichette(value) {
+  filtroEtichette = value.toLowerCase();
+  renderEtichetteList();
+}
+
+function toggleInactiveEtichette() {
+  mostraVecchie = document.getElementById('toggleInactive').checked;
+  renderEtichetteList();
 }
 
 function saveEtichette() {


### PR DESCRIPTION
## Summary
- Permette di visualizzare inizialmente solo le etichette attive nel modal di dettaglio
- Aggiunge campo di ricerca e opzione per mostrare anche le etichette disattivate
- Mantiene le selezioni correnti quando si filtra o si mostra/nasconde le etichette vecchie

## Testing
- `php -l dettaglio.php`


------
https://chatgpt.com/codex/tasks/task_e_68930aabc29c8331b7725301680fd96c