### PR TITLE
feat: add label detail view

### DIFF
--- a/ajax/load_movimenti_mese.php
+++ b/ajax/load_movimenti_mese.php
@@ -1,0 +1,40 @@
+<?php
+require_once __DIR__ . '/../includes/db.php';
+setlocale(LC_TIME, 'it_IT.UTF-8');
+
+$mese = $_GET['mese'] ?? date('Y-m');
+
+$stmt = $conn->prepare("SELECT id_movimento_revolut, started_date, amount, COALESCE(NULLIF(descrizione_extra, ''), description) AS descrizione, etichette FROM v_movimenti_revolut WHERE DATE_FORMAT(started_date, '%Y-%m') = ? ORDER BY started_date DESC");
+$stmt->bind_param('s', $mese);
+$stmt->execute();
+$result = $stmt->get_result();
+
+$giorno_corrente = '';
+while ($mov = $result->fetch_assoc()) {
+    $giorno = strftime('%A %e %B', strtotime($mov['started_date']));
+    if ($giorno !== $giorno_corrente) {
+        echo '<div class="day-header mt-3 mb-1 fw-bold">' . ucfirst($giorno) . '</div>';
+        $giorno_corrente = $giorno;
+    }
+
+    $importo = number_format($mov['amount'], 2, ',', '.');
+    $classe_importo = $mov['amount'] >= 0 ? 'text-success' : 'text-danger';
+    $ora = date('H:i', strtotime($mov['started_date']));
+    echo '<div class="movement d-flex align-items-center py-2">';
+    echo '  <div class="icon me-3"><i class="bi bi-arrow-left-right fs-4"></i></div>';
+    echo '  <div class="flex-grow-1">';
+    echo '    <div class="descr">' . htmlspecialchars($mov['descrizione']) . '</div>';
+    echo '    <div class="text-muted small">' . $ora . '</div>';
+    if (!empty($mov['etichette'])) {
+        echo '    <div class="mt-1">';
+        foreach (explode(',', $mov['etichette']) as $tag) {
+            $tag = trim($tag);
+            echo '      <a href="etichetta.php?etichetta=' . urlencode($tag) . '" class="badge-etichetta me-1 text-white">' . htmlspecialchars($tag) . '</a>';
+        }
+        echo '    </div>';
+    }
+    echo '  </div>';
+    echo '  <div class="amount ms-2 ' . $classe_importo . '">' . ($mov['amount'] >= 0 ? '+' : '') . $importo . ' €</div>';
+    echo '</div>';
+}
+?>

--- a/assets/style.css
+++ b/assets/style.css
@@ -24,4 +24,36 @@ body {
   display: inline-block;
   padding: 4px 8px;
   border-radius: 6px;
+  color: #fff;
+  text-decoration: none;
+  cursor: pointer;
+}
+.badge-etichetta:hover {
+  background-color: #5a6268;
+}
+.months-scroll {
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.months-scroll .btn {
+  border-radius: 20px;
+  min-width: 120px;
+  flex: 0 0 auto;
+}
+.months-scroll .btn.active {
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+  color: #fff;
+}
+.day-header {
+  font-size: .85rem;
+  text-transform: capitalize;
+}
+.movement {
+  border-bottom: 1px solid rgba(255,255,255,.1);
+}
+.amount {
+  min-width: 80px;
+  text-align: right;
+  font-weight: 500;
 }

--- a/etichetta.php
+++ b/etichetta.php
@@ -1,0 +1,50 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+include 'includes/header.php';
+setlocale(LC_TIME, 'it_IT.UTF-8');
+
+$etichetta = $_GET['etichetta'] ?? '';
+?>
+<h4 class="mb-3">Movimenti per etichetta: <?= htmlspecialchars($etichetta) ?></h4>
+<?php
+if ($etichetta === '') {
+    echo '<p class="text-center text-muted">Nessuna etichetta selezionata.</p>';
+} else {
+    $stmt = $conn->prepare("SELECT id_movimento_revolut, started_date, amount, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, etichette FROM v_movimenti_revolut WHERE FIND_IN_SET(?, etichette) ORDER BY started_date DESC");
+    $stmt->bind_param('s', $etichetta);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $giorno_corrente = '';
+    while ($mov = $result->fetch_assoc()) {
+        $giorno = strftime('%A %e %B', strtotime($mov['started_date']));
+        if ($giorno !== $giorno_corrente) {
+            echo '<div class="day-header mt-3 mb-1 fw-bold">' . ucfirst($giorno) . '</div>';
+            $giorno_corrente = $giorno;
+        }
+        $importo = number_format($mov['amount'], 2, ',', '.');
+        $classe_importo = $mov['amount'] >= 0 ? 'text-success' : 'text-danger';
+        $ora = date('H:i', strtotime($mov['started_date']));
+        echo '<div class="movement d-flex align-items-center py-2">';
+        echo '  <div class="icon me-3"><i class="bi bi-arrow-left-right fs-4"></i></div>';
+        echo '  <div class="flex-grow-1">';
+        echo '    <div class="descr">' . htmlspecialchars($mov['descrizione']) . '</div>';
+        echo '    <div class="text-muted small">' . $ora . '</div>';
+        if (!empty($mov['etichette'])) {
+            echo '    <div class="mt-1">';
+            foreach (explode(',', $mov['etichette']) as $tag) {
+                $tag = trim($tag);
+                echo '      <a href="etichetta.php?etichetta=' . urlencode($tag) . '" class="badge-etichetta me-1 text-white">' . htmlspecialchars($tag) . '</a>';
+            }
+            echo '    </div>';
+        }
+        echo '  </div>';
+        echo '  <div class="amount ms-2 ' . $classe_importo . '">' . ($mov['amount'] >= 0 ? '+' : '') . $importo . ' €</div>';
+        echo '</div>';
+    }
+    if ($giorno_corrente === '') {
+        echo '<p class="text-center text-muted">Nessun movimento per questa etichetta.</p>';
+    }
+}
+include 'includes/footer.php';
+?>

--- a/js/tutti_movimenti.js
+++ b/js/tutti_movimenti.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const buttons = document.querySelectorAll('.months-scroll button');
+    if (!buttons.length) return;
+
+    const loadMovimenti = (mese, clickedBtn) => {
+        buttons.forEach(btn => btn.classList.remove('active'));
+        clickedBtn.classList.add('active');
+
+        fetch(`ajax/load_movimenti_mese.php?mese=${encodeURIComponent(mese)}`)
+            .then(resp => resp.text())
+            .then(html => {
+                document.getElementById('movimenti').innerHTML = html;
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            });
+    };
+
+    buttons.forEach(btn => {
+        btn.addEventListener('click', () => loadMovimenti(btn.dataset.mese, btn));
+    });
+
+    // Carica il primo mese all'apertura
+    loadMovimenti(buttons[0].dataset.mese, buttons[0]);
+});


### PR DESCRIPTION
## Summary
- load monthly movements via AJAX
- make labels clickable and show dedicated page for each tag
- style movements list and month selector

## Testing
- `php -l tutti_movimenti.php`
- `php -l ajax/load_movimenti_mese.php`
- `php -l etichetta.php`


------
https://chatgpt.com/codex/tasks/task_e_689309675d248331b5f2f5f07acdd5a8