### PR TITLE
feature/etichette-movimenti-ui

### DIFF
--- a/etichetta.php
+++ b/etichetta.php
@@ -5,46 +5,121 @@ include 'includes/header.php';
 setlocale(LC_TIME, 'it_IT.UTF-8');
 
 $etichetta = $_GET['etichetta'] ?? '';
-?>
-<h4 class="mb-3">Movimenti per etichetta: <?= htmlspecialchars($etichetta) ?></h4>
-<?php
+$mese = $_GET['mese'] ?? '';
+
 if ($etichetta === '') {
     echo '<p class="text-center text-muted">Nessuna etichetta selezionata.</p>';
+    include 'includes/footer.php';
+    return;
+}
+
+// Lista mesi disponibili per questa etichetta
+$mesi = [];
+$stmtM = $conn->prepare("SELECT DATE_FORMAT(started_date,'%Y-%m') AS ym, DATE_FORMAT(started_date,'%M %Y') AS label FROM v_movimenti_revolut WHERE FIND_IN_SET(?, etichette) GROUP BY ym ORDER BY ym DESC");
+$stmtM->bind_param('s', $etichetta);
+$stmtM->execute();
+$resM = $stmtM->get_result();
+while ($row = $resM->fetch_assoc()) {
+    $mesi[] = $row;
+}
+$stmtM->close();
+
+// Calcolo dei totali entrate/uscite
+if ($mese !== '') {
+    $stmtTot = $conn->prepare("SELECT SUM(CASE WHEN amount>=0 THEN amount ELSE 0 END) AS entrate, SUM(CASE WHEN amount<0 THEN amount ELSE 0 END) AS uscite FROM v_movimenti_revolut WHERE FIND_IN_SET(?, etichette) AND DATE_FORMAT(started_date,'%Y-%m')=?");
+    $stmtTot->bind_param('ss', $etichetta, $mese);
 } else {
-    $stmt = $conn->prepare("SELECT id_movimento_revolut, started_date, amount, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, etichette FROM v_movimenti_revolut WHERE FIND_IN_SET(?, etichette) ORDER BY started_date DESC");
-    $stmt->bind_param('s', $etichetta);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $giorno_corrente = '';
-    while ($mov = $result->fetch_assoc()) {
-        $giorno = strftime('%A %e %B', strtotime($mov['started_date']));
-        if ($giorno !== $giorno_corrente) {
-            echo '<div class="day-header mt-3 mb-1 fw-bold">' . ucfirst($giorno) . '</div>';
-            $giorno_corrente = $giorno;
-        }
+    $stmtTot = $conn->prepare("SELECT SUM(CASE WHEN amount>=0 THEN amount ELSE 0 END) AS entrate, SUM(CASE WHEN amount<0 THEN amount ELSE 0 END) AS uscite FROM v_movimenti_revolut WHERE FIND_IN_SET(?, etichette)");
+    $stmtTot->bind_param('s', $etichetta);
+}
+$stmtTot->execute();
+$totali = $stmtTot->get_result()->fetch_assoc();
+$stmtTot->close();
+
+// Movimenti dell'etichetta
+if ($mese !== '') {
+    $stmtMov = $conn->prepare("SELECT id_movimento_revolut, started_date, amount, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, etichette FROM v_movimenti_revolut WHERE FIND_IN_SET(?, etichette) AND DATE_FORMAT(started_date,'%Y-%m')=? ORDER BY started_date DESC");
+    $stmtMov->bind_param('ss', $etichetta, $mese);
+} else {
+    $stmtMov = $conn->prepare("SELECT id_movimento_revolut, started_date, amount, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, etichette FROM v_movimenti_revolut WHERE FIND_IN_SET(?, etichette) ORDER BY started_date DESC");
+    $stmtMov->bind_param('s', $etichetta);
+}
+$stmtMov->execute();
+$movimenti = $stmtMov->get_result();
+$stmtMov->close();
+
+// Dettaglio per gruppo
+if ($mese !== '') {
+    $stmtGrp = $conn->prepare("SELECT m.id_gruppo_transazione, g.descrizione AS gruppo, SUM(CASE WHEN m.amount>=0 THEN m.amount ELSE 0 END) AS entrate, SUM(CASE WHEN m.amount<0 THEN m.amount ELSE 0 END) AS uscite FROM v_movimenti_revolut m LEFT JOIN bilancio_gruppi_transazione g ON m.id_gruppo_transazione = g.id_gruppo_transazione WHERE FIND_IN_SET(?, m.etichette) AND DATE_FORMAT(m.started_date,'%Y-%m')=? GROUP BY m.id_gruppo_transazione, g.descrizione ORDER BY g.descrizione");
+    $stmtGrp->bind_param('ss', $etichetta, $mese);
+} else {
+    $stmtGrp = $conn->prepare("SELECT m.id_gruppo_transazione, g.descrizione AS gruppo, SUM(CASE WHEN m.amount>=0 THEN m.amount ELSE 0 END) AS entrate, SUM(CASE WHEN m.amount<0 THEN m.amount ELSE 0 END) AS uscite FROM v_movimenti_revolut m LEFT JOIN bilancio_gruppi_transazione g ON m.id_gruppo_transazione = g.id_gruppo_transazione WHERE FIND_IN_SET(?, m.etichette) GROUP BY m.id_gruppo_transazione, g.descrizione ORDER BY g.descrizione");
+    $stmtGrp->bind_param('s', $etichetta);
+}
+$stmtGrp->execute();
+$resGrp = $stmtGrp->get_result();
+$gruppi = [];
+while ($r = $resGrp->fetch_assoc()) {
+    $gruppi[] = $r;
+}
+$stmtGrp->close();
+?>
+
+<div class="text-white">
+  <h4 class="mb-3">Movimenti per etichetta: <?= htmlspecialchars($etichetta) ?></h4>
+
+  <form method="get" class="mb-3">
+    <input type="hidden" name="etichetta" value="<?= htmlspecialchars($etichetta) ?>">
+    <div class="d-flex gap-2 align-items-center">
+      <label for="mese" class="form-label mb-0">Mese:</label>
+      <select name="mese" id="mese" class="form-select w-auto" onchange="this.form.submit()">
+        <option value="" <?= $mese === '' ? 'selected' : '' ?>>Tutti i mesi</option>
+        <?php foreach ($mesi as $m): ?>
+          <option value="<?= htmlspecialchars($m['ym']) ?>" <?= $mese === $m['ym'] ? 'selected' : '' ?>><?= ucfirst($m['label']) ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+  </form>
+
+  <div class="d-flex gap-4 mb-4">
+    <div>Entrate: <span class="text-success"><?= number_format($totali['entrate'] ?? 0, 2, ',', '.') ?> €</span></div>
+    <div>Uscite: <span class="text-danger"><?= number_format(abs($totali['uscite'] ?? 0), 2, ',', '.') ?> €</span></div>
+  </div>
+
+  <?php if ($movimenti->num_rows > 0): ?>
+    <?php while ($mov = $movimenti->fetch_assoc()): ?>
+      <?php
         $importo = number_format($mov['amount'], 2, ',', '.');
         $classe_importo = $mov['amount'] >= 0 ? 'text-success' : 'text-danger';
-        $ora = date('H:i', strtotime($mov['started_date']));
-        echo '<div class="movement d-flex align-items-center py-2">';
-        echo '  <div class="icon me-3"><i class="bi bi-arrow-left-right fs-4"></i></div>';
-        echo '  <div class="flex-grow-1">';
-        echo '    <div class="descr">' . htmlspecialchars($mov['descrizione']) . '</div>';
-        echo '    <div class="text-muted small">' . $ora . '</div>';
-        if (!empty($mov['etichette'])) {
-            echo '    <div class="mt-1">';
-            foreach (explode(',', $mov['etichette']) as $tag) {
-                $tag = trim($tag);
-                echo '      <a href="etichetta.php?etichetta=' . urlencode($tag) . '" class="badge-etichetta me-1 text-white">' . htmlspecialchars($tag) . '</a>';
-            }
-            echo '    </div>';
-        }
-        echo '  </div>';
-        echo '  <div class="amount ms-2 ' . $classe_importo . '">' . ($mov['amount'] >= 0 ? '+' : '') . $importo . ' €</div>';
-        echo '</div>';
-    }
-    if ($giorno_corrente === '') {
-        echo '<p class="text-center text-muted">Nessun movimento per questa etichetta.</p>';
-    }
-}
-include 'includes/footer.php';
-?>
+      ?>
+      <div class="movement d-flex align-items-center py-2">
+        <div class="icon me-3"><i class="bi bi-arrow-left-right fs-4"></i></div>
+        <div class="flex-grow-1">
+          <div class="descr"><?= htmlspecialchars($mov['descrizione']) ?></div>
+          <div class="text-muted small"><?= date('d/m/Y H:i', strtotime($mov['started_date'])) ?></div>
+        </div>
+        <div class="amount ms-2 <?= $classe_importo ?>"><?= ($mov['amount'] >= 0 ? '+' : '') . $importo ?> €</div>
+      </div>
+    <?php endwhile; ?>
+  <?php else: ?>
+    <p class="text-center text-muted">Nessun movimento per questa etichetta.</p>
+  <?php endif; ?>
+
+  <?php if (!empty($gruppi)): ?>
+    <h5 class="mt-4">Dettaglio per gruppo</h5>
+    <ul class="list-group list-group-flush">
+      <?php foreach ($gruppi as $g): ?>
+        <li class="list-group-item bg-dark text-white d-flex justify-content-between">
+          <span><?= htmlspecialchars($g['gruppo'] ?? $g['id_gruppo_transazione']) ?></span>
+          <span>
+            <span class="text-success me-3"><?= number_format($g['entrate'], 2, ',', '.') ?> €</span>
+            <span class="text-danger"><?= number_format(abs($g['uscite']), 2, ',', '.') ?> €</span>
+          </span>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+  <?php endif; ?>
+</div>
+
+<?php include 'includes/footer.php'; ?>
+

--- a/etichette_lista.php
+++ b/etichette_lista.php
@@ -1,0 +1,64 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+include 'includes/header.php';
+
+$q = trim($_GET['q'] ?? '');
+$show_inactive = isset($_GET['show_inactive']);
+
+$sql = "SELECT id_etichetta, descrizione, attivo FROM bilancio_etichette";
+$params = [];
+$types = '';
+$conds = [];
+
+if ($q !== '') {
+    $conds[] = "descrizione LIKE ?";
+    $params[] = "%$q%";
+    $types .= 's';
+} elseif (!$show_inactive) {
+    $conds[] = "attivo = 1";
+}
+
+if ($conds) {
+    $sql .= ' WHERE ' . implode(' AND ', $conds);
+}
+$sql .= ' ORDER BY descrizione ASC';
+
+$stmt = $conn->prepare($sql);
+if ($params) {
+    $stmt->bind_param($types, ...$params);
+}
+$stmt->execute();
+$etichette = $stmt->get_result();
+$stmt->close();
+?>
+
+<div class="text-white">
+  <h4 class="mb-3">Etichette</h4>
+  <form method="get" class="mb-3">
+    <div class="mb-2">
+      <input type="text" name="q" class="form-control" placeholder="Cerca..." value="<?= htmlspecialchars($q) ?>">
+    </div>
+    <div class="form-check mb-2">
+      <input class="form-check-input" type="checkbox" value="1" id="show_inactive" name="show_inactive" <?= $show_inactive ? 'checked' : '' ?>>
+      <label class="form-check-label" for="show_inactive">Includi etichette disattivate</label>
+    </div>
+    <button class="btn btn-outline-light w-100" type="submit">Filtra</button>
+  </form>
+
+  <div class="list-group">
+    <?php while ($row = $etichette->fetch_assoc()): ?>
+      <a href="etichetta.php?etichetta=<?= urlencode($row['descrizione']) ?>" class="list-group-item bg-dark text-white d-flex justify-content-between align-items-center text-decoration-none">
+        <span><?= htmlspecialchars($row['descrizione']) ?></span>
+        <?php if ($row['attivo']): ?>
+          <i class="bi bi-check-circle-fill text-success"></i>
+        <?php else: ?>
+          <i class="bi bi-x-circle-fill text-danger"></i>
+        <?php endif; ?>
+      </a>
+    <?php endwhile; ?>
+  </div>
+</div>
+
+<?php include 'includes/footer.php'; ?>
+

--- a/includes/header.php
+++ b/includes/header.php
@@ -32,6 +32,11 @@
         </a>
       </li>
       <li class="mb-3">
+        <a href="/Gestionale25/etichette_lista.php" class="btn btn-outline-light w-100 text-start">
+          🏷️ Etichette
+        </a>
+      </li>
+      <li class="mb-3">
         <a href="/Gestionale25/change_password.php" class="btn btn-outline-light w-100 text-start">
           🔑 Cambia Password
         </a>


### PR DESCRIPTION
## Summary
- show label-specific totals with month filter and grouped breakdown
- add searchable labels list with active/inactive indicator
- link labels list from main menu

## Testing
- `php -l etichetta.php`
- `php -l etichette_lista.php`
- `php -l includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_689389ec1ba08331acb3d96f3d48180d