### PR TITLE
Enhance group detail with categories and types

### DIFF
--- a/dettaglio.php
+++ b/dettaglio.php
@@ -9,9 +9,13 @@ if (!$id) {
 
 // Dati del movimento
 $stmt = $conn->prepare("
-  SELECT m.*, g.descrizione AS gruppo_descrizione, GROUP_CONCAT(e.descrizione SEPARATOR ', ') AS etichette
+  SELECT m.*, g.descrizione AS gruppo_descrizione,
+         COALESCE(c.descrizione_categoria, 'Nessuna categoria') AS categoria_descrizione,
+         g.tipo_gruppo,
+         GROUP_CONCAT(e.descrizione SEPARATOR ', ') AS etichette
   FROM movimenti_revolut m
   LEFT JOIN bilancio_gruppi_transazione g ON m.id_gruppo_transazione = g.id_gruppo_transazione
+  LEFT JOIN bilancio_gruppi_categorie c ON g.id_categoria = c.id_categoria
   LEFT JOIN bilancio_etichette2operazioni eo ON eo.id_tabella = m.id_movimento_revolut AND eo.tabella_operazione = 'movimenti_revolut'
   LEFT JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
   WHERE m.id_movimento_revolut = ?
@@ -24,6 +28,7 @@ $movimento = $result->fetch_assoc();
 if (!$movimento) {
   die("Movimento non trovato");
 }
+$movimento['categoria_descrizione'] = sanitize_string($movimento['categoria_descrizione'] ?? 'Nessuna categoria');
 
 // Etichette disponibili
 $etichette = [];
@@ -43,18 +48,47 @@ foreach ($etichette as &$et) {
 }
 unset($et); 
 
+function tipo_label($tipo) {
+  return [
+    'spese_base'   => 'Spese Base',
+    'divertimento' => 'Divertimento',
+    'risparmio'    => 'Risparmio',
+    ''             => 'Altro'
+  ][$tipo] ?? $tipo;
+}
+
 // Gruppi transazione
 $gruppi = [];
-$res2 = $conn->query("SELECT id_gruppo_transazione, descrizione, categoria, attivo FROM bilancio_gruppi_transazione ORDER BY categoria, descrizione");
+$filtroCategoria = $_GET['categoria'] ?? $_POST['categoria'] ?? null;
+$sqlGruppi = "SELECT g.id_gruppo_transazione, g.descrizione, g.tipo_gruppo, g.attivo,
+              COALESCE(c.descrizione_categoria, 'Nessuna categoria') AS categoria
+              FROM bilancio_gruppi_transazione g
+              LEFT JOIN bilancio_gruppi_categorie c ON g.id_categoria = c.id_categoria";
+if ($filtroCategoria !== null && $filtroCategoria !== '') {
+  if ($filtroCategoria === '0') {
+    $sqlGruppi .= " WHERE g.id_categoria IS NULL";
+  } else {
+    $sqlGruppi .= " WHERE g.id_categoria = ?";
+  }
+}
+$sqlGruppi .= " ORDER BY categoria, g.descrizione";
+if (isset($filtroCategoria) && $filtroCategoria !== '' && $filtroCategoria !== '0') {
+  $stmtGrp = $conn->prepare($sqlGruppi);
+  $stmtGrp->bind_param('i', $filtroCategoria);
+  $stmtGrp->execute();
+  $res2 = $stmtGrp->get_result();
+  $stmtGrp->close();
+} else {
+  $res2 = $conn->query($sqlGruppi);
+}
 while ($row = $res2->fetch_assoc()) {
+  $row['descrizione'] = sanitize_string($row['descrizione']);
+  $row['categoria'] = sanitize_string($row['categoria']);
+  $row['tipo_label'] = tipo_label($row['tipo_gruppo']);
   $gruppi[] = $row;
 }
 
-foreach ($gruppi as &$et) {
-  $et['descrizione'] = sanitize_string($et['descrizione']);
-  $et['categoria'] = sanitize_string($et['categoria']);
-}
-unset($et);
+$movimento['tipo_gruppo_label'] = tipo_label($movimento['tipo_gruppo'] ?? '');
 
 include 'includes/header.php';
 ?>
@@ -100,6 +134,7 @@ include 'includes/header.php';
       <span>Gruppo</span>
       <span>
         <?= htmlspecialchars($movimento['gruppo_descrizione']) ?>
+        <small>(<?= htmlspecialchars($movimento['categoria_descrizione']) ?> - <?= htmlspecialchars($movimento['tipo_gruppo_label']) ?>)</small>
         <i class="bi bi-pencil ms-2" onclick="openSelectModal('id_gruppo_transazione', <?= $movimento['id_gruppo_transazione'] ?>)"></i>
       </span>
     </li>
@@ -213,7 +248,7 @@ function populateGroups(showInactive) {
   for (let cat in grouped) {
     html += `<optgroup label="${cat}">`;
     for (let g of grouped[cat]) {
-      html += `<option value="${g.id_gruppo_transazione}" ${g.id_gruppo_transazione == currentGroupId ? 'selected' : ''}>${g.descrizione}</option>`;
+      html += `<option value="${g.id_gruppo_transazione}" ${g.id_gruppo_transazione == currentGroupId ? 'selected' : ''}>${g.descrizione} (${g.tipo_label})</option>`;
     }
     html += '</optgroup>';
   }

--- a/etichetta.php
+++ b/etichetta.php
@@ -6,6 +6,7 @@ setlocale(LC_TIME, 'it_IT.UTF-8');
 
 $etichetta = $_GET['etichetta'] ?? '';
 $mese = $_GET['mese'] ?? '';
+$categoria = $_GET['categoria'] ?? '';
 
 if ($etichetta === '') {
     echo '<p class="text-center text-muted">Nessuna etichetta selezionata.</p>';
@@ -44,22 +45,70 @@ if ($mese !== '') {
     $stmtMov = $conn->prepare("SELECT id_movimento_revolut, started_date, amount, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, etichette FROM v_movimenti_revolut WHERE FIND_IN_SET(?, etichette) ORDER BY started_date DESC");
     $stmtMov->bind_param('s', $etichetta);
 }
+// Categoria per filtro gruppi
+$categorie = [];
+$resCat = $conn->query("SELECT id_categoria, descrizione_categoria FROM bilancio_gruppi_categorie ORDER BY descrizione_categoria");
+while ($rc = $resCat->fetch_assoc()) {
+    $categorie[] = $rc;
+}
+
 $stmtMov->execute();
 $movimenti = $stmtMov->get_result();
 $stmtMov->close();
 
+function tipo_label($t) {
+    return [
+        'spese_base' => 'Spese Base',
+        'divertimento' => 'Divertimento',
+        'risparmio' => 'Risparmio',
+        '' => 'Altro'
+    ][$t] ?? $t;
+}
+
 // Dettaglio per gruppo
+$sqlGrp = "SELECT m.id_gruppo_transazione, g.descrizione AS gruppo, g.tipo_gruppo,
+                  COALESCE(c.descrizione_categoria, 'Nessuna categoria') AS categoria,
+                  SUM(CASE WHEN m.amount>=0 THEN m.amount ELSE 0 END) AS entrate,
+                  SUM(CASE WHEN m.amount<0 THEN m.amount ELSE 0 END) AS uscite
+           FROM v_movimenti_revolut m
+           LEFT JOIN bilancio_gruppi_transazione g ON m.id_gruppo_transazione = g.id_gruppo_transazione
+           LEFT JOIN bilancio_gruppi_categorie c ON g.id_categoria = c.id_categoria
+           WHERE FIND_IN_SET(?, m.etichette)";
 if ($mese !== '') {
-    $stmtGrp = $conn->prepare("SELECT m.id_gruppo_transazione, g.descrizione AS gruppo, SUM(CASE WHEN m.amount>=0 THEN m.amount ELSE 0 END) AS entrate, SUM(CASE WHEN m.amount<0 THEN m.amount ELSE 0 END) AS uscite FROM v_movimenti_revolut m LEFT JOIN bilancio_gruppi_transazione g ON m.id_gruppo_transazione = g.id_gruppo_transazione WHERE FIND_IN_SET(?, m.etichette) AND DATE_FORMAT(m.started_date,'%Y-%m')=? GROUP BY m.id_gruppo_transazione, g.descrizione ORDER BY g.descrizione");
+    $sqlGrp .= " AND DATE_FORMAT(m.started_date,'%Y-%m')=?";
+}
+if ($categoria !== '') {
+    if ($categoria === '0') {
+        $sqlGrp .= " AND g.id_categoria IS NULL";
+    } else {
+        $sqlGrp .= " AND g.id_categoria = ?";
+    }
+}
+$sqlGrp .= " GROUP BY m.id_gruppo_transazione, g.descrizione, g.tipo_gruppo, categoria ORDER BY categoria, g.descrizione";
+
+if ($mese !== '' && $categoria !== '' && $categoria !== '0') {
+    $stmtGrp = $conn->prepare($sqlGrp);
+    $stmtGrp->bind_param('ssi', $etichetta, $mese, $categoria);
+} elseif ($mese !== '' && $categoria === '0') {
+    $stmtGrp = $conn->prepare($sqlGrp);
     $stmtGrp->bind_param('ss', $etichetta, $mese);
+} elseif ($mese !== '' && $categoria === '') {
+    $stmtGrp = $conn->prepare($sqlGrp);
+    $stmtGrp->bind_param('ss', $etichetta, $mese);
+} elseif ($mese === '' && $categoria !== '' && $categoria !== '0') {
+    $stmtGrp = $conn->prepare($sqlGrp);
+    $stmtGrp->bind_param('si', $etichetta, $categoria);
 } else {
-    $stmtGrp = $conn->prepare("SELECT m.id_gruppo_transazione, g.descrizione AS gruppo, SUM(CASE WHEN m.amount>=0 THEN m.amount ELSE 0 END) AS entrate, SUM(CASE WHEN m.amount<0 THEN m.amount ELSE 0 END) AS uscite FROM v_movimenti_revolut m LEFT JOIN bilancio_gruppi_transazione g ON m.id_gruppo_transazione = g.id_gruppo_transazione WHERE FIND_IN_SET(?, m.etichette) GROUP BY m.id_gruppo_transazione, g.descrizione ORDER BY g.descrizione");
+    $stmtGrp = $conn->prepare($sqlGrp);
     $stmtGrp->bind_param('s', $etichetta);
 }
+
 $stmtGrp->execute();
 $resGrp = $stmtGrp->get_result();
 $gruppi = [];
 while ($r = $resGrp->fetch_assoc()) {
+    $r['categoria'] = $r['categoria'] ?? 'Nessuna categoria';
+    $r['tipo_label'] = tipo_label($r['tipo_gruppo']);
     $gruppi[] = $r;
 }
 $stmtGrp->close();
@@ -82,15 +131,15 @@ $stmtGrp->close();
   </form>
 
   <div class="d-flex gap-4 mb-4">
-    <div>Entrate: <span class="text-success"><?= number_format($totali['entrate'] ?? 0, 2, ',', '.') ?> €</span></div>
-    <div>Uscite: <span class="text-danger"><?= number_format(abs($totali['uscite'] ?? 0), 2, ',', '.') ?> €</span></div>
+    <div>Entrate: <span><?= '+' . number_format($totali['entrate'] ?? 0, 2, ',', '.') ?> €</span></div>
+    <div>Uscite: <span><?= number_format($totali['uscite'] ?? 0, 2, ',', '.') ?> €</span></div>
   </div>
 
   <?php if ($movimenti->num_rows > 0): ?>
     <?php while ($mov = $movimenti->fetch_assoc()): ?>
       <?php
         $importo = number_format($mov['amount'], 2, ',', '.');
-        $classe_importo = $mov['amount'] >= 0 ? 'text-success' : 'text-danger';
+        $segno = $mov['amount'] >= 0 ? '+' : '';
       ?>
       <div class="movement d-flex align-items-center py-2">
         <div class="icon me-3"><i class="bi bi-arrow-left-right fs-4"></i></div>
@@ -98,7 +147,7 @@ $stmtGrp->close();
           <div class="descr"><?= htmlspecialchars($mov['descrizione']) ?></div>
           <div class="text-muted small"><?= date('d/m/Y H:i', strtotime($mov['started_date'])) ?></div>
         </div>
-        <div class="amount ms-2 <?= $classe_importo ?>"><?= ($mov['amount'] >= 0 ? '+' : '') . $importo ?> €</div>
+        <div class="amount ms-2"><?= $segno . $importo ?> €</div>
       </div>
     <?php endwhile; ?>
   <?php else: ?>
@@ -107,17 +156,44 @@ $stmtGrp->close();
 
   <?php if (!empty($gruppi)): ?>
     <h5 class="mt-4">Dettaglio per gruppo</h5>
-    <ul class="list-group list-group-flush">
-      <?php foreach ($gruppi as $g): ?>
-        <li class="list-group-item bg-dark text-white d-flex justify-content-between">
-          <span><?= htmlspecialchars($g['gruppo'] ?? $g['id_gruppo_transazione']) ?></span>
-          <span>
-            <span class="text-success me-3"><?= number_format($g['entrate'], 2, ',', '.') ?> €</span>
-            <span class="text-danger"><?= number_format(abs($g['uscite']), 2, ',', '.') ?> €</span>
-          </span>
-        </li>
-      <?php endforeach; ?>
-    </ul>
+    <form method="get" class="mb-3">
+      <input type="hidden" name="etichetta" value="<?= htmlspecialchars($etichetta) ?>">
+      <input type="hidden" name="mese" value="<?= htmlspecialchars($mese) ?>">
+      <div class="d-flex gap-2 align-items-center">
+        <label for="categoria" class="form-label mb-0">Categoria:</label>
+        <select name="categoria" id="categoria" class="form-select w-auto" onchange="this.form.submit()">
+          <option value="" <?= $categoria === '' ? 'selected' : '' ?>>Tutte</option>
+          <option value="0" <?= $categoria === '0' ? 'selected' : '' ?>>Nessuna categoria</option>
+          <?php foreach ($categorie as $cat): ?>
+            <option value="<?= $cat['id_categoria'] ?>" <?= $categoria == $cat['id_categoria'] ? 'selected' : '' ?>><?= htmlspecialchars($cat['descrizione_categoria']) ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+    </form>
+    <div class="table-responsive">
+      <table class="table table-dark table-striped align-middle">
+        <thead>
+          <tr>
+            <th>Categoria</th>
+            <th>Gruppo</th>
+            <th>Tipo</th>
+            <th class="text-end">Entrate</th>
+            <th class="text-end">Uscite</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach ($gruppi as $g): ?>
+            <tr>
+              <td><?= htmlspecialchars($g['categoria']) ?></td>
+              <td><?= htmlspecialchars($g['gruppo'] ?? $g['id_gruppo_transazione']) ?></td>
+              <td><?= htmlspecialchars($g['tipo_label']) ?></td>
+              <td class="text-end"><?= ($g['entrate'] > 0 ? '+' : '') . number_format($g['entrate'], 2, ',', '.') ?> €</td>
+              <td class="text-end"><?= number_format($g['uscite'], 2, ',', '.') ?> €</td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
   <?php endif; ?>
 </div>
 


### PR DESCRIPTION
## Summary
- Integrate category info for transaction groups, map `tipo_gruppo` to human-readable labels, and expose optional category filter.
- Add responsive dark-themed table with category filtering for group breakdowns and remove red/green styling.

## Testing
- `php -l dettaglio.php`
- `php -l etichetta.php`


------
https://chatgpt.com/codex/tasks/task_e_6893a8b9b52083319f57fc52b9bf42e9