### PR TITLE
feature/unified-movements-quote-split

### DIFF
--- a/ajax/search_movimenti.php
+++ b/ajax/search_movimenti.php
@@ -8,7 +8,33 @@ if ($q === '') {
 }
 
 $like = "%" . $q . "%";
-$stmt = $conn->prepare("SELECT id_movimento_revolut, started_date, amount, COALESCE(NULLIF(descrizione_extra, ''), description) AS descrizione, etichette FROM v_movimenti_revolut WHERE descrizione_extra LIKE ? OR description LIKE ? OR gruppo LIKE ? OR etichette LIKE ? ORDER BY started_date DESC LIMIT 50");
+$sql = "SELECT * FROM (
+            SELECT id_movimento_revolut AS id, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione,
+                   descrizione_extra, started_date AS data_operazione, amount,
+                   etichette, id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella
+            FROM v_movimenti_revolut
+            UNION ALL
+            SELECT be.id_entrata AS id, be.descrizione, be.descrizione_extra,
+                   be.data_operazione, be.importo AS amount,
+                   (SELECT GROUP_CONCAT(e.descrizione SEPARATOR ',')
+                      FROM bilancio_etichette2operazioni eo
+                      JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
+                     WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
+                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella
+            FROM bilancio_entrate be
+            UNION ALL
+            SELECT bu.id_uscita AS id, bu.descrizione_operazione AS descrizione, bu.descrizione_extra,
+                   bu.data_operazione, -bu.importo AS amount,
+                   (SELECT GROUP_CONCAT(e.descrizione SEPARATOR ',')
+                      FROM bilancio_etichette2operazioni eo
+                      JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
+                     WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
+                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella
+            FROM bilancio_uscite bu
+        ) t
+        WHERE descrizione LIKE ? OR descrizione_extra LIKE ? OR id_gruppo_transazione LIKE ? OR etichette LIKE ?
+        ORDER BY data_operazione DESC LIMIT 50";
+$stmt = $conn->prepare($sql);
 $stmt->bind_param('ssss', $like, $like, $like, $like);
 $stmt->execute();
 $result = $stmt->get_result();

--- a/includes/render_movimento.php
+++ b/includes/render_movimento.php
@@ -1,11 +1,51 @@
 <?php
 function render_movimento(array $mov) {
+    global $conn;
+
     $importo = number_format($mov['amount'], 2, ',', '.');
-    $dataOra = date('d/m/Y H:i', strtotime($mov['started_date']));
-    echo '<div class="movement d-flex justify-content-between align-items-start text-white text-decoration-none" style="cursor:pointer" onclick="window.location.href=\'dettaglio.php?id=' . (int)$mov['id_movimento_revolut'] . '\'">';
+    $dataOra  = date('d/m/Y H:i', strtotime($mov['data_operazione']));
+
+    // Determine icon based on source
+    $icon = $mov['source'] === 'revolut' ? 'assets/revolut.jpeg' : 'assets/credit.jpeg';
+
+    $url = 'dettaglio.php?id=' . (int)$mov['id'] . '&src=' . urlencode($mov['source']);
+
+    echo '<div class="movement d-flex justify-content-between align-items-start text-white text-decoration-none" style="cursor:pointer" onclick="window.location.href=\'' . $url . '\'">';
+    echo '  <img src="' . htmlspecialchars($icon) . '" alt="src" class="me-2" style="width:24px;height:24px">';
     echo '  <div class="flex-grow-1 me-3">';
     echo '    <div class="descr fw-semibold">' . htmlspecialchars($mov['descrizione']) . '</div>';
     echo '    <div class="small">' . $dataOra . '</div>';
+
+    // Quote per utente se presenti
+    $stmtU = $conn->prepare("SELECT u.nome, u.cognome, ue.importo_utente, ue.utente_pagante, ue.saldata
+                              FROM bilancio_utenti2operazioni_etichettate ue
+                              JOIN utenti u ON u.id_utente = ue.id_utente
+                             WHERE ue.id_tabella = ? AND ue.tabella_operazione = ?");
+    $stmtU->bind_param('is', $mov['id'], $mov['tabella']);
+    if ($stmtU->execute()) {
+        $resU = $stmtU->get_result();
+        $users = $resU->fetch_all(MYSQLI_ASSOC);
+        if ($users) {
+            $count = count($users);
+            $total = abs($mov['amount']);
+            foreach ($users as &$u) {
+                if ($u['importo_utente'] === null) {
+                    $u['importo_utente'] = $total / $count;
+                }
+            }
+            echo '    <div class="mt-1">';
+            foreach ($users as $u) {
+                $name = htmlspecialchars(trim(($u['nome'] ?? '') . ' ' . ($u['cognome'] ?? '')));
+                $amt  = number_format($u['importo_utente'], 2, ',', '.');
+                $class = $u['utente_pagante'] ? 'badge bg-success' : 'badge bg-secondary';
+                $status = $u['saldata'] ? '✔' : '✖';
+                echo "<span class='" . $class . " me-1'>$name $amt € $status</span>";
+            }
+            echo '    </div>';
+        }
+    }
+    $stmtU->close();
+
     echo '  </div>';
     echo '  <div class="text-end">';
     echo '    <div class="amount text-white">' . ($mov['amount'] >= 0 ? '+' : '') . $importo . ' €</div>';

--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <?php include 'includes/session_check.php'; ?>
 <?php
 include 'includes/db.php';
+require_once 'includes/render_movimento.php';
 include 'includes/header.php';
 ?>
 
@@ -8,26 +9,38 @@ include 'includes/header.php';
 <div id="searchResults"></div>
 
 <?php
-$sql = "SELECT * FROM v_movimenti_revolut ORDER BY started_date DESC LIMIT 5";
+$sql = "SELECT * FROM (
+            SELECT id_movimento_revolut AS id, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione,
+                   descrizione_extra, started_date AS data_operazione, amount,
+                   etichette, id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella
+            FROM v_movimenti_revolut
+            UNION ALL
+            SELECT be.id_entrata AS id, be.descrizione, be.descrizione_extra,
+                   be.data_operazione, be.importo AS amount,
+                   (SELECT GROUP_CONCAT(e.descrizione SEPARATOR ',')
+                      FROM bilancio_etichette2operazioni eo
+                      JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
+                     WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
+                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella
+            FROM bilancio_entrate be
+            UNION ALL
+            SELECT bu.id_uscita AS id, bu.descrizione_operazione AS descrizione, bu.descrizione_extra,
+                   bu.data_operazione, -bu.importo AS amount,
+                   (SELECT GROUP_CONCAT(e.descrizione SEPARATOR ',')
+                      FROM bilancio_etichette2operazioni eo
+                      JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
+                     WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
+                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella
+            FROM bilancio_uscite bu
+        ) t
+        ORDER BY data_operazione DESC LIMIT 5";
+
 $result = $conn->query($sql);
 
-if ($result->num_rows > 0): ?>
+if ($result && $result->num_rows > 0): ?>
   <div id="recentMovimenti" class="list-group">
     <?php while($row = $result->fetch_assoc()): ?>
-      <a href="dettaglio.php?id=<?= $row['id_movimento_revolut'] ?>" class="list-group-item shadow-sm text-white text-decoration-none">
-        <div class="d-flex justify-content-between">
-          <div>
-            <strong><?= htmlspecialchars($row['descrizione_extra'] ?: $row['description']) ?></strong><br>
-            <small><?= date('d/m/Y H:i', strtotime($row['started_date'])) ?></small><br>
-            <?php if (!empty($row['etichette'])): ?>
-              <span class="badge-etichetta"><?= htmlspecialchars($row['etichette']) ?></span>
-            <?php endif; ?>
-          </div>
-          <div class="fs-5 text-end">
-            <?= number_format($row['amount'], 2, ',', '.') ?> €
-          </div>
-        </div>
-      </a>
+      <?php render_movimento($row); ?>
     <?php endwhile; ?>
   </div>
 

--- a/tutti_movimenti.php
+++ b/tutti_movimenti.php
@@ -5,7 +5,16 @@ include 'includes/header.php';
 setlocale(LC_TIME, 'it_IT.UTF-8');
 
 $mesi = [];
-$sql = "SELECT DATE_FORMAT(started_date, '%Y-%m') AS ym, DATE_FORMAT(started_date, '%M %Y') AS mese_label FROM v_movimenti_revolut GROUP BY ym ORDER BY ym ASC";
+$sql = "SELECT DATE_FORMAT(data_operazione, '%Y-%m') AS ym,
+                DATE_FORMAT(data_operazione, '%M %Y') AS mese_label
+         FROM (
+            SELECT started_date AS data_operazione FROM v_movimenti_revolut
+            UNION ALL
+            SELECT data_operazione FROM bilancio_entrate
+            UNION ALL
+            SELECT data_operazione FROM bilancio_uscite
+         ) t
+         GROUP BY ym ORDER BY ym ASC";
 $result = $conn->query($sql);
 while ($row = $result->fetch_assoc()) {
     $mesi[] = $row;


### PR DESCRIPTION
## Summary
- unify movement listing across Revolut and Crédit Agricole tables using UNION queries
- render movement cards with account icon and per-user quota details
- expose unified movements in index, search, monthly view and label pages

## Testing
- `php -l GestioneFamiglia/includes/render_movimento.php`
- `php -l GestioneFamiglia/index.php`
- `php -l GestioneFamiglia/ajax/search_movimenti.php`
- `php -l GestioneFamiglia/ajax/load_movimenti_mese.php`
- `php -l GestioneFamiglia/tutti_movimenti.php`
- `php -l GestioneFamiglia/etichetta.php`


------
https://chatgpt.com/codex/tasks/task_e_6893bcdef4ac833184f4fcfe6eba2f96