### PR TITLE
Support fetching legacy entries

### DIFF
--- a/ajax/update_etichette.php
+++ b/ajax/update_etichette.php
@@ -5,26 +5,29 @@ include '../includes/db.php';
 $data = json_decode(file_get_contents("php://input"), true);
 $id = intval($data['id'] ?? 0);
 $etichette = $data['etichette'] ?? [];
+$src = $data['src'] ?? 'movimenti_revolut';
 
-if (!$id) {
+$allowedSources = ['movimenti_revolut', 'bilancio_entrate', 'bilancio_uscite'];
+if (!$id || !in_array($src, $allowedSources, true)) {
   http_response_code(400);
-  echo "ID non valido";
+  echo "Dati non validi";
   exit;
 }
 
 // Cancella le etichette precedenti
-$stmt = $conn->prepare("DELETE FROM bilancio_etichette2operazioni WHERE tabella_operazione = 'movimenti_revolut' AND id_tabella = ?");
-$stmt->bind_param("i", $id);
+$stmt = $conn->prepare("DELETE FROM bilancio_etichette2operazioni WHERE tabella_operazione = ? AND id_tabella = ?");
+$stmt->bind_param("si", $src, $id);
 $stmt->execute();
 
 // Inserisce le nuove etichette
 if (!empty($etichette)) {
-  $insert = $conn->prepare("INSERT INTO bilancio_etichette2operazioni (tabella_operazione, id_tabella, id_etichetta) VALUES ('movimenti_revolut', ?, ?)");
+  $insert = $conn->prepare("INSERT INTO bilancio_etichette2operazioni (tabella_operazione, id_tabella, id_etichetta) VALUES (?, ?, ?)");
   foreach ($etichette as $e) {
     $ide = intval($e);
-    $insert->bind_param("ii", $id, $ide);
+    $insert->bind_param("sii", $src, $id, $ide);
     $insert->execute();
   }
 }
 
 echo "ok";
+

--- a/ajax/update_field.php
+++ b/ajax/update_field.php
@@ -1,0 +1,35 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$data = json_decode(file_get_contents('php://input'), true);
+$id = intval($data['id'] ?? 0);
+$field = $data['field'] ?? '';
+$value = trim($data['value'] ?? '');
+$src = $data['src'] ?? 'movimenti_revolut';
+
+$allowedSources = ['movimenti_revolut', 'bilancio_entrate', 'bilancio_uscite'];
+$allowedFields = [
+  'movimenti_revolut' => ['descrizione_extra', 'note', 'id_gruppo_transazione'],
+  'bilancio_entrate'  => ['descrizione_extra', 'id_gruppo_transazione'],
+  'bilancio_uscite'   => ['descrizione_extra', 'id_gruppo_transazione']
+];
+
+if (!$id || !in_array($src, $allowedSources, true) || !in_array($field, $allowedFields[$src])) {
+  echo json_encode(['success' => false, 'error' => 'Parametri non validi']);
+  exit;
+}
+
+$idFields = [
+  'movimenti_revolut' => 'id_movimento_revolut',
+  'bilancio_entrate'  => 'id_entrata',
+  'bilancio_uscite'   => 'id_uscita'
+];
+
+$sql = "UPDATE $src SET $field = ? WHERE {$idFields[$src]} = ?";
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('si', $value, $id);
+$success = $stmt->execute();
+
+echo json_encode(['success' => $success]);


### PR DESCRIPTION
## Summary
- allow `dettaglio.php` to load entries from `bilancio_entrate`, `bilancio_uscite`, or `movimenti_revolut` based on the `src` table name
- include the `src` value in label/field edits and make `update_etichette.php` honour it
- add `ajax/update_field.php` to persist `descrizione_extra`, `note`, or `id_gruppo_transazione` edits for the chosen source table

## Testing
- `php -l dettaglio.php`
- `php -l ajax/update_etichette.php`
- `php -l ajax/update_field.php`


------
https://chatgpt.com/codex/tasks/task_e_68943722afbc8331ad20d8d8bcf46143