### PR TITLE
Add credential management and family-based access controls

### DIFF
--- a/cambia_famiglia.php
+++ b/cambia_famiglia.php
@@ -1,0 +1,24 @@
+<?php
+include 'includes/session_check.php';
+include 'includes/db.php';
+
+$idUtente = $_SESSION['utente_id'] ?? 0;
+$idFamiglia = isset($_POST['id_famiglia_gestione']) ? (int)$_POST['id_famiglia_gestione'] : 0;
+
+if ($idUtente && $idFamiglia) {
+    $stmt = $conn->prepare('SELECT 1 FROM utenti2famiglie WHERE id_utente = ? AND id_famiglia = ?');
+    $stmt->bind_param('ii', $idUtente, $idFamiglia);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($res && $res->num_rows === 1) {
+        $_SESSION['id_famiglia_gestione'] = $idFamiglia;
+        $upd = $conn->prepare('UPDATE utenti SET id_famiglia_gestione = ? WHERE id = ?');
+        $upd->bind_param('ii', $idFamiglia, $idUtente);
+        $upd->execute();
+    }
+}
+
+$redirect = $_SERVER['HTTP_REFERER'] ?? 'index.php';
+header('Location: ' . $redirect);
+exit;
+?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -25,15 +25,36 @@
     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Chiudi"></button>
   </div>
   <div class="offcanvas-body">
+    <?php if (isset($_SESSION['utente_id'])): ?>
+    <form method="post" action="cambia_famiglia.php" class="mb-3">
+      <select name="id_famiglia_gestione" class="form-select bg-dark text-white border-secondary" onchange="this.form.submit()">
+        <?php
+        $stmt = $conn->prepare('SELECT f.id_famiglia, f.nome FROM famiglie f JOIN utenti2famiglie u2f ON f.id_famiglia = u2f.id_famiglia WHERE u2f.id_utente = ?');
+        $stmt->bind_param('i', $_SESSION['utente_id']);
+        $stmt->execute();
+        $resFam = $stmt->get_result();
+        while ($fam = $resFam->fetch_assoc()): ?>
+          <option value="<?= (int)$fam['id_famiglia'] ?>" <?= (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == $fam['id_famiglia']) ? 'selected' : '' ?>><?= htmlspecialchars($fam['nome']) ?></option>
+        <?php endwhile; $stmt->close(); ?>
+      </select>
+    </form>
+    <?php endif; ?>
     <ul class="list-unstyled">
       <li class="mb-3">
         <a href="/Gestionale25/index.php" class="btn btn-outline-light w-100 text-start">
           🏠 Home
         </a>
       </li>
+      <?php if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == 1): ?>
       <li class="mb-3">
         <a href="/Gestionale25/etichette_lista.php" class="btn btn-outline-light w-100 text-start">
           🏷️ Etichette
+        </a>
+      </li>
+      <?php endif; ?>
+      <li class="mb-3">
+        <a href="/Gestionale25/password.php" class="btn btn-outline-light w-100 text-start">
+          🔐 Password
         </a>
       </li>
       <li class="mb-3">

--- a/includes/render_password.php
+++ b/includes/render_password.php
@@ -1,0 +1,26 @@
+<?php
+function render_password(array $row) {
+    $classes = 'password-card movement d-flex justify-content-between align-items-start text-white text-decoration-none';
+    if (isset($row['attiva']) && !$row['attiva']) {
+        $classes .= ' inactive';
+    }
+    $search = strtolower(($row['url_login'] ?? '') . ' ' . ($row['username'] ?? '') . ' ' . ($row['note'] ?? ''));
+    $searchAttr = htmlspecialchars($search, ENT_QUOTES);
+    $url = 'password_dettaglio.php?id=' . (int)$row['id_account'];
+    echo '<div class="' . $classes . '" data-search="' . $searchAttr . '" onclick="window.location.href=\'' . $url . '\'">';
+    echo '  <div class="flex-grow-1">';
+    $icon = !empty($row['attiva']) ? '<i class="bi bi-check-circle-fill text-success me-2"></i>' : '<i class="bi bi-x-circle-fill text-danger me-2"></i>';
+    $urlLogin = htmlspecialchars($row['url_login']);
+    if (filter_var($row['url_login'], FILTER_VALIDATE_URL)) {
+        $urlLogin = '<a href="' . htmlspecialchars($row['url_login']) . '" target="_blank" onclick="event.stopPropagation();">' . $urlLogin . '</a>';
+    }
+    echo '    <div class="fw-semibold">' . $icon . $urlLogin . '</div>';
+    echo '    <div class="small">Username: ' . htmlspecialchars($row['username']) . '</div>';
+    echo '    <div class="small">Password: ' . htmlspecialchars($row['password_account']) . '</div>';
+    if (!empty($row['note'])) {
+        echo '    <div class="small text-muted">' . htmlspecialchars($row['note']) . '</div>';
+    }
+    echo '  </div>';
+    echo '</div>';
+}
+?>

--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@ include 'includes/header.php';
 
 require_once 'includes/render_movimento.php';
 
-?>
+if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == 1): ?>
 
 <input type="text" id="search" class="form-control bg-dark text-white border-secondary mb-3" placeholder="Cerca nei movimenti">
 <div id="searchResults"></div>
@@ -56,4 +56,8 @@ if ($result && $result->num_rows > 0): ?>
 <?php endif; ?>
 
 <script src="js/index.js"></script>
+<?php else: ?>
+<p class="text-center text-muted">Movimenti non disponibili per questa famiglia.</p>
+<?php endif; ?>
+
 <?php include 'includes/footer.php'; ?>

--- a/js/password.js
+++ b/js/password.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const search = document.getElementById('search');
+  const showInactive = document.getElementById('showInactive');
+  const cards = Array.from(document.querySelectorAll('.password-card'));
+
+  function filter() {
+    const q = search.value.toLowerCase();
+    cards.forEach(card => {
+      const text = card.dataset.search;
+      const isInactive = card.classList.contains('inactive');
+      const match = text.includes(q);
+      const visible = match && (!isInactive || showInactive.checked);
+      card.style.display = visible ? '' : 'none';
+    });
+  }
+
+  search.addEventListener('input', filter);
+  showInactive.addEventListener('change', filter);
+  filter();
+});

--- a/login.php
+++ b/login.php
@@ -48,6 +48,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 $upd->execute();
             }
 
+            $_SESSION['2fa_id_famiglia_gestione'] = $user['id_famiglia_gestione'] ?? 0;
             $code = str_pad((string)rand(0, 999999), 6, '0', STR_PAD_LEFT);
             $expires = date('Y-m-d H:i:s', time() + 300);
             $ins = $conn->prepare("INSERT INTO codici_2fa (id_utente, codice, scadenza) VALUES (?, ?, ?)");

--- a/login_passcode.php
+++ b/login_passcode.php
@@ -26,7 +26,7 @@ $error = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $pass = $_POST['passcode'] ?? '';
-    $sql = 'SELECT id, nome, passcode FROM utenti WHERE id = ? AND attivo = 1 LIMIT 1';
+    $sql = 'SELECT id, nome, passcode, id_famiglia_gestione FROM utenti WHERE id = ? AND attivo = 1 LIMIT 1';
     $stmt = $conn->prepare($sql);
     $stmt->bind_param('i', $device['id_utente']);
     $stmt->execute();
@@ -36,6 +36,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (!empty($user['passcode']) && password_verify($pass, $user['passcode'])) {
             $_SESSION['utente_id'] = $user['id'];
             $_SESSION['utente_nome'] = $user['nome'];
+            $_SESSION['id_famiglia_gestione'] = $user['id_famiglia_gestione'] ?? 0;
             $newExp = date('Y-m-d H:i:s', time() + 60*60*24*30);
             $upd = $conn->prepare('UPDATE dispositivi_riconosciuti SET scadenza = ? WHERE token_dispositivo = ?');
             $upd->bind_param('ss', $newExp, $token);

--- a/password.php
+++ b/password.php
@@ -1,0 +1,33 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+require_once 'includes/render_password.php';
+include 'includes/header.php';
+
+$idUtente = $_SESSION['utente_id'] ?? ($_SESSION['id_utente'] ?? 0);
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+
+$stmt = $conn->prepare("SELECT g.* FROM gestione_account_password g JOIN utenti2famiglie u2f ON g.id_famiglia = u2f.id_famiglia WHERE u2f.id_utente = ? AND g.id_famiglia = ?");
+$stmt->bind_param('ii', $idUtente, $idFamiglia);
+$stmt->execute();
+$res = $stmt->get_result();
+?>
+
+<div class="d-flex mb-3 align-items-center">
+  <input type="text" id="search" class="form-control bg-dark text-white border-secondary me-2" placeholder="Cerca">
+  <div class="form-check form-switch text-nowrap">
+    <input class="form-check-input" type="checkbox" id="showInactive">
+    <label class="form-check-label" for="showInactive">Mostra non attive</label>
+  </div>
+</div>
+<div class="mb-3">
+  <a href="password_dettaglio.php" class="btn btn-success w-100">➕ Nuovo</a>
+</div>
+<div id="passwordList">
+<?php while ($row = $res->fetch_assoc()): ?>
+  <?php render_password($row); ?>
+<?php endwhile; ?>
+</div>
+
+<script src="js/password.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/password_dettaglio.php
+++ b/password_dettaglio.php
@@ -1,0 +1,79 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+include 'includes/header.php';
+
+$idUtente = $_SESSION['utente_id'] ?? ($_SESSION['id_utente'] ?? 0);
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$data = ['url_login'=>'','username'=>'','password_account'=>'','note'=>'','attiva'=>1,'id_account'=>0];
+
+if ($id > 0) {
+    $stmt = $conn->prepare("SELECT * FROM gestione_account_password WHERE id_account = ? AND id_famiglia = ?");
+    $stmt->bind_param('ii', $id, $idFamiglia);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($res && $res->num_rows > 0) {
+        $data = $res->fetch_assoc();
+    } else {
+        echo '<p class="text-danger">Record non trovato.</p>';
+        include 'includes/footer.php';
+        exit;
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id_account = isset($_POST['id_account']) ? (int)$_POST['id_account'] : 0;
+    $url = $_POST['url_login'] ?? '';
+    $username = $_POST['username'] ?? '';
+    $password_account = $_POST['password_account'] ?? '';
+    $note = $_POST['note'] ?? '';
+    $attiva = isset($_POST['attiva']) ? 1 : 0;
+
+    if ($id_account > 0) {
+        $stmt = $conn->prepare("UPDATE gestione_account_password SET url_login=?, username=?, password_account=?, note=?, attiva=? WHERE id_account=? AND id_famiglia=?");
+        $stmt->bind_param('ssssiii', $url, $username, $password_account, $note, $attiva, $id_account, $idFamiglia);
+        $stmt->execute();
+        $stmt->close();
+    } else {
+        $stmt = $conn->prepare("INSERT INTO gestione_account_password (url_login, username, password_account, note, attiva, id_utente, id_famiglia) VALUES (?,?,?,?,?,?,?)");
+        $stmt->bind_param('ssssiii', $url, $username, $password_account, $note, $attiva, $idUtente, $idFamiglia);
+        $stmt->execute();
+        $stmt->close();
+    }
+    header('Location: password.php');
+    exit;
+}
+?>
+
+<form method="post" class="bg-dark text-white p-3 rounded">
+  <div class="mb-3">
+    <label class="form-label">URL Login</label>
+    <input type="text" name="url_login" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['url_login']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input type="text" name="username" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['username']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input type="text" name="password_account" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['password_account']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Note</label>
+    <textarea name="note" class="form-control bg-dark text-white border-secondary" rows="3"><?= htmlspecialchars($data['note']) ?></textarea>
+  </div>
+  <div class="form-check form-switch mb-3">
+    <input class="form-check-input" type="checkbox" id="attiva" name="attiva" <?= $data['attiva'] ? 'checked' : '' ?>>
+    <label class="form-check-label" for="attiva">Attiva</label>
+  </div>
+  <input type="hidden" name="id_utente" value="<?= (int)$idUtente ?>">
+  <input type="hidden" name="id_famiglia" value="<?= (int)$idFamiglia ?>">
+  <?php if ($data['id_account']): ?>
+    <input type="hidden" name="id_account" value="<?= (int)$data['id_account'] ?>">
+  <?php endif; ?>
+  <button type="submit" class="btn btn-primary w-100">Salva</button>
+</form>
+
+<?php include 'includes/footer.php'; ?>

--- a/verifica_2fa.php
+++ b/verifica_2fa.php
@@ -27,7 +27,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $_SESSION['utente_id'] = $_SESSION['2fa_user_id'];
         $_SESSION['utente_nome'] = $_SESSION['2fa_user_nome'];
-        unset($_SESSION['2fa_user_id'], $_SESSION['2fa_user_nome'], $_SESSION['2fa_attempts']);
+        $_SESSION['id_famiglia_gestione'] = $_SESSION['2fa_id_famiglia_gestione'] ?? 0;
+        unset($_SESSION['2fa_user_id'], $_SESSION['2fa_user_nome'], $_SESSION['2fa_attempts'], $_SESSION['2fa_id_famiglia_gestione']);
         header('Location: setup_passcode.php');
         exit;
     } else {


### PR DESCRIPTION
## Summary
- Add password.php and password_dettaglio.php for managing family credentials
- Implement card renderer and live search with inactive toggle
- Restrict sensitive menu items and movements display to family 1
- Switch to id_famiglia_gestione with login initialization and menu family selector

## Testing
- `php -l includes/render_password.php`
- `php -l password.php`
- `php -l password_dettaglio.php`
- `php -l includes/header.php`
- `php -l index.php`
- `php -l login.php`
- `php -l verifica_2fa.php`
- `php -l login_passcode.php`
- `php -l cambia_famiglia.php`


------
https://chatgpt.com/codex/tasks/task_e_68943e03759c8331822b745de5408e61