### PR TITLE
Use secure random_int for 2FA code generation

### DIFF
--- a/login.php
+++ b/login.php
@@ -49,7 +49,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             }
 
             $_SESSION['2fa_id_famiglia_gestione'] = $user['id_famiglia_gestione'] ?? 0;
-            $code = str_pad((string)rand(0, 999999), 6, '0', STR_PAD_LEFT);
+            $code = str_pad((string)random_int(0, 999999), 6, '0', STR_PAD_LEFT);
             $expires = date('Y-m-d H:i:s', time() + 300);
             $ins = $conn->prepare("INSERT INTO codici_2fa (id_utente, codice, scadenza) VALUES (?, ?, ?)");
             $ins->bind_param("iss", $user["id"], $code, $expires);


### PR DESCRIPTION
## Summary
- use cryptographically secure `random_int` instead of `rand` when creating two-factor authentication codes

## Testing
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_e_68945dbfd7f483318808446c1b7f5ce0