### PR TITLE
Add session validation and JSON response to salva_campo

### DIFF
--- a/ajax/salva_campo.php
+++ b/ajax/salva_campo.php
@@ -1,7 +1,8 @@
 <?php
+include '../includes/session_check.php';
 require_once '../includes/db.php';
 
-$id = $_POST['id'];
+$id = intval($_POST['id'] ?? 0);
 $campo = $_POST['campo'];
 $valore = $_POST['valore'];
 
@@ -11,3 +12,7 @@ if (!in_array($campo, $allowed)) exit;
 $stmt = $conn->prepare("UPDATE movimenti_revolut SET $campo = ? WHERE id_movimento_revolut = ?");
 $stmt->bind_param("si", $valore, $id);
 $stmt->execute();
+
+header('Content-Type: application/json');
+echo json_encode(['success' => true]);
+exit;


### PR DESCRIPTION
## Summary
- include session_check for authenticated access
- sanitize `id` via `intval()` and send JSON success response

## Testing
- `php -l ajax/salva_campo.php`


------
https://chatgpt.com/codex/tasks/task_e_68945f89e1b88331b8c30074971f804c