### PR TITLE
Fix update_movimento SQL clause

### DIFF
--- a/ajax/update_movimento.php
+++ b/ajax/update_movimento.php
@@ -17,7 +17,7 @@ if (!$id || !in_array($field, $allowed_fields)) {
     exit;
 }
 
-$sql = "UPDATE movimenti_revolut SET $field = ? WHERE id = ?";
+$sql = "UPDATE movimenti_revolut SET $field = ? WHERE id_movimento_revolut = ?";
 $stmt = $conn->prepare($sql);
 $stmt->bind_param("si", $value, $id);
 $success = $stmt->execute();


### PR DESCRIPTION
## Summary
- Use id_movimento_revolut when updating movimenti_revolut

## Testing
- `php -l ajax/update_movimento.php`


------
https://chatgpt.com/codex/tasks/task_e_68945fa453148331987525411621ea84