### PR TITLE
Improve month filter UX

### DIFF
--- a/ajax/load_movimenti_mese.php
+++ b/ajax/load_movimenti_mese.php
@@ -37,6 +37,7 @@ $stmt->bind_param('s', $mese);
 $stmt->execute();
 $result = $stmt->get_result();
 
+echo '<div class="month-section" data-mese="' . htmlspecialchars($mese, ENT_QUOTES) . '">';
 $giorno_corrente = '';
 while ($mov = $result->fetch_assoc()) {
     $giorno = strftime('%A %e %B', strtotime($mov['data_operazione']));
@@ -47,4 +48,5 @@ while ($mov = $result->fetch_assoc()) {
 
     render_movimento($mov);
 }
+echo '</div>';
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -34,6 +34,10 @@ body {
 .months-scroll {
   overflow-x: auto;
   white-space: nowrap;
+  position: sticky;
+  top: 0;
+  background-color: #121212;
+  z-index: 1000;
 }
 .months-scroll .btn {
   border-radius: 20px;

--- a/js/tutti_movimenti.js
+++ b/js/tutti_movimenti.js
@@ -10,6 +10,28 @@ document.addEventListener('DOMContentLoaded', () => {
     let minIdx = mesi.length - 1;
     let maxIdx = mesi.length - 1;
 
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting && entry.intersectionRatio > 0.5) {
+                const ym = entry.target.dataset.mese;
+                const idx = mesi.indexOf(ym);
+                if (idx !== -1) {
+                    buttons.forEach((btn, i) => btn.classList.toggle('active', i === idx));
+                    buttons[idx].scrollIntoView({ inline: 'center', behavior: 'smooth' });
+                }
+            }
+        });
+    }, { threshold: 0.6 });
+
+    const observeSections = () => {
+        document.querySelectorAll('.month-section').forEach(sec => {
+            if (!sec.dataset.observed) {
+                observer.observe(sec);
+                sec.dataset.observed = '1';
+            }
+        });
+    };
+
     const loadMovimenti = (idx, mode = 'replace', setActive = true) => {
         fetch(`ajax/load_movimenti_mese.php?mese=${encodeURIComponent(mesi[idx])}`)
             .then(r => r.text())
@@ -22,6 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     movimenti.innerHTML = html;
                     window.scrollTo({ top: 0 });
                 }
+                observeSections();
                 if (setActive) {
                     buttons.forEach((btn, i) => btn.classList.toggle('active', i === idx));
                 }

--- a/tutti_movimenti.php
+++ b/tutti_movimenti.php
@@ -5,8 +5,7 @@ include 'includes/header.php';
 setlocale(LC_TIME, 'it_IT.UTF-8');
 
 $mesi = [];
-$sql = "SELECT DATE_FORMAT(data_operazione, '%Y-%m') AS ym,
-                DATE_FORMAT(data_operazione, '%M %Y') AS mese_label
+$sql = "SELECT DATE_FORMAT(data_operazione, '%Y-%m') AS ym
          FROM (
             SELECT started_date AS data_operazione FROM v_movimenti_revolut
             UNION ALL
@@ -16,15 +15,25 @@ $sql = "SELECT DATE_FORMAT(data_operazione, '%Y-%m') AS ym,
          ) t
          GROUP BY ym ORDER BY ym ASC";
 $result = $conn->query($sql);
+$annoCorrente = date('Y');
 while ($row = $result->fetch_assoc()) {
-    $mesi[] = $row;
+    $timestamp = strtotime($row['ym'] . '-01');
+    $label = strftime('%B', $timestamp);
+    $anno = date('Y', $timestamp);
+    if ($anno < $annoCorrente) {
+        $label .= ' ' . $anno;
+    }
+    $mesi[] = [
+        'ym' => $row['ym'],
+        'label' => ucfirst($label)
+    ];
 }
 $ultimoIndice = count($mesi) - 1;
 ?>
 <div class="months-scroll d-flex mb-3" id="monthsContainer">
     <?php foreach ($mesi as $idx => $m): ?>
         <button class="btn btn-outline-light me-2 <?= $idx === $ultimoIndice ? 'active' : '' ?>" data-mese="<?= htmlspecialchars($m['ym']) ?>">
-            <?= ucfirst($m['mese_label']) ?>
+            <?= $m['label'] ?>
         </button>
     <?php endforeach; ?>
 </div>


### PR DESCRIPTION
## Summary
- Make month filter bar sticky and visually separated
- Hide year for current-year months and include it for previous years
- Auto-select month while scrolling using IntersectionObserver

## Testing
- `php -l tutti_movimenti.php`
- `php -l ajax/load_movimenti_mese.php`
- `node --check js/tutti_movimenti.js`


------
https://chatgpt.com/codex/tasks/task_e_689468242c288331849caf8ce6e96bae