### PR TITLE
Fix search and active filter for passwords and labels

### DIFF
--- a/includes/render_password.php
+++ b/includes/render_password.php
@@ -9,21 +9,25 @@ function render_password(array $row) {
     $url = 'password_dettaglio.php?id=' . (int)$row['id_account_password'];
     echo '<div class="' . $classes . '" data-search="' . $searchAttr . '" onclick="window.location.href=\'' . $url . '\'">';
     echo '  <div class="flex-grow-1">';
-    $icon = !empty($row['attiva']) ? '<i class="bi bi-check-circle-fill text-success me-2"></i>' : '<i class="bi bi-x-circle-fill text-danger me-2"></i>';
-    if (!empty($row['condivisa_con_famiglia'])) {
-        $icon .= '<i class="bi bi-people-fill text-info me-2" title="Condivisa con famiglia"></i>';
-    }
     $urlLogin = htmlspecialchars($row['url_login']);
     if (filter_var($row['url_login'], FILTER_VALIDATE_URL)) {
         $urlLogin = '<a href="' . htmlspecialchars($row['url_login']) . '" target="_blank" onclick="event.stopPropagation();">' . $urlLogin . '</a>';
     }
-    echo '    <div class="fw-semibold">' . $icon . $urlLogin . '</div>';
+    echo '    <div class="fw-semibold">' . $urlLogin . '</div>';
     echo '    <div class="small">Username: ' . htmlspecialchars($row['username']) . '</div>';
     echo '    <div class="small">Password: ' . htmlspecialchars($row['password_account']) . '</div>';
     if (!empty($row['note'])) {
         echo '    <div class="small text-muted">' . htmlspecialchars($row['note']) . '</div>';
     }
     echo '  </div>';
+    $icons = '';
+    if (!empty($row['condivisa_con_famiglia'])) {
+        $icons .= '<i class="bi bi-people-fill text-info me-2" title="Condivisa con famiglia"></i>';
+    }
+    $icons .= !empty($row['attiva'])
+        ? '<i class="bi bi-check-circle-fill text-success"></i>'
+        : '<i class="bi bi-x-circle-fill text-danger"></i>';
+    echo '  <div class="ms-2 text-nowrap">' . $icons . '</div>';
     echo '</div>';
 }
 ?>

--- a/js/etichette.js
+++ b/js/etichette.js
@@ -4,12 +4,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const cards = Array.from(document.querySelectorAll('.label-card'));
 
   function filter() {
-    const q = search.value.toLowerCase();
+    const q = search.value.trim().toLowerCase();
     cards.forEach(card => {
-      const text = card.dataset.search;
+      const text = card.dataset.search || '';
       const isInactive = card.classList.contains('inactive');
       const match = text.includes(q);
-      const visible = match && (!isInactive || showInactive.checked);
+      const visible = match && (!isInactive || showInactive.checked || q !== '');
       card.style.display = visible ? '' : 'none';
     });
   }

--- a/js/password.js
+++ b/js/password.js
@@ -4,12 +4,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const cards = Array.from(document.querySelectorAll('.password-card'));
 
   function filter() {
-    const q = search.value.toLowerCase();
+    const q = search.value.trim().toLowerCase();
     cards.forEach(card => {
-      const text = card.dataset.search;
+      const text = card.dataset.search || '';
       const isInactive = card.classList.contains('inactive');
       const match = text.includes(q);
-      const visible = match && (!isInactive || showInactive.checked);
+      const visible = match && (!isInactive || showInactive.checked || q !== '');
       card.style.display = visible ? '' : 'none';
     });
   }


### PR DESCRIPTION
## Summary
- Ensure password entries show status and sharing icons on the right
- Show only active passwords and labels by default while still searching inactive entries

## Testing
- `php -l includes/render_password.php`
- `node --check js/password.js`
- `node --check js/etichette.js`


------
https://chatgpt.com/codex/tasks/task_e_689475e108488331985da36b963a56d9