### PR TITLE
Mostra solo record attivi di default con filtro live

### DIFF
--- a/etichette_lista.php
+++ b/etichette_lista.php
@@ -19,9 +19,10 @@ $etichette = $conn->query($sql);
 
   <div class="list-group" id="labelList">
     <?php while ($row = $etichette->fetch_assoc()): ?>
-      <a href="etichetta.php?etichetta=<?= urlencode($row['descrizione']) ?>" class="list-group-item bg-dark text-white d-flex justify-content-between align-items-center text-decoration-none label-card<?= $row['attivo'] ? '' : ' inactive' ?>" data-search="<?= strtolower($row['descrizione']) ?>">
+      <?php $isActive = (int)($row['attivo'] ?? 0) === 1; ?>
+      <a href="etichetta.php?etichetta=<?= urlencode($row['descrizione']) ?>" class="list-group-item bg-dark text-white d-flex justify-content-between align-items-center text-decoration-none label-card<?= $isActive ? '' : ' inactive' ?>" data-search="<?= strtolower($row['descrizione']) ?>" style="<?= $isActive ? '' : 'display:none;' ?>">
         <span><?= htmlspecialchars($row['descrizione']) ?></span>
-        <?php if ($row['attivo']): ?>
+        <?php if ($isActive): ?>
           <i class="bi bi-check-circle-fill text-success"></i>
         <?php else: ?>
           <i class="bi bi-x-circle-fill text-danger"></i>

--- a/includes/render_password.php
+++ b/includes/render_password.php
@@ -1,13 +1,15 @@
 <?php
 function render_password(array $row) {
+    $isActive = (int)($row['attiva'] ?? 0) === 1;
     $classes = 'password-card movement d-flex justify-content-between align-items-start text-white text-decoration-none';
-    if (isset($row['attiva']) && !$row['attiva']) {
+    if (!$isActive) {
         $classes .= ' inactive';
     }
-    $search = strtolower(($row['url_login'] ?? '') . ' ' . ($row['username'] ?? '') . ' ' . ($row['note'] ?? ''));
+    $search = strtolower(($row['url_login'] ?? '') . ' ' . ($row['username'] ?? '') . ' ' . ($row['password_account'] ?? ''));
     $searchAttr = htmlspecialchars($search, ENT_QUOTES);
     $url = 'password_dettaglio.php?id=' . (int)$row['id_account_password'];
-    echo '<div class="' . $classes . '" data-search="' . $searchAttr . '" onclick="window.location.href=\'' . $url . '\'">';
+    $style = $isActive ? '' : ' style="display:none;"';
+    echo '<div class="' . $classes . '" data-search="' . $searchAttr . '"' . $style . ' onclick="window.location.href=\'' . $url . '\'">';
     echo '  <div class="flex-grow-1">';
     $urlLogin = htmlspecialchars($row['url_login']);
     if (filter_var($row['url_login'], FILTER_VALIDATE_URL)) {
@@ -24,7 +26,7 @@ function render_password(array $row) {
     if (!empty($row['condivisa_con_famiglia'])) {
         $icons .= '<i class="bi bi-people-fill text-info me-2" title="Condivisa con famiglia"></i>';
     }
-    $icons .= !empty($row['attiva'])
+    $icons .= $isActive
         ? '<i class="bi bi-check-circle-fill text-success"></i>'
         : '<i class="bi bi-x-circle-fill text-danger"></i>';
     echo '  <div class="ms-2 text-nowrap">' . $icons . '</div>';

--- a/js/etichette.js
+++ b/js/etichette.js
@@ -15,6 +15,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   search.addEventListener('input', filter);
-  showInactive.addEventListener('change', filter);
+  showInactive.addEventListener('input', filter);
   filter();
 });

--- a/js/password.js
+++ b/js/password.js
@@ -15,6 +15,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   search.addEventListener('input', filter);
-  showInactive.addEventListener('change', filter);
+  showInactive.addEventListener('input', filter);
   filter();
 });


### PR DESCRIPTION
## Summary
- Nasconde gli elementi non attivi di etichette e password al caricamento
- Filtra liste in tempo reale con evento `input` per la casella "Mostra non attive"
- Consente la ricerca di password anche per url, nome utente e password

## Testing
- `php -l etichette_lista.php`
- `php -l includes/render_password.php`
- `php -l password.php`
- `node` script di simulazione del filtro (ricerca per descrizione etichette e per url_login, username e password delle password)


------
https://chatgpt.com/codex/tasks/task_e_68947c745ec08331a0d3c122983242b3