### PR TITLE
Enable editing of labels from detail page

### DIFF
--- a/ajax/update_etichetta.php
+++ b/ajax/update_etichetta.php
@@ -1,0 +1,26 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$data = json_decode(file_get_contents('php://input'), true);
+$id = intval($data['id_etichetta'] ?? 0);
+$descrizione = trim($data['descrizione'] ?? '');
+$attivo = isset($data['attivo']) && $data['attivo'] == 1 ? 1 : 0;
+$da_dividere = isset($data['da_dividere']) && $data['da_dividere'] == 1 ? 1 : 0;
+$utenti = trim($data['utenti_tra_cui_dividere'] ?? '');
+
+if (!$id || $descrizione === '') {
+    echo json_encode(['success' => false, 'error' => 'Dati non validi']);
+    exit;
+}
+
+$stmt = $conn->prepare('UPDATE bilancio_etichette SET descrizione = ?, attivo = ?, da_dividere = ?, utenti_tra_cui_dividere = ? WHERE id_etichetta = ?');
+$stmt->bind_param('siisi', $descrizione, $attivo, $da_dividere, $utenti, $id);
+$ok = $stmt->execute();
+
+if ($ok) {
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['success' => false, 'error' => 'Errore durante l\'aggiornamento']);
+}


### PR DESCRIPTION
## Summary
- Fetch detailed label info from the database when viewing a label
- Add edit icon and modal to edit label properties
- Provide AJAX endpoint to update label fields and refresh page

## Testing
- `php -l etichetta.php`
- `php -l ajax/update_etichetta.php`


------
https://chatgpt.com/codex/tasks/task_e_689499c514f08331b6707fcde9fbcf8b