### PR TITLE
Enable label creation via modal

### DIFF
--- a/ajax/add_etichetta.php
+++ b/ajax/add_etichetta.php
@@ -1,0 +1,26 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$data = json_decode(file_get_contents('php://input'), true);
+$descrizione = trim($data['descrizione'] ?? '');
+$attivo = isset($data['attivo']) && $data['attivo'] == 1 ? 1 : 0;
+$da_dividere = isset($data['da_dividere']) && $data['da_dividere'] == 1 ? 1 : 0;
+$utenti = trim($data['utenti_tra_cui_dividere'] ?? '');
+
+if ($descrizione === '') {
+    echo json_encode(['success' => false, 'error' => 'Descrizione mancante']);
+    exit;
+}
+
+$stmt = $conn->prepare('INSERT INTO bilancio_etichette (descrizione, attivo, da_dividere, utenti_tra_cui_dividere) VALUES (?, ?, ?, ?)');
+$stmt->bind_param('siis', $descrizione, $attivo, $da_dividere, $utenti);
+$ok = $stmt->execute();
+
+if ($ok) {
+    echo json_encode(['success' => true, 'id' => $conn->insert_id]);
+} else {
+    echo json_encode(['success' => false, 'error' => 'Errore durante l\'inserimento']);
+}
+

--- a/etichette_lista.php
+++ b/etichette_lista.php
@@ -8,7 +8,7 @@ $etichette = $conn->query($sql);
 ?>
 
 <div class="text-white">
-  <div class="d-flex mb-3 justify-content-between"><h4>Etichette</h4><a href="etichetta_dettaglio.php" class="btn btn-outline-light btn-sm">Aggiungi nuova</a></div>
+  <div class="d-flex mb-3 justify-content-between"><h4>Etichette</h4><button type="button" class="btn btn-outline-light btn-sm" onclick="openEtichettaModal()">Aggiungi nuova</button></div>
   <div class="d-flex mb-3 align-items-center">
     <input type="text" id="search" class="form-control bg-dark text-white border-secondary me-2" placeholder="Cerca">
     <div class="form-check form-switch text-nowrap">
@@ -29,6 +29,38 @@ $etichette = $conn->query($sql);
         <?php endif; ?>
       </a>
     <?php endwhile; ?>
+  </div>
+</div>
+
+<div class="modal fade" id="editEtichettaModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" onsubmit="saveEtichetta(event)">
+      <div class="modal-header">
+        <h5 class="modal-title">Nuova etichetta</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="descrizione" class="form-label">Descrizione</label>
+          <input type="text" class="form-control bg-secondary text-white" id="descrizione" required>
+        </div>
+        <div class="form-check mb-3">
+          <input class="form-check-input" type="checkbox" id="attivo" checked>
+          <label class="form-check-label" for="attivo">Attivo</label>
+        </div>
+        <div class="form-check mb-3">
+          <input class="form-check-input" type="checkbox" id="da_dividere">
+          <label class="form-check-label" for="da_dividere">Da dividere</label>
+        </div>
+        <div class="mb-3">
+          <label for="utenti_tra_cui_dividere" class="form-label">Utenti tra cui dividere</label>
+          <input type="text" class="form-control bg-secondary text-white" id="utenti_tra_cui_dividere">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Salva</button>
+      </div>
+    </form>
   </div>
 </div>
 

--- a/js/etichette.js
+++ b/js/etichette.js
@@ -23,3 +23,32 @@ document.addEventListener('DOMContentLoaded', () => {
   showInactive.addEventListener('input', filter);
   filter();
 });
+
+function openEtichettaModal() {
+  document.getElementById('descrizione').value = '';
+  document.getElementById('attivo').checked = true;
+  document.getElementById('da_dividere').checked = false;
+  document.getElementById('utenti_tra_cui_dividere').value = '';
+  new bootstrap.Modal(document.getElementById('editEtichettaModal')).show();
+}
+
+function saveEtichetta(event) {
+  event.preventDefault();
+  const payload = {
+    descrizione: document.getElementById('descrizione').value.trim(),
+    attivo: document.getElementById('attivo').checked ? 1 : 0,
+    da_dividere: document.getElementById('da_dividere').checked ? 1 : 0,
+    utenti_tra_cui_dividere: document.getElementById('utenti_tra_cui_dividere').value.trim()
+  };
+  fetch('ajax/add_etichetta.php', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  }).then(r => r.json()).then(resp => {
+    if (resp.success) {
+      window.location.reload();
+    } else {
+      alert(resp.error || 'Errore nel salvataggio');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Replace "Aggiungi nuova" link with button that opens a creation modal
- Add JavaScript handlers and backend endpoint to save new labels

## Testing
- `php -l etichette_lista.php`
- `php -l ajax/add_etichetta.php`


------
https://chatgpt.com/codex/tasks/task_e_6894a435596c8331a64c66e38bc7a436