### PR TITLE
Aggiungi eliminazione movimenti in contanti

### DIFF
--- a/ajax/delete_movimento.php
+++ b/ajax/delete_movimento.php
@@ -1,0 +1,27 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$data = json_decode(file_get_contents('php://input'), true);
+$id = intval($data['id'] ?? 0);
+$src = $data['src'] ?? '';
+
+$allowed = [
+    'bilancio_entrate' => 'id_entrata',
+    'bilancio_uscite' => 'id_uscita'
+];
+
+if (!$id || !isset($allowed[$src])) {
+    echo json_encode(['success' => false, 'error' => 'Parametri non validi']);
+    exit;
+}
+
+$idField = $allowed[$src];
+$sql = "DELETE FROM $src WHERE $idField = ? AND mezzo = 'contanti'";
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('i', $id);
+$success = $stmt->execute();
+
+echo json_encode(['success' => $success]);
+

--- a/ajax/load_movimenti_mese.php
+++ b/ajax/load_movimenti_mese.php
@@ -6,10 +6,10 @@ setlocale(LC_TIME, 'it_IT.UTF-8');
 
 $mese = $_GET['mese'] ?? date('Y-m');
 
-$sql = "SELECT * FROM (
+ $sql = "SELECT * FROM (
             SELECT id_movimento_revolut AS id, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione,
                    descrizione_extra, started_date AS data_operazione, amount,
-                   etichette, id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella
+                   etichette, id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella, NULL AS mezzo
             FROM v_movimenti_revolut
             UNION ALL
             SELECT be.id_entrata AS id, be.descrizione_operazione AS descrizione, be.descrizione_extra,
@@ -18,7 +18,7 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
-                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella
+                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
             FROM bilancio_entrate be
             UNION ALL
             SELECT bu.id_uscita AS id, bu.descrizione_operazione AS descrizione, bu.descrizione_extra,
@@ -27,7 +27,7 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
-                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella
+                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
             FROM bilancio_uscite bu
         ) t
         WHERE DATE_FORMAT(data_operazione, '%Y-%m') = ?

--- a/ajax/search_movimenti.php
+++ b/ajax/search_movimenti.php
@@ -9,10 +9,10 @@ if ($q === '') {
 }
 
 $like = "%" . $q . "%";
-$sql = "SELECT * FROM (
+ $sql = "SELECT * FROM (
             SELECT id_movimento_revolut AS id, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione,
                    descrizione_extra, started_date AS data_operazione, amount,
-                   etichette, id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella
+                   etichette, id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella, NULL AS mezzo
             FROM v_movimenti_revolut
             UNION ALL
             SELECT be.id_entrata AS id, be.descrizione_operazione AS descrizione, be.descrizione_extra,
@@ -21,7 +21,7 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
-                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella
+                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
             FROM bilancio_entrate be
             UNION ALL
             SELECT bu.id_uscita AS id, bu.descrizione_operazione AS descrizione, bu.descrizione_extra,
@@ -30,7 +30,7 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
-                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella
+                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
             FROM bilancio_uscite bu
         ) t
         WHERE descrizione LIKE ? OR descrizione_extra LIKE ? OR id_gruppo_transazione LIKE ? OR etichette LIKE ?

--- a/includes/render_movimento.php
+++ b/includes/render_movimento.php
@@ -15,14 +15,18 @@ function render_movimento(array $mov) {
 
     $url = 'dettaglio.php?id=' . (int)$mov['id'] . '&src=' . urlencode($mov['tabella']);
 
-    echo '<div class="movement d-flex justify-content-between align-items-start text-white text-decoration-none" style="cursor:pointer" onclick="window.location.href=\'' . $url . '\'">';
+    echo '<div class="movement d-flex justify-content-between align-items-start text-white text-decoration-none" data-id="' . (int)$mov['id'] . '" data-src="' . htmlspecialchars($mov['tabella'], ENT_QUOTES) . '" style="cursor:pointer" onclick="window.location.href=\'' . $url . '\'">';
     echo '  <img src="' . htmlspecialchars($icon) . '" alt="src" class="me-2" style="width:24px;height:24px">';
     echo '  <div class="flex-grow-1 me-3">';
     echo '    <div class="descr fw-semibold">' . htmlspecialchars($mov['descrizione']) . '</div>';
     echo '    <div class="small">' . $dataOra . '</div>';
     echo '  </div>';
     echo '  <div class="text-end">';
-    echo '    <div class="amount text-white">' . ($mov['amount'] >= 0 ? '+' : '') . $importo . ' €</div>';
+    echo '    <div class="amount text-white">' . ($mov['amount'] >= 0 ? '+' : '') . $importo . ' €';
+    if (!empty($mov['mezzo']) && $mov['mezzo'] === 'contanti' && in_array($mov['tabella'], ['bilancio_entrate', 'bilancio_uscite'], true)) {
+        echo ' <i class="bi bi-trash text-danger ms-2 delete-movimento" onclick="event.stopPropagation();"></i>';
+    }
+    echo '</div>';
     if (!empty($mov['etichette'])) {
         echo '    <div class="mt-1">';
         foreach (explode(',', $mov['etichette']) as $tag) {

--- a/index.php
+++ b/index.php
@@ -18,10 +18,10 @@ if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'
 <div id="searchResults"></div>
 
 <?php
-$sql = "SELECT * FROM (
+ $sql = "SELECT * FROM (
             SELECT id_movimento_revolut AS id, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione,
                    descrizione_extra, started_date AS data_operazione, amount,
-                   etichette, id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella
+                   etichette, id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella, NULL AS mezzo
             FROM v_movimenti_revolut
             UNION ALL
             SELECT be.id_entrata AS id, COALESCE(NULLIF(be.descrizione_extra,''), be.descrizione_operazione) AS descrizione, be.descrizione_extra,
@@ -30,7 +30,7 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
-                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella
+                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
             FROM bilancio_entrate be
             UNION ALL
             SELECT bu.id_uscita AS id, COALESCE(NULLIF(bu.descrizione_extra,''), bu.descrizione_operazione) AS descrizione, bu.descrizione_extra,
@@ -39,7 +39,7 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
-                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella
+                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
             FROM bilancio_uscite bu
         ) t
         ORDER BY data_operazione DESC LIMIT 5";
@@ -61,7 +61,27 @@ if ($result && $result->num_rows > 0): ?>
   <p class="text-center text-muted">Nessun movimento presente.</p>
 <?php endif; ?>
 
-<script src="js/index.js"></script>
+ <!-- Modal conferma eliminazione -->
+ <div class="modal fade" id="deleteModal" tabindex="-1">
+   <div class="modal-dialog">
+     <div class="modal-content bg-dark text-white">
+       <div class="modal-header">
+         <h5 class="modal-title">Conferma eliminazione</h5>
+         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+       </div>
+       <div class="modal-body">
+         Sei sicuro di voler eliminare questo movimento?
+       </div>
+       <div class="modal-footer">
+         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+         <button type="button" class="btn btn-danger" id="confirmDelete">Elimina</button>
+       </div>
+     </div>
+   </div>
+ </div>
+
+ <script src="js/index.js"></script>
+ <script src="js/delete_movimento.js"></script>
 <?php else: ?>
 <p class="text-center text-muted">Movimenti non disponibili per questa famiglia.</p>
 <?php endif; ?>

--- a/js/delete_movimento.js
+++ b/js/delete_movimento.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const modalEl = document.getElementById('deleteModal');
+    if (!modalEl) return;
+    const modal = new bootstrap.Modal(modalEl);
+    let target = null;
+
+    document.body.addEventListener('click', e => {
+        const icon = e.target.closest('.delete-movimento');
+        if (!icon) return;
+        const movement = icon.closest('.movement');
+        if (!movement) return;
+        target = {
+            id: movement.dataset.id,
+            src: movement.dataset.src,
+            element: movement
+        };
+        modal.show();
+    });
+
+    document.getElementById('confirmDelete').addEventListener('click', () => {
+        if (!target) return;
+        fetch('ajax/delete_movimento.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: target.id, src: target.src })
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success) {
+                target.element.remove();
+            }
+            modal.hide();
+            target = null;
+        });
+    });
+});

--- a/tutti_movimenti.php
+++ b/tutti_movimenti.php
@@ -37,6 +37,27 @@ $ultimoIndice = count($mesi) - 1;
         </button>
     <?php endforeach; ?>
 </div>
-<div id="movimenti" class="pb-5 text-white"></div>
-<script src="js/tutti_movimenti.js"></script>
-<?php include 'includes/footer.php'; ?>
+ <div id="movimenti" class="pb-5 text-white"></div>
+
+ <!-- Modal conferma eliminazione -->
+ <div class="modal fade" id="deleteModal" tabindex="-1">
+   <div class="modal-dialog">
+     <div class="modal-content bg-dark text-white">
+       <div class="modal-header">
+         <h5 class="modal-title">Conferma eliminazione</h5>
+         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+       </div>
+       <div class="modal-body">
+         Sei sicuro di voler eliminare questo movimento?
+       </div>
+       <div class="modal-footer">
+         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+         <button type="button" class="btn btn-danger" id="confirmDelete">Elimina</button>
+       </div>
+     </div>
+   </div>
+ </div>
+
+ <script src="js/tutti_movimenti.js"></script>
+ <script src="js/delete_movimento.js"></script>
+ <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Aggiunge icona cestino e conferma tramite modal per movimenti in contanti
- Estende le query SQL con il campo `mezzo` per individuare i movimenti cash
- Implementa endpoint AJAX e script JS per cancellare i movimenti

## Testing
- `php -l includes/render_movimento.php`
- `php -l index.php`
- `php -l ajax/load_movimenti_mese.php`
- `php -l ajax/search_movimenti.php`
- `php -l ajax/delete_movimento.php`
- `php -l tutti_movimenti.php`

------
https://chatgpt.com/codex/tasks/task_e_6894a525f1a083319d9f0ef51fa41eb6