### PR TITLE
Aggiunta cancellazione etichetta dai movimenti

### DIFF
--- a/ajax/delete_e2o.php
+++ b/ajax/delete_e2o.php
@@ -1,0 +1,24 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_e2o = intval($_POST['id_e2o'] ?? 0);
+if (!$id_e2o) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare("DELETE FROM bilancio_etichette2operazioni WHERE id_e2o = ?");
+$stmt->bind_param('i', $id_e2o);
+$success = $stmt->execute();
+$stmt->close();
+
+if ($success) {
+    $stmtU = $conn->prepare("DELETE FROM bilancio_utenti2operazioni_etichettate WHERE id_e2o = ?");
+    $stmtU->bind_param('i', $id_e2o);
+    $stmtU->execute();
+    $stmtU->close();
+}
+
+echo json_encode(['success' => $success]);

--- a/etichetta.php
+++ b/etichetta.php
@@ -476,7 +476,30 @@ function attachEditHandlers() {
       new bootstrap.Modal(document.getElementById('editE2oModal')).show();
     });
   });
+
+  document.querySelectorAll('.delete-e2o').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.dataset.idE2o;
+      const rowId = btn.dataset.rowId;
+      if (!id) return;
+      if (!confirm('Rimuovere questa etichetta dal movimento?')) return;
+      fetch('ajax/delete_e2o.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: 'id_e2o=' + encodeURIComponent(id)
+      })
+      .then(r => r.json())
+      .then(res => {
+        if (res.success) {
+          const el = document.getElementById(rowId);
+          if (el) el.remove();
+        }
+      });
+    });
+  });
 }
+
+attachEditHandlers();
 
 
 document.getElementById('editE2oForm').addEventListener('submit', function(e){

--- a/includes/render_movimento_etichetta.php
+++ b/includes/render_movimento_etichetta.php
@@ -126,6 +126,7 @@ function render_movimento_etichetta(array $mov, int $id_etichetta) {
     $allAttr = htmlspecialchars($info['allegato'] ?? '', ENT_QUOTES);
     $rowAttr = htmlspecialchars($rowId, ENT_QUOTES);
     echo '    <button class="btn btn-sm btn-link text-white edit-e2o" data-id-e2o="' . $idE2oAttr . '" data-descrizione-extra="' . $descAttr . '" data-importo="' . $impAttr . '" data-allegato="' . $allAttr . '" data-row-id="' . $rowAttr . '" onclick="event.stopPropagation();"><i class="bi bi-pencil"></i></button>';
+    echo '    <button class="btn btn-sm btn-link text-danger delete-e2o" data-id-e2o="' . $idE2oAttr . '" data-row-id="' . $rowAttr . '" onclick="event.stopPropagation();"><i class="bi bi-trash"></i></button>';
     echo '  </div>';
     echo '</div>';
 


### PR DESCRIPTION
## Summary
- Aggiunto bottone cestino per rimuovere l'etichetta da un movimento
- Gestione frontend per cancellazione e aggiornamento lista movimenti
- Endpoint AJAX per eliminare i record collegati all'etichetta

## Testing
- `php -l includes/render_movimento_etichetta.php`
- `php -l etichetta.php`
- `php -l ajax/delete_e2o.php`


------
https://chatgpt.com/codex/tasks/task_e_6894a56509d483318099eccf41e4642d