### PR TITLE
Show label descriptions in movement listings

### DIFF
--- a/ajax/load_movimenti_mese.php
+++ b/ajax/load_movimenti_mese.php
@@ -9,7 +9,7 @@ $mese = $_GET['mese'] ?? date('Y-m');
  $sql = "SELECT * FROM (
             SELECT id_movimento_revolut AS id, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, bm.descrizione_extra,
                    started_date AS data_operazione, amount,
-                   (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
+                   (SELECT GROUP_CONCAT(CONCAT(e.id_etichetta, ':', e.descrizione) SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette,
@@ -18,7 +18,7 @@ $mese = $_GET['mese'] ?? date('Y-m');
             UNION ALL
             SELECT be.id_entrata AS id, be.descrizione_operazione AS descrizione, be.descrizione_extra,
                    be.data_operazione, be.importo AS amount,
-                   (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
+                   (SELECT GROUP_CONCAT(CONCAT(e.id_etichetta, ':', e.descrizione) SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
@@ -27,7 +27,7 @@ $mese = $_GET['mese'] ?? date('Y-m');
             UNION ALL
             SELECT bu.id_uscita AS id, bu.descrizione_operazione AS descrizione, bu.descrizione_extra,
                    bu.data_operazione, -bu.importo AS amount,
-                   (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
+                   (SELECT GROUP_CONCAT(CONCAT(e.id_etichetta, ':', e.descrizione) SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,

--- a/includes/render_movimento.php
+++ b/includes/render_movimento.php
@@ -31,9 +31,13 @@ function render_movimento(array $mov) {
         echo '    <div class="mt-1">';
         foreach (explode(',', $mov['etichette']) as $tag) {
             $tag = trim($tag);
-
-            echo '      <a href="etichetta.php?id_etichetta=' . urlencode($tag) . '" class="badge-etichetta me-1" onclick="event.stopPropagation();">' . htmlspecialchars($tag) . '</a>';
-
+            if ($tag === '') {
+                continue;
+            }
+            $parts = explode(':', $tag, 2);
+            $idTag = $parts[0];
+            $descTag = $parts[1] ?? $parts[0];
+            echo '      <a href="etichetta.php?id_etichetta=' . urlencode($idTag) . '" class="badge-etichetta me-1" onclick="event.stopPropagation();">' . htmlspecialchars($descTag) . '</a>';
         }
         echo '    </div>';
     }

--- a/index.php
+++ b/index.php
@@ -21,7 +21,7 @@ if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'
  $sql = "SELECT * FROM (
             SELECT id_movimento_revolut AS id, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, bm.descrizione_extra,
                    started_date AS data_operazione, amount,
-                   (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
+                   (SELECT GROUP_CONCAT(CONCAT(e.id_etichetta, ':', e.descrizione) SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette,
@@ -30,7 +30,7 @@ if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'
             UNION ALL
             SELECT be.id_entrata AS id, COALESCE(NULLIF(be.descrizione_extra,''), be.descrizione_operazione) AS descrizione, be.descrizione_extra,
                    be.data_operazione, be.importo AS amount,
-                   (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
+                   (SELECT GROUP_CONCAT(CONCAT(e.id_etichetta, ':', e.descrizione) SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
@@ -39,7 +39,7 @@ if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'
             UNION ALL
             SELECT bu.id_uscita AS id, COALESCE(NULLIF(bu.descrizione_extra,''), bu.descrizione_operazione) AS descrizione, bu.descrizione_extra,
                    bu.data_operazione, -bu.importo AS amount,
-                   (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
+                   (SELECT GROUP_CONCAT(CONCAT(e.id_etichetta, ':', e.descrizione) SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,


### PR DESCRIPTION
## Summary
- Display label descriptions instead of IDs for movements
- Include label ID and description pairs in movement queries
- Adjust rendering to link by ID while showing descriptive text

## Testing
- `php -l index.php`
- `php -l ajax/load_movimenti_mese.php`
- `php -l ajax/search_movimenti.php`
- `php -l includes/render_movimento.php`


------
https://chatgpt.com/codex/tasks/task_e_6894abb1f7cc8331b452a569d6daa6f0