### PR TITLE
Fix delete icon for movement lists

### DIFF
--- a/includes/render_movimento.php
+++ b/includes/render_movimento.php
@@ -24,7 +24,7 @@ function render_movimento(array $mov) {
     echo '  <div class="text-end">';
     echo '    <div class="amount text-white">' . ($mov['amount'] >= 0 ? '+' : '') . $importo . ' €';
     if (!empty($mov['mezzo']) && $mov['mezzo'] === 'contanti' && in_array($mov['tabella'], ['bilancio_entrate', 'bilancio_uscite'], true)) {
-        echo ' <i class="bi bi-trash text-danger ms-2 delete-movimento" onclick="event.stopPropagation();"></i>';
+        echo ' <i class="bi bi-trash text-danger ms-2 delete-movimento"></i>';
     }
     echo '</div>';
     if (!empty($mov['etichette'])) {

--- a/js/delete_movimento.js
+++ b/js/delete_movimento.js
@@ -7,6 +7,8 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.addEventListener('click', e => {
         const icon = e.target.closest('.delete-movimento');
         if (!icon) return;
+        e.stopPropagation();
+        e.preventDefault();
         const movement = icon.closest('.movement');
         if (!movement) return;
         target = {
@@ -15,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
             element: movement
         };
         modal.show();
-    });
+    }, true);
 
     document.getElementById('confirmDelete').addEventListener('click', () => {
         if (!target) return;


### PR DESCRIPTION
## Summary
- Remove inline stopPropagation from trash icon
- Capture click on delete icon and stop propagation to avoid navigation

## Testing
- `php -l includes/render_movimento.php`
- `node --check js/delete_movimento.js`

------
https://chatgpt.com/codex/tasks/task_e_6894b091639c8331be1f5e649c92bd0a