### PR TITLE
Add user credit summary page

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -53,6 +53,11 @@
       </li>
       <?php endif; ?>
       <li class="mb-3">
+        <a href="/Gestionale25/credito_utente.php" class="btn btn-outline-light w-100 text-start">
+          💰 Credito Utente
+        </a>
+      </li>
+      <li class="mb-3">
         <a href="/Gestionale25/password.php" class="btn btn-outline-light w-100 text-start">
           🔐 Siti e password
         </a>


### PR DESCRIPTION
## Summary
- add new `credito_utente.php` page to compute each user's net credit or debt from labelled movements
- show per-movement details with associated labels and total balance
- link the credit summary page in the navigation menu

## Testing
- `php -l includes/header.php`
- `php -l credito_utente.php`


------
https://chatgpt.com/codex/tasks/task_e_6894b013254c83318a9b7d19e39964ed