### PR TITLE
feat: add generic CRUD interface

### DIFF
--- a/ajax/table_crud.php
+++ b/ajax/table_crud.php
@@ -1,0 +1,90 @@
+<?php
+header('Content-Type: application/json');
+require_once __DIR__ . '/../includes/db.php';
+$config = include __DIR__ . '/../includes/table_config.php';
+
+$table = $_GET['table'] ?? $_POST['table'] ?? '';
+if (!isset($config[$table])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Tabella non valida']);
+    exit;
+}
+$primaryKey = $config[$table]['primary_key'];
+$columns = $config[$table]['columns'];
+$action = $_GET['action'] ?? $_POST['action'] ?? 'list';
+
+switch ($action) {
+    case 'list':
+        $search = $_GET['search'] ?? '';
+        $sql = "SELECT " . implode(',', $columns) . " FROM `$table`";
+        if ($search !== '') {
+            $likes = [];
+            foreach ($columns as $col) {
+                $likes[] = "`$col` LIKE ?";
+            }
+            $sql .= " WHERE " . implode(' OR ', $likes);
+            $stmt = $conn->prepare($sql);
+            $param = "%$search%";
+            $params = array_fill(0, count($columns), $param);
+            $stmt->bind_param(str_repeat('s', count($columns)), ...$params);
+        } else {
+            $stmt = $conn->prepare($sql);
+        }
+        $stmt->execute();
+        $result = $stmt->get_result();
+        echo json_encode($result->fetch_all(MYSQLI_ASSOC));
+        break;
+    case 'insert':
+        $data = [];
+        foreach ($columns as $col) {
+            if ($col === $primaryKey) continue;
+            $data[$col] = $_POST[$col] ?? null;
+        }
+        $cols = array_keys($data);
+        $placeholders = implode(',', array_fill(0, count($cols), '?'));
+        $sql = "INSERT INTO `$table` (" . implode(',', $cols) . ") VALUES ($placeholders)";
+        $stmt = $conn->prepare($sql);
+        $stmt->bind_param(str_repeat('s', count($cols)), ...array_values($data));
+        $stmt->execute();
+        echo json_encode(['id' => $conn->insert_id]);
+        break;
+    case 'update':
+        $id = $_POST[$primaryKey] ?? null;
+        if (!$id) {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID mancante']);
+            break;
+        }
+        $data = [];
+        foreach ($columns as $col) {
+            if ($col === $primaryKey) continue;
+            if (isset($_POST[$col])) $data[$col] = $_POST[$col];
+        }
+        $set = implode(',', array_map(fn($c) => "`$c`=?", array_keys($data)));
+        $sql = "UPDATE `$table` SET $set WHERE `$primaryKey`=?";
+        $stmt = $conn->prepare($sql);
+        $types = str_repeat('s', count($data)) . 'i';
+        $params = array_merge(array_values($data), [$id]);
+        $stmt->bind_param($types, ...$params);
+        $stmt->execute();
+        echo json_encode(['success' => true]);
+        break;
+    case 'delete':
+        $id = $_POST[$primaryKey] ?? null;
+        if (!$id) {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID mancante']);
+            break;
+        }
+        $sql = "DELETE FROM `$table` WHERE `$primaryKey`=?";
+        $stmt = $conn->prepare($sql);
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        echo json_encode(['success' => true]);
+        break;
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Azione non valida']);
+        break;
+}
+?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -70,6 +70,33 @@
           </ul>
         </div>
       </li>
+      <li class="mb-3">
+        <div class="dropdown w-100">
+          <button class="btn btn-outline-light w-100 text-start dropdown-toggle"
+                  data-bs-toggle="dropdown" aria-expanded="false">
+            🗃️ Tabelle
+          </button>
+          <ul class="dropdown-menu dropdown-menu-dark w-100">
+            <li><h6 class="dropdown-header">Bilancio</h6></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=bilancio_descrizione2id">Descrizioni</a></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=bilancio_entrate">Entrate</a></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=bilancio_gruppi_categorie">Gruppi categorie</a></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=bilancio_gruppi_transazione">Gruppi transazione</a></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=bilancio_uscite">Uscite</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><h6 class="dropdown-header">Sicurezza</h6></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=codici_2fa">Codici 2FA</a></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=dispositivi_riconosciuti">Dispositivi riconosciuti</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><h6 class="dropdown-header">Utenti</h6></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=famiglie">Famiglie</a></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=userlevels">User Levels</a></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=utenti">Utenti</a></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=utenti2famiglie">Utenti-Famiglie</a></li>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=utenti2ip">Utenti-IP</a></li>
+          </ul>
+        </div>
+      </li>
       <li>
         <a href="/Gestionale25/logout.php" class="btn btn-outline-danger w-100 text-start">
           ⎋ Logout

--- a/includes/table_config.php
+++ b/includes/table_config.php
@@ -1,0 +1,52 @@
+<?php
+return [
+    'bilancio_descrizione2id' => [
+        'primary_key' => 'id_d2id',
+        'columns' => ['id_d2id','id_utente','descrizione','id_gruppo_transazione','id_metodo_pagamento','id_etichetta','conto']
+    ],
+    'bilancio_entrate' => [
+        'primary_key' => 'id_entrata',
+        'columns' => ['id_entrata','id_utente','mezzo','id_tipologia','id_gruppo_transazione','id_metodo_pagamento','descrizione_operazione','descrizione_extra','importo','note','data_operazione','data_inserimento','data_aggiornamento']
+    ],
+    'bilancio_gruppi_categorie' => [
+        'primary_key' => 'id_categoria',
+        'columns' => ['id_categoria','descrizione_categoria']
+    ],
+    'bilancio_gruppi_transazione' => [
+        'primary_key' => 'id_gruppo_transazione',
+        'columns' => ['id_gruppo_transazione','id_categoria','id_utente','descrizione','tipo_gruppo','attivo','ricorsivo','ogni_quanto','cosa_quanto']
+    ],
+    'bilancio_uscite' => [
+        'primary_key' => 'id_uscita',
+        'columns' => ['id_uscita','id_utente','id_caricamento','mezzo','id_tipologia','id_gruppo_transazione','id_metodo_pagamento','descrizione_operazione','descrizione_extra','importo','note','data_operazione','data_inserimento','data_aggiornamento']
+    ],
+    'codici_2fa' => [
+        'primary_key' => 'id',
+        'columns' => ['id','id_utente','codice','scadenza']
+    ],
+    'dispositivi_riconosciuti' => [
+        'primary_key' => 'id',
+        'columns' => ['id','id_utente','token_dispositivo','user_agent','ip','data_attivazione','scadenza']
+    ],
+    'famiglie' => [
+        'primary_key' => 'id_famiglia',
+        'columns' => ['id_famiglia','nome_famiglia','in_gestione']
+    ],
+    'userlevels' => [
+        'primary_key' => 'userlevelid',
+        'columns' => ['userlevelid','userlevelname']
+    ],
+    'utenti' => [
+        'primary_key' => 'id',
+        'columns' => ['id','username','password','nome','cognome','soprannome','email','id_famiglia_attuale','id_famiglia_gestione','admin','bilancio_voluto_fine_anno','userlevelid','profile','id_file','attivo','disponibile_per_soso','passcode']
+    ],
+    'utenti2famiglie' => [
+        'primary_key' => 'id_u2f',
+        'columns' => ['id_u2f','id_utente','id_famiglia']
+    ],
+    'utenti2ip' => [
+        'primary_key' => 'id_u2i',
+        'columns' => ['id_u2i','id_utente','ip_address']
+    ]
+];
+?>

--- a/js/table_crud.js
+++ b/js/table_crud.js
@@ -1,0 +1,79 @@
+function initTableManager(table, columns, primaryKey) {
+    const tbody = document.querySelector('#data-table tbody');
+    const searchInput = document.getElementById('search');
+    let rows = [];
+
+    function load() {
+        fetch(`../ajax/table_crud.php?action=list&table=${encodeURIComponent(table)}`)
+            .then(r => r.json())
+            .then(data => { rows = data; render(); });
+    }
+
+    function render() {
+        tbody.innerHTML = '';
+        const q = searchInput.value.toLowerCase();
+        rows.filter(r => Object.values(r).some(v => String(v).toLowerCase().includes(q)))
+            .forEach(r => {
+                const tr = document.createElement('tr');
+                columns.forEach(c => {
+                    const td = document.createElement('td');
+                    td.textContent = r[c];
+                    tr.appendChild(td);
+                });
+                const actions = document.createElement('td');
+                const editBtn = document.createElement('button');
+                editBtn.textContent = 'Modifica';
+                editBtn.addEventListener('click', () => editRow(r));
+                const delBtn = document.createElement('button');
+                delBtn.textContent = 'Elimina';
+                delBtn.addEventListener('click', () => deleteRow(r[primaryKey]));
+                actions.appendChild(editBtn);
+                actions.appendChild(delBtn);
+                tr.appendChild(actions);
+                tbody.appendChild(tr);
+            });
+    }
+
+    searchInput.addEventListener('input', render);
+
+    document.getElementById('add-form').addEventListener('submit', e => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        formData.append('action', 'insert');
+        formData.append('table', table);
+        fetch('../ajax/table_crud.php', { method: 'POST', body: formData })
+            .then(r => r.json())
+            .then(() => { e.target.reset(); load(); });
+    });
+
+    function editRow(row) {
+        const data = {};
+        columns.forEach(c => {
+            data[c] = prompt(`Modifica ${c}`, row[c]);
+        });
+        const formData = new FormData();
+        formData.append('action', 'update');
+        formData.append('table', table);
+        formData.append(primaryKey, row[primaryKey]);
+        columns.forEach(c => {
+            if (c === primaryKey) return;
+            formData.append(c, data[c]);
+        });
+        fetch('../ajax/table_crud.php', { method: 'POST', body: formData })
+            .then(r => r.json())
+            .then(load);
+    }
+
+    function deleteRow(id) {
+        if (!confirm('Eliminare il record?')) return;
+        const formData = new FormData();
+        formData.append('action', 'delete');
+        formData.append('table', table);
+        formData.append(primaryKey, id);
+        fetch('../ajax/table_crud.php', { method: 'POST', body: formData })
+            .then(r => r.json())
+            .then(load);
+    }
+
+    load();
+}

--- a/pages/table_manager.php
+++ b/pages/table_manager.php
@@ -1,0 +1,44 @@
+<?php
+$config = include __DIR__ . '/../includes/table_config.php';
+$table = $_GET['table'] ?? '';
+if (!isset($config[$table])) {
+    die('Tabella non valida');
+}
+$columns = $config[$table]['columns'];
+$primaryKey = $config[$table]['primary_key'];
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="UTF-8">
+<title>Gestione tabella <?php echo htmlspecialchars($table); ?></title>
+</head>
+<body>
+<h1>Gestione tabella <?php echo htmlspecialchars($table); ?></h1>
+<input type="text" id="search" placeholder="Cerca...">
+<table border="1" id="data-table">
+    <thead>
+        <tr>
+            <?php foreach ($columns as $col): ?>
+                <th><?php echo htmlspecialchars($col); ?></th>
+            <?php endforeach; ?>
+            <th>Azioni</th>
+        </tr>
+    </thead>
+    <tbody></tbody>
+</table>
+
+<h2>Nuovo record</h2>
+<form id="add-form">
+    <?php foreach ($columns as $col): if ($col === $primaryKey) continue; ?>
+        <label><?php echo htmlspecialchars($col); ?>: <input type="text" name="<?php echo htmlspecialchars($col); ?>"></label><br>
+    <?php endforeach; ?>
+    <button type="submit">Inserisci</button>
+</form>
+
+<script src="../js/table_crud.js"></script>
+<script>
+initTableManager('<?php echo $table; ?>', <?php echo json_encode($columns); ?>, '<?php echo $primaryKey; ?>');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add table configuration listing all tables and fields
- create generic CRUD AJAX endpoint
- add dynamic page and JavaScript for realtime searchable CRUD views
- expose table management links in the navigation menu grouped by domain

## Testing
- `php -l ajax/table_crud.php`
- `php -l includes/table_config.php`
- `php -l pages/table_manager.php`
- `php -l includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_6894b2815748833181a9654087ce78ce