### PR TITLE
Improve table manager layout and add foreign key selects

### DIFF
--- a/includes/foreign_keys.php
+++ b/includes/foreign_keys.php
@@ -1,0 +1,24 @@
+<?php
+return [
+    'id_utente' => [
+        'table' => 'utenti',
+        'key'   => 'id',
+        'label' => "CONCAT(nome, ' ', cognome)"
+    ],
+    'id_gruppo_transazione' => [
+        'table' => 'bilancio_gruppi_transazione',
+        'key'   => 'id_gruppo_transazione',
+        'label' => 'descrizione'
+    ],
+    'id_categoria' => [
+        'table' => 'bilancio_gruppi_categorie',
+        'key'   => 'id_categoria',
+        'label' => 'descrizione_categoria'
+    ],
+    'id_famiglia' => [
+        'table' => 'famiglie',
+        'key'   => 'id_famiglia',
+        'label' => 'nome_famiglia'
+    ]
+];
+?>

--- a/pages/table_manager.php
+++ b/pages/table_manager.php
@@ -1,44 +1,72 @@
 <?php
+include '../includes/session_check.php';
+require_once '../includes/db.php';
 $config = include __DIR__ . '/../includes/table_config.php';
+$foreignMap = include __DIR__ . '/../includes/foreign_keys.php';
+
 $table = $_GET['table'] ?? '';
 if (!isset($config[$table])) {
     die('Tabella non valida');
 }
 $columns = $config[$table]['columns'];
 $primaryKey = $config[$table]['primary_key'];
+$displayColumns = array_values(array_filter($columns, fn($c) => $c !== $primaryKey));
+
+$lookups = [];
+foreach ($displayColumns as $col) {
+    if (isset($foreignMap[$col])) {
+        $fk = $foreignMap[$col];
+        $sql = "SELECT {$fk['key']} AS id, {$fk['label']} AS label FROM {$fk['table']}";
+        $res = $conn->query($sql);
+        if ($res) {
+            while ($row = $res->fetch_assoc()) {
+                $lookups[$col][$row['id']] = $row['label'];
+            }
+        }
+    }
+}
+
+include '../includes/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="it">
-<head>
-<meta charset="UTF-8">
-<title>Gestione tabella <?php echo htmlspecialchars($table); ?></title>
-</head>
-<body>
-<h1>Gestione tabella <?php echo htmlspecialchars($table); ?></h1>
-<input type="text" id="search" placeholder="Cerca...">
-<table border="1" id="data-table">
-    <thead>
-        <tr>
-            <?php foreach ($columns as $col): ?>
-                <th><?php echo htmlspecialchars($col); ?></th>
-            <?php endforeach; ?>
-            <th>Azioni</th>
-        </tr>
-    </thead>
-    <tbody></tbody>
+<div class="d-flex mb-3 justify-content-between">
+  <h4><?= htmlspecialchars($table) ?></h4>
+  <button id="addBtn" class="btn btn-outline-light btn-sm">Aggiungi nuovo</button>
+</div>
+<input type="text" id="search" class="form-control bg-dark text-white border-secondary mb-3" placeholder="Cerca...">
+<table class="table table-dark table-striped" id="data-table">
+  <thead>
+    <tr>
+      <?php foreach ($displayColumns as $col): ?>
+      <th><?= htmlspecialchars($col) ?></th>
+      <?php endforeach; ?>
+      <th>Azioni</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
 </table>
 
-<h2>Nuovo record</h2>
-<form id="add-form">
-    <?php foreach ($columns as $col): if ($col === $primaryKey) continue; ?>
-        <label><?php echo htmlspecialchars($col); ?>: <input type="text" name="<?php echo htmlspecialchars($col); ?>"></label><br>
-    <?php endforeach; ?>
-    <button type="submit">Inserisci</button>
+<form id="record-form" class="d-none mt-4">
+  <input type="hidden" name="<?= htmlspecialchars($primaryKey) ?>">
+  <?php foreach ($displayColumns as $col): ?>
+    <div class="mb-3">
+      <label class="form-label"><?= htmlspecialchars($col) ?></label>
+      <?php if (isset($lookups[$col])): ?>
+        <select name="<?= htmlspecialchars($col) ?>" class="form-select bg-dark text-white border-secondary">
+          <?php foreach ($lookups[$col] as $id => $label): ?>
+            <option value="<?= htmlspecialchars($id) ?>"><?= htmlspecialchars($label) ?></option>
+          <?php endforeach; ?>
+        </select>
+      <?php else: ?>
+        <input type="text" name="<?= htmlspecialchars($col) ?>" class="form-control bg-dark text-white border-secondary">
+      <?php endif; ?>
+    </div>
+  <?php endforeach; ?>
+  <button type="submit" class="btn btn-primary">Salva</button>
+  <button type="button" id="cancelBtn" class="btn btn-secondary">Annulla</button>
 </form>
 
 <script src="../js/table_crud.js"></script>
 <script>
-initTableManager('<?php echo $table; ?>', <?php echo json_encode($columns); ?>, '<?php echo $primaryKey; ?>');
+initTableManager('<?= $table ?>', <?= json_encode($displayColumns) ?>, '<?= $primaryKey ?>', <?= json_encode($lookups) ?>);
 </script>
-</body>
-</html>
+<?php include '../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Use Bootstrap layout for generic table manager and add top-right "Aggiungi nuovo" button
- Hide auto-increment primary key column and render foreign key descriptions via lookup maps
- Add reusable front-end CRUD form with select inputs and JS support for lookups

## Testing
- `php -l pages/table_manager.php`
- `php -l includes/foreign_keys.php`


------
https://chatgpt.com/codex/tasks/task_e_6894b89f9b348331850a9413916f9e79