### PR TITLE
Add storia page for browsing company and user history

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -62,6 +62,13 @@
           🔐 Siti e password
         </a>
       </li>
+      <?php if (isset($_SESSION['utente_id']) && $_SESSION['utente_id'] == 1): ?>
+      <li class="mb-3">
+        <a href="/Gestionale25/storia.php" class="btn btn-outline-light w-100 text-start">
+          📜 Storia
+        </a>
+      </li>
+      <?php endif; ?>
       <li class="mb-3">
         <div class="dropdown w-100">
           <button class="btn btn-outline-light w-100 text-start dropdown-toggle"

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Utility functions for remote data retrieval.
+ */
+function Encrypt(string $string, string $key): string
+{
+    // Placeholder encryption using base64 encoding.
+    // Replace with proper encryption as needed.
+    return base64_encode($string);
+}
+
+class Utility
+{
+    public function getDati(string $SQLinv): array
+    {
+        $token = Encrypt(microtime(true) . rand(1000, 9999), 'test');
+        $SQLen = Encrypt(htmlspecialchars_decode($SQLinv), 'test');
+        $url = 'https://new.cosulich.it/approvazione_fatture/user_get_inaz_json.php?action=execute_query'
+            . '&token=' . $token . '&SQL=' . $SQLen;
+
+        $response = @file_get_contents($url);
+
+        return json_decode($response, true) ?? [];
+    }
+}

--- a/js/storia.js
+++ b/js/storia.js
@@ -1,0 +1,548 @@
+var models = {};
+                                          
+models.current_nav =
+'<span class="sr-only">(current)</span>';
+
+models.effettua_la_ricerca =
+"<div class='alert alert-info'>Effettua una ricerca{{label_cosa}}</div>";
+
+models.nessun_risultato =
+"<div class='alert alert-warning'>Nessun risultato</div>";
+
+models.elemento_lista =
+'<div class="border-bottom pb-3 pt-3 d-flex justify-content-between">'+
+    '<div>'+
+        '<b>{{dato_principale}}</b>'+
+        '{{contenuto}}'+
+    '</div>'+
+    '{{vedi_altro}}'+
+'</div>';
+
+models.icona_altro =
+'<div class="d-flex align-items-center ml-4 risultato" {{valori_chiave}}>'+ 
+    '<i class="fa fa-chevron-right fa-2x"></i>'+ 
+'</div>';
+
+models.contenuto_singolo =
+'<div>{{chiave}}: {{valore}}</div>';
+
+models.card_collapsed =
+'<div class="card collapsed-card mt-2">'+
+    '<div class="card-header">'+
+        '<h3 class="card-title">{{card_title}}</h3>'+ 
+        '<div class="card-tools">'+ 
+            '<button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fas fa-plus"></i></button>'+ 
+        '</div>'+ 
+    '</div>'+ 
+    '<div class="card-body">'+ 
+        '{{card_content}}'+ 
+    '</div>'+ 
+'</div>';
+class PageManager {
+    constructor() {
+
+        this.ar_filtri          = {};
+        this.aziende            = aziende_chiavi;
+        this.ar_dati            = {};
+        this.ar_dati['aziende'] = aziende;
+        this.ar_dati['utenti']  = {};
+        this.nav_attivo         = "utenti";
+        this.valore_ricercato   = "";
+        this.loading_el        = $('#loading');
+
+        this.disegna_tabella();
+        this.inizializza_menu();
+    }
+
+    render_models(json_data, modello)
+    {
+        var str = modello,
+            obj = json_data;
+        str = str.replace(/{{(\w+)}}/g, function (m, m1) {
+
+            let ret = "";
+
+            if(m1 in obj)
+            {
+                ret = obj[m1];
+            }
+
+            return ret;
+        });
+        return str;
+    }
+
+    inizializza_menu()
+    {
+        this.attiva_nav();
+
+        $('.nav-link').on('click', (e) => {
+            e.preventDefault();
+            this.nav_attivo = $(e.currentTarget).data("quale");
+            this.attiva_nav();
+        });
+
+        $('#btn_ricerca').on('click', (e) => {
+
+            this.ricerca();
+        });
+    }
+
+    attiva_nav()
+    {
+        $(".nav-link").removeClass("active");
+        $("#nav-"+this.nav_attivo).addClass("active");
+        this.toggle_filter();
+    }
+
+    disegna_tabella(quale="")
+    {
+        let tabella_da_disegnare = "";
+
+        if(quale!="")
+        {
+            tabella_da_disegnare = quale;
+        }else{
+            tabella_da_disegnare = this.nav_attivo;
+        }
+
+        let ar_dati_att         = {};
+        let dati_render         = {};
+        /*
+        dati_render.testata     = "";
+        dati_render.contenuto   = "";
+        */
+        let dbcolprinc   = [];
+
+        let ar_colonne      = {};
+
+        let valore_chiave = [];
+
+        switch(tabella_da_disegnare)
+        {
+            case "aziende":
+
+                ar_colonne.CODAZI   = "ID";
+                ar_colonne.RAGSOC   = "Azienda";
+                ar_colonne.INIZIO   = "Inizio";
+                ar_colonne.FINE     = "Fine";
+                ar_colonne.PARTIVA  = "P.Iva";
+
+                ar_dati_att = this.ar_dati['aziende'];
+
+                dbcolprinc = ["RAGSOC"];
+
+                valore_chiave = ["CODAZI"];
+
+            break;
+            case "utenti":
+
+                ar_colonne.CODDIP       = "ID";
+                ar_colonne.DATANAS      = "Data nascita";
+                ar_colonne.DATAASSUNZ   = "Data assunzione";
+                ar_colonne.DATALICEN    = "Data fine";
+                /*
+                ar_colonne.CODQUALIF    = "Qualifica";
+                ar_colonne.CODLIVELLO    = "Livello";
+                */
+
+                ar_dati_att = this.ar_dati['utenti'];
+
+                dbcolprinc = ["COGNOME","NOME"];
+
+                valore_chiave = ["CODDIP","CODAZI"];
+
+            break;
+            case 'dettagli_utente':
+
+                ar_colonne.eta                  = "Et&agrave;";
+                ar_colonne.ORDINARIA            = "Retribuzione ordinaria";
+                ar_colonne.IRPEF                = "Irpef";
+                ar_colonne.TOTALE_COMPETENZE    = "Totale competenze";
+                ar_colonne.TOTALE_RITENUTE      = "Totale ritenute";
+                ar_colonne.NETTO                = "Netto";
+
+                ar_dati_att = this.ar_dati['dettagli_utente'];
+
+                dbcolprinc = ["ANNO"];
+
+                valore_chiave = ["CODDIP","CODAZI","ANNO"];
+
+                //this.show_breadcrumbs();
+
+            break;
+            case 'anno':
+
+                ar_colonne.NETTO                = "Netto";
+                ar_colonne.ORDINARIA            = "Retribuzione ordinaria";
+                /*
+                ar_colonne.TFR                  = "Accantomento Tfr";
+                ar_colonne.COMPETENZE           = "Totale competenze";
+                ar_colonne.DETRAZIONI           = "Totale detrazioni";
+                */
+                ar_colonne.BONUS                = "Bonus Una Tantum";
+                ar_colonne.PREMIO               = "Premio";
+                ar_colonne.PREMIO_RISULTATO     = "Premio di risultato";
+
+                ar_dati_att = this.ar_dati['anno'];
+
+                dbcolprinc = ["ANNO_MESE"];
+
+                valore_chiave = ["CODDIP","CODAZI","ANNO","MESE"];
+
+                //this.show_breadcrumbs();
+
+            break;
+            case 'cedolino':
+
+                ar_colonne.IMPORTO        = "Valore";
+
+                ar_dati_att = this.ar_dati['cedolino'];
+
+                dbcolprinc = ["DESCRIZ"];
+
+            break;
+        }
+
+        let lista = "";
+        let dati_render_dato = {};
+        let ar_chiave_valore = {};
+
+        //console.log(ar_dati_att);
+
+        for(let pos in ar_dati_att)
+        {
+            let az = ar_dati_att[pos];
+
+            dati_render.dato_principale = "";
+
+            for(let chiave in dbcolprinc)
+            {
+                dati_render.dato_principale += az[dbcolprinc[chiave]]+" ";
+            }
+
+            dati_render.contenuto       = "";
+            dati_render.vedi_altro      = "";
+
+            let dati_render_altro = {};
+            dati_render_altro.valori_chiave   = "";
+
+            for(let posk in valore_chiave)
+            {
+                let chiave = valore_chiave[posk];
+                dati_render_altro.valori_chiave += "data-"+chiave+"="+az[chiave]+" ";
+            }
+
+            if(dati_render_altro.valori_chiave!="")
+            {
+                dati_render.vedi_altro = this.render_models(dati_render_altro, models.icona_altro);
+            }
+
+            /*CONTENUTO*/
+
+            if(tabella_da_disegnare=="utenti")
+            {
+                dati_render.contenuto += "<br><i>"+this.aziende[az['CODAZI']]['RAGSOC']+"</i>";
+            }
+
+            for(let dbcol in ar_colonne)
+            {
+                dati_render_dato.chiave = ar_colonne[dbcol];
+                dati_render_dato.valore = az[dbcol];
+
+                dati_render.contenuto += this.render_models(dati_render_dato, models.contenuto_singolo);
+            }
+
+            lista += this.render_models(dati_render, models.elemento_lista);
+
+            ar_chiave_valore[az['CODVOCE']] = az;
+        }
+
+        if(ar_dati_att.length>0)
+        {
+            if(tabella_da_disegnare=="cedolino")
+            {
+                let lista_finale = "";
+                let ar_chiavi = [];
+                ar_chiavi.push("C99");
+                ar_chiavi.push("002");
+                ar_chiavi.push("C97");
+                ar_chiavi.push("C75");
+                ar_chiavi.push("019");
+                ar_chiavi.push("018");
+                ar_chiavi.push("176");
+                ar_chiavi.push("217");
+                ar_chiavi.push("081");
+                ar_chiavi.push("082");
+                ar_chiavi.push("008");
+                /*
+                ar_chiavi["C99"] = "";
+                ar_chiavi["002"] = "";
+                ar_chiavi["019"] = "";
+                ar_chiavi["018"] = "";
+                ar_chiavi["176"] = "";
+                ar_chiavi["C97"] = "";
+                ar_chiavi["008"] = "";
+                */
+
+                //console.log(ar_chiavi);
+
+                for(let c in ar_chiavi)
+                {
+                    let k = ar_chiavi[c];
+                    let dati_render = {};
+
+                    if(ar_chiave_valore[k] !== undefined)
+                    {
+                        dati_render.chiave   = ar_chiave_valore[k]['DESCRIZ'];
+                        dati_render.valore   = ar_chiave_valore[k]['IMPORTO'];
+
+                    }else{
+
+                        dati_render.chiave   = k;
+                        dati_render.valore   = "";
+                    }
+
+                    lista_finale += this.render_models(dati_render, models.contenuto_singolo);
+                }
+
+                let dati_render = {};
+                dati_render.card_title     = "Vedi dettagli";
+                dati_render.card_content   = lista;
+
+                lista_finale += this.render_models(dati_render, models.card_collapsed);
+
+                lista = lista_finale;
+            }
+
+            //document.getElementById("div_content").innerHTML = this.render_models(dati_render, models.tabella);
+            document.getElementById("div_content").innerHTML = lista;
+
+            switch(tabella_da_disegnare)
+            {
+                case 'aziende':
+
+                    $('.risultato').on('click', (e) => {
+                        this.ar_filtri = {};
+                        this.ar_filtri['codazi'] = $(e.currentTarget).data("codazi");
+                        this.ricerca_dettagli("utenti");
+                    });
+
+                break;
+                case 'utenti':
+
+                    $('.risultato').on('click', (e) => {
+                        this.ar_filtri = {};
+                        this.ar_filtri['codazi'] = $(e.currentTarget).data("codazi");
+                        this.ar_filtri['coddip'] = $(e.currentTarget).data("coddip");
+                        this.ricerca_dettagli("dettagli_utente");
+                    });
+
+                break;
+                case 'dettagli_utente':
+
+                    $('.risultato').on('click', (e) => {
+                        this.ar_filtri = {};
+                        this.ar_filtri['codazi'] = $(e.currentTarget).data("codazi");
+                        this.ar_filtri['coddip'] = $(e.currentTarget).data("coddip");
+                        this.ar_filtri['anno'] = $(e.currentTarget).data("anno");
+                        this.ricerca_dettagli("anno");
+                    });
+
+                break;
+                case 'anno':
+
+                    $('.risultato').on('click', (e) => {
+                        this.ar_filtri = {};
+                        this.ar_filtri['codazi'] = $(e.currentTarget).data("codazi");
+                        this.ar_filtri['coddip'] = $(e.currentTarget).data("coddip");
+                        this.ar_filtri['anno'] = $(e.currentTarget).data("anno");
+                        this.ar_filtri['mese'] = $(e.currentTarget).data("mese");
+                        this.ricerca_dettagli("cedolino");
+                    });
+
+                break;
+            }
+
+        }else if(this.valore_ricercato!=""){
+            document.getElementById("div_content").innerHTML = this.render_models({}, models.nessun_risultato);
+        }else{
+            document.getElementById("div_content").innerHTML = this.render_models({"label_cosa":" su "+this.nav_attivo}, models.effettua_la_ricerca);
+        }
+    }
+
+    ricerca()
+    {
+        this.valore_ricercato = $("#ricerca").val();
+
+        this.ar_dati_precedente = this.ar_dati;
+
+        this.show_loading();
+
+        $.ajax({
+            method: "POST",
+            url: "ajax.php",
+            data:
+            {
+                'azione': 'ricerca',
+                'cosa': this.nav_attivo,
+                'valore_ricercato': this.valore_ricercato,
+                'filtro_azienda': $('#filtroAzienda').val()
+            }
+        })
+        .done(( msg )=>{
+
+            if(msg=="login")
+            {
+                ew.prompt("Sessione scaduta. Effettua il login!");
+                location.href="logout.php";
+                return;
+            }
+
+            let dati_risposta = JSON.parse(msg);
+
+            this.ar_dati[this.nav_attivo] = dati_risposta.ar_dati;
+
+            this.hide_breadcrumbs();
+            this.disegna_tabella();
+        })
+        .always(()=>{
+            this.hide_loading();
+        });
+    }
+
+    ricerca_dettagli(cosa)
+    {
+
+        this.show_loading();
+
+        $.ajax({
+            method: "POST",
+            url: "ajax.php",
+            data:
+            {
+                'azione': 'ricerca',
+                'cosa': cosa,
+                'ar_filtri': this.ar_filtri
+            }
+        })
+        .done(( msg )=>{
+
+            if(msg=="login")
+            {
+                ew.prompt("Sessione scaduta. Effettua il login!");
+                location.href="logout.php";
+                return;
+            }
+
+            let dati_risposta = JSON.parse(msg);
+
+            this.ar_dati[cosa] = dati_risposta.ar_dati;
+
+            this.disegna_tabella(cosa);
+            this.update_breadcrumbs(cosa);
+        })
+        .always(()=>{
+            this.hide_loading();
+        });
+    }
+
+    update_breadcrumbs(cosa)
+    {
+        let bc = '<li class="breadcrumb-item"><a href="#" id="home_storia">Home</a></li>';
+        let utente = null;
+        for(let k in this.ar_dati['utenti'])
+        {
+            let ar_ut = this.ar_dati['utenti'][k];
+            if(this.ar_filtri['codazi'] == ar_ut['CODAZI'] && this.ar_filtri['coddip'] == ar_ut['CODDIP'])
+            {
+                utente = ar_ut;
+            }
+        }
+
+        if(cosa == 'dettagli_utente')
+        {
+            if(utente)
+            {
+                bc += '<li class="breadcrumb-item active" aria-current="page">'+utente['NOME']+' '+utente['COGNOME']+'</li>';
+            }
+        }
+
+        if(cosa == 'anno' || cosa == 'cedolino')
+        {
+            if(utente)
+            {
+                bc += '<li class="breadcrumb-item"><a href="#" id="utente_storia">'+utente['NOME']+' '+utente['COGNOME']+'</a></li>';
+            }
+
+            if(cosa == 'anno')
+            {
+                bc += '<li class="breadcrumb-item active" aria-current="page">'+this.ar_filtri['anno']+'</li>';
+            }
+
+            if(cosa == 'cedolino')
+            {
+                bc += '<li class="breadcrumb-item"><a href="#" id="anno_storia">'+this.ar_filtri['anno']+'</a></li>';
+                bc += '<li class="breadcrumb-item active" aria-current="page">'+this.ar_filtri['mese']+'</li>';
+            }
+        }
+
+        document.getElementById('breadcrumbs_storia_content').innerHTML = bc;
+        this.show_breadcrumbs();
+
+        $('#home_storia').on('click', (e) => {
+            this.valore_ricercato = '';
+            this.ricerca();
+        });
+
+        $('#utente_storia').on('click', (e) => {
+            this.ar_filtri = {codazi:this.ar_filtri['codazi'], coddip:this.ar_filtri['coddip']};
+            this.ricerca_dettagli('dettagli_utente');
+        });
+
+        $('#anno_storia').on('click', (e) => {
+            this.ar_filtri = {codazi:this.ar_filtri['codazi'], coddip:this.ar_filtri['coddip'], anno:this.ar_filtri['anno']};
+            this.ricerca_dettagli('anno');
+        });
+    }
+
+    show_loading()
+    {
+        this.loading_el.show();
+    }
+
+    hide_loading()
+    {
+        this.loading_el.hide();
+    }
+
+    toggle_filter()
+    {
+        if(this.nav_attivo === 'utenti')
+        {
+            $('#filtroAzienda').show();
+        }else{
+            $('#filtroAzienda').hide();
+        }
+    }
+
+    hide_breadcrumbs()
+    {
+        var yourUl = document.getElementById("breadcrumbs_storia");
+        yourUl.style.display = 'none';
+    }
+
+    show_breadcrumbs()
+    {
+        var yourUl = document.getElementById("breadcrumbs_storia");
+        yourUl.style.display = '';
+    }
+}
+
+var PageM;
+
+setTimeout(()=>{
+
+PageM = new PageManager();
+
+}, 1000);

--- a/storia.php
+++ b/storia.php
@@ -1,0 +1,71 @@
+<?php
+include 'includes/session_check.php';
+include 'includes/db.php';
+require_once 'includes/utility.php';
+include 'includes/header.php';
+
+$SQLinv =
+"SELECT
+    CODAZI,
+    RAGSOC,
+    SIGLA,
+    INIZIO,
+    FINE,
+    PARTIVA
+FROM
+    dbo.ARCAZI
+ORDER BY
+    RAGSOC ASC";
+
+$utility = new Utility();
+$per_aziende = $utility->getDati($SQLinv);
+
+$aziende = [];
+$aziende_chiavi = [];
+
+foreach ($per_aziende as $azienda) {
+    $aziende[] = $azienda;
+    $aziende_chiavi[$azienda['CODAZI']] = $azienda;
+}
+?>
+<script>
+var aziende = JSON.parse('<?= json_encode($aziende, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>');
+var aziende_chiavi = JSON.parse('<?= json_encode($aziende_chiavi, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>');
+</script>
+<div class="d-flex mb-3 justify-content-between">
+    <h4>Storia</h4>
+</div>
+<ul class="nav nav-tabs mb-3">
+    <li class="nav-item">
+        <a class="nav-link active" id="nav-utenti" data-quale="utenti" href="#">Utenti</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" id="nav-aziende" data-quale="aziende" href="#">Aziende</a>
+    </li>
+</ul>
+<div class="d-flex mb-3 align-items-center">
+    <input type="text" id="ricerca" class="form-control bg-dark text-white border-secondary me-2" placeholder="Cerca">
+    <select id="filtroAzienda" class="form-select bg-dark text-white border-secondary me-2">
+        <option value="">Tutte le aziende</option>
+        <?php foreach ($aziende as $az): ?>
+            <option value="<?= $az['CODAZI']; ?>"><?= htmlspecialchars($az['RAGSOC']); ?></option>
+        <?php endforeach; ?>
+    </select>
+    <button class="btn btn-outline-light btn-sm" id="btn_ricerca" type="button">Cerca</button>
+</div>
+<nav aria-label="breadcrumb" id="breadcrumbs_storia" style="display:none">
+    <ol class="breadcrumb" id="breadcrumbs_storia_content">
+    </ol>
+</nav>
+<div id="loading" class="text-center my-3" style="display:none">
+    <div class="spinner-border" role="status">
+        <span class="visually-hidden">Loading...</span>
+    </div>
+</div>
+<div id="div_content">
+
+</div>
+
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="js/storia.js"></script>
+<?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- create utility class with placeholder encryption and remote data retrieval
- add storia.php page with search navigation and dynamic company data
- move front-end logic to dedicated js/storia.js
- show storia menu link only to admin user
- align storia layout with other pages, adding breadcrumbs, loading spinner and company filter

## Testing
- `php -l includes/header.php`
- `php -l storia.php`
- `node --check js/storia.js`


------
https://chatgpt.com/codex/tasks/task_e_6894b66de7308331970316afcc7f33f0