### PR TITLE
Enable per-user credit view with permission-based switching

### DIFF
--- a/sql/add_userlevelid_to_utenti2famiglie.sql
+++ b/sql/add_userlevelid_to_utenti2famiglie.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `utenti2famiglie`
+  ADD COLUMN `userlevelid` int(11) NOT NULL DEFAULT '0' AFTER `id_famiglia`;


### PR DESCRIPTION
## Summary
- Default `credito_utente.php` to the logged user's balances and filter movements with `saldata = 0`
- Allow switching to other family members only if the current user has sufficient admin/userlevel privileges
- Provide SQL script to store `userlevelid` per family for future permission management

## Testing
- `php -l credito_utente.php`


------
https://chatgpt.com/codex/tasks/task_e_6894be8197c88331aeac112558dc8ca3