### PR TITLE
Improve mobile layout and fix storia click handler

### DIFF
--- a/js/storia.js
+++ b/js/storia.js
@@ -10,8 +10,8 @@ models.nessun_risultato =
 "<div class='alert alert-warning'>Nessun risultato</div>";
 
 models.elemento_lista =
-'<div class="border-bottom pb-3 pt-3 d-flex justify-content-between">'+
-    '<div>'+
+'<div class="border-bottom py-3 d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center gap-2">'+
+    '<div class="text-break">'+
         '<b>{{dato_principale}}</b>'+
         '{{contenuto}}'+
     '</div>'+
@@ -19,8 +19,8 @@ models.elemento_lista =
 '</div>';
 
 models.icona_altro =
-'<div class="d-flex align-items-center ml-4 risultato" {{valori_chiave}}>'+ 
-    '<i class="fa fa-chevron-right fa-2x"></i>'+ 
+'<div class="d-flex align-items-center ms-sm-4 risultato" style="cursor:pointer" {{valori_chiave}}>'+
+    '<i class="fa fa-chevron-right fa-2x"></i>'+
 '</div>';
 
 models.contenuto_singolo =
@@ -52,6 +52,9 @@ class PageManager {
 
         this.disegna_tabella();
         this.inizializza_menu();
+        $(document).on('click', '.risultato', (e) => {
+            this.handleRisultatoClick(e);
+        });
     }
 
     render_models(json_data, modello)
@@ -86,6 +89,49 @@ class PageManager {
 
             this.ricerca();
         });
+    }
+
+    handleRisultatoClick(e)
+    {
+        const el = $(e.currentTarget);
+        this.ar_filtri = {};
+
+        if(el.data('codazi') !== undefined)
+        {
+            this.ar_filtri['codazi'] = el.data('codazi');
+        }
+
+        if(el.data('coddip') !== undefined)
+        {
+            this.ar_filtri['coddip'] = el.data('coddip');
+        }
+
+        if(el.data('anno') !== undefined)
+        {
+            this.ar_filtri['anno'] = el.data('anno');
+        }
+
+        if(el.data('mese') !== undefined)
+        {
+            this.ar_filtri['mese'] = el.data('mese');
+        }
+
+        let prossimo = 'utenti';
+
+        if(el.data('mese') !== undefined)
+        {
+            prossimo = 'cedolino';
+        }
+        else if(el.data('anno') !== undefined)
+        {
+            prossimo = 'anno';
+        }
+        else if(el.data('coddip') !== undefined)
+        {
+            prossimo = 'dettagli_utente';
+        }
+
+        this.ricerca_dettagli(prossimo);
     }
 
     attiva_nav()
@@ -317,52 +363,6 @@ class PageManager {
 
             //document.getElementById("div_content").innerHTML = this.render_models(dati_render, models.tabella);
             document.getElementById("div_content").innerHTML = lista;
-
-            switch(tabella_da_disegnare)
-            {
-                case 'aziende':
-
-                    $('.risultato').on('click', (e) => {
-                        this.ar_filtri = {};
-                        this.ar_filtri['codazi'] = $(e.currentTarget).data("codazi");
-                        this.ricerca_dettagli("utenti");
-                    });
-
-                break;
-                case 'utenti':
-
-                    $('.risultato').on('click', (e) => {
-                        this.ar_filtri = {};
-                        this.ar_filtri['codazi'] = $(e.currentTarget).data("codazi");
-                        this.ar_filtri['coddip'] = $(e.currentTarget).data("coddip");
-                        this.ricerca_dettagli("dettagli_utente");
-                    });
-
-                break;
-                case 'dettagli_utente':
-
-                    $('.risultato').on('click', (e) => {
-                        this.ar_filtri = {};
-                        this.ar_filtri['codazi'] = $(e.currentTarget).data("codazi");
-                        this.ar_filtri['coddip'] = $(e.currentTarget).data("coddip");
-                        this.ar_filtri['anno'] = $(e.currentTarget).data("anno");
-                        this.ricerca_dettagli("anno");
-                    });
-
-                break;
-                case 'anno':
-
-                    $('.risultato').on('click', (e) => {
-                        this.ar_filtri = {};
-                        this.ar_filtri['codazi'] = $(e.currentTarget).data("codazi");
-                        this.ar_filtri['coddip'] = $(e.currentTarget).data("coddip");
-                        this.ar_filtri['anno'] = $(e.currentTarget).data("anno");
-                        this.ar_filtri['mese'] = $(e.currentTarget).data("mese");
-                        this.ricerca_dettagli("cedolino");
-                    });
-
-                break;
-            }
 
         }else if(this.valore_ricercato!=""){
             document.getElementById("div_content").innerHTML = this.render_models({}, models.nessun_risultato);

--- a/storia.php
+++ b/storia.php
@@ -32,10 +32,10 @@ foreach ($per_aziende as $azienda) {
 var aziende = JSON.parse('<?= json_encode($aziende, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>');
 var aziende_chiavi = JSON.parse('<?= json_encode($aziende_chiavi, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>');
 </script>
-<div class="d-flex mb-3 justify-content-between">
+<div class="mb-3 text-center text-md-start">
     <h4>Storia</h4>
 </div>
-<ul class="nav nav-tabs mb-3">
+<ul class="nav nav-tabs mb-3 justify-content-center">
     <li class="nav-item">
         <a class="nav-link active" id="nav-utenti" data-quale="utenti" href="#">Utenti</a>
     </li>
@@ -43,15 +43,21 @@ var aziende_chiavi = JSON.parse('<?= json_encode($aziende_chiavi, JSON_HEX_TAG |
         <a class="nav-link" id="nav-aziende" data-quale="aziende" href="#">Aziende</a>
     </li>
 </ul>
-<div class="d-flex mb-3 align-items-center">
-    <input type="text" id="ricerca" class="form-control bg-dark text-white border-secondary me-2" placeholder="Cerca">
-    <select id="filtroAzienda" class="form-select bg-dark text-white border-secondary me-2">
-        <option value="">Tutte le aziende</option>
-        <?php foreach ($aziende as $az): ?>
-            <option value="<?= $az['CODAZI']; ?>"><?= htmlspecialchars($az['RAGSOC']); ?></option>
-        <?php endforeach; ?>
-    </select>
-    <button class="btn btn-outline-light btn-sm" id="btn_ricerca" type="button">Cerca</button>
+<div class="row g-2 mb-3">
+    <div class="col-12 col-md-4">
+        <input type="text" id="ricerca" class="form-control bg-dark text-white border-secondary" placeholder="Cerca">
+    </div>
+    <div class="col-12 col-md-5">
+        <select id="filtroAzienda" class="form-select bg-dark text-white border-secondary">
+            <option value="">Tutte le aziende</option>
+            <?php foreach ($aziende as $az): ?>
+                <option value="<?= $az['CODAZI']; ?>"><?= htmlspecialchars($az['RAGSOC']); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <div class="col-12 col-md-3">
+        <button class="btn btn-outline-light w-100" id="btn_ricerca" type="button">Cerca</button>
+    </div>
 </div>
 <nav aria-label="breadcrumb" id="breadcrumbs_storia" style="display:none">
     <ol class="breadcrumb" id="breadcrumbs_storia_content">


### PR DESCRIPTION
## Summary
- Refactor search results layout and icons for mobile-friendly spacing
- Delegate `.risultato` click handling to reliably load details
- Rework `storia.php` layout with responsive grid controls for small screens

## Testing
- `php -l storia.php`
- `node --check js/storia.js && echo 'Syntax OK'`

------
https://chatgpt.com/codex/tasks/task_e_6894c7f780e08331b5ef6872b428fd80