### PR TITLE
Prefill movement date with current time

### DIFF
--- a/aggiungi_entrata.php
+++ b/aggiungi_entrata.php
@@ -39,7 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </div>
     <div class="mb-3">
       <label class="form-label">Data Operazione</label>
-      <input type="datetime-local" name="data_operazione" class="form-control bg-dark text-white" required>
+      <input type="datetime-local" name="data_operazione" class="form-control bg-dark text-white" value="<?php echo date('Y-m-d\\TH:i'); ?>" required>
     </div>
     <div class="mb-3">
       <label class="form-label">Note</label>

--- a/aggiungi_uscita.php
+++ b/aggiungi_uscita.php
@@ -39,7 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </div>
     <div class="mb-3">
       <label class="form-label">Data Operazione</label>
-      <input type="datetime-local" name="data_operazione" class="form-control bg-dark text-white" required>
+      <input type="datetime-local" name="data_operazione" class="form-control bg-dark text-white" value="<?php echo date('Y-m-d\\TH:i'); ?>" required>
     </div>
     <div class="mb-3">
       <label class="form-label">Note</label>


### PR DESCRIPTION
## Summary
- Prefill operation date fields with the current timestamp in entry and exit forms

## Testing
- `php -l aggiungi_entrata.php aggiungi_uscita.php`


------
https://chatgpt.com/codex/tasks/task_e_6894d5d8e4b483318a84aa0a5076ce48