### PR TITLE
Add settlement controls and details for user credits

### DIFF
--- a/ajax/update_u2o_saldata.php
+++ b/ajax/update_u2o_saldata.php
@@ -1,0 +1,30 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$loggedUserId = $_SESSION['utente_id'] ?? 0;
+if ($loggedUserId != 1) {
+    echo json_encode(['success' => false, 'error' => 'Non autorizzato']);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$id    = isset($data['id_u2o']) ? (int)$data['id_u2o'] : 0;
+$saldata = !empty($data['saldata']) ? 1 : 0;
+
+if ($id <= 0) {
+    echo json_encode(['success' => false, 'error' => 'ID non valido']);
+    exit;
+}
+
+if ($saldata) {
+    $stmt = $conn->prepare("UPDATE bilancio_utenti2operazioni_etichettate SET saldata = 1, data_saldo = NOW() WHERE id_u2o = ?");
+} else {
+    $stmt = $conn->prepare("UPDATE bilancio_utenti2operazioni_etichettate SET saldata = 0, data_saldo = NULL WHERE id_u2o = ?");
+}
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => true]);


### PR DESCRIPTION
## Summary
- allow admin user to mark credit movements as settled, updating data_saldo
- show per-user movement details in a modal when clicking a movement
- add AJAX endpoint to update settlement state

## Testing
- `php -l credito_utente.php`
- `php -l ajax/update_u2o_saldata.php`


------
https://chatgpt.com/codex/tasks/task_e_6894dc5fd49083318391f32d4b7e718a