### PR TITLE
Add ability to insert user quotes from modal

### DIFF
--- a/ajax/update_utenti2operazioni_etichettate.php
+++ b/ajax/update_utenti2operazioni_etichettate.php
@@ -10,17 +10,27 @@ if (!is_array($rows)) {
     exit;
 }
 
-$stmt = $conn->prepare("UPDATE bilancio_utenti2operazioni_etichettate SET importo_utente = ?, saldata = ?, data_saldo = ? WHERE id_u2o = ?");
+$stmtUpd = $conn->prepare("UPDATE bilancio_utenti2operazioni_etichettate SET importo_utente = ?, saldata = ?, data_saldo = ? WHERE id_u2o = ?");
+$stmtIns = $conn->prepare("INSERT INTO bilancio_utenti2operazioni_etichettate (id_e2o, id_utente, importo_utente, saldata, data_saldo) VALUES (?, ?, ?, ?, ?)");
 foreach ($rows as $r) {
     $id = intval($r['id_u2o'] ?? 0);
-    if ($id <= 0) continue;
     $importo = isset($r['importo_utente']) && $r['importo_utente'] !== '' ? (float)$r['importo_utente'] : 0;
     $saldata = !empty($r['saldata']) ? 1 : 0;
     $data_saldo = $r['data_saldo'] ?? null;
     if ($data_saldo === '') $data_saldo = null;
-    $stmt->bind_param('disi', $importo, $saldata, $data_saldo, $id);
-    $stmt->execute();
+    if ($id > 0) {
+        $stmtUpd->bind_param('disi', $importo, $saldata, $data_saldo, $id);
+        $stmtUpd->execute();
+    } else {
+        $id_e2o = intval($r['id_e2o'] ?? 0);
+        $id_utente = intval($r['id_utente'] ?? 0);
+        if ($id_e2o > 0 && $id_utente > 0) {
+            $stmtIns->bind_param('iidis', $id_e2o, $id_utente, $importo, $saldata, $data_saldo);
+            $stmtIns->execute();
+        }
+    }
 }
-$stmt->close();
+$stmtUpd->close();
+$stmtIns->close();
 
 echo json_encode(['success' => true]);


### PR DESCRIPTION
## Summary
- Load only active users for family to populate dropdowns
- Allow adding user shares via Quote Utenti modal and save new entries

## Testing
- `php -l etichetta.php`
- `php -l ajax/update_utenti2operazioni_etichettate.php`


------
https://chatgpt.com/codex/tasks/task_e_6894dd95425c83319360871e152d77b5