### PR TITLE
Improve mobile arrow usability on storia page

### DIFF
--- a/js/storia.js
+++ b/js/storia.js
@@ -19,8 +19,8 @@ models.elemento_lista =
 '</div>';
 
 models.icona_altro =
-'<div class="d-flex align-items-center ms-sm-4 risultato" style="cursor:pointer" {{valori_chiave}}>'+
-    '&gt;'+
+'<div class="d-flex align-items-center ms-sm-4 risultato p-2" style="cursor:pointer" {{valori_chiave}}>'+
+    '<i class="bi bi-chevron-right fs-3"></i>'+
 '</div>';
 
 models.contenuto_singolo =


### PR DESCRIPTION
## Summary
- enlarge the left-side arrow clickable area in storia results for better mobile usability using a larger Bootstrap chevron icon

## Testing
- `node --check js/storia.js`


------
https://chatgpt.com/codex/tasks/task_e_6894e1312ad8833199a1b4ea7ad4b21c