### PR TITLE
Use per-family user levels for permissions

### DIFF
--- a/ajax/table_crud.php
+++ b/ajax/table_crud.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
+require_once __DIR__ . '/../includes/session_check.php';
 require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/permissions.php';
 $config = include __DIR__ . '/../includes/table_config.php';
 
 $table = $_GET['table'] ?? $_POST['table'] ?? '';
@@ -12,6 +14,14 @@ if (!isset($config[$table])) {
 $primaryKey = $config[$table]['primary_key'];
 $columns = $config[$table]['columns'];
 $action = $_GET['action'] ?? $_POST['action'] ?? 'list';
+$actionMap = ['list' => 'view', 'insert' => 'insert', 'update' => 'update', 'delete' => 'delete'];
+$permAction = $actionMap[$action] ?? '';
+if (!has_permission($conn, 'table:' . $table, $permAction)) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Permesso negato']);
+    exit;
+}
+
 
 switch ($action) {
     case 'list':

--- a/cambia_famiglia.php
+++ b/cambia_famiglia.php
@@ -6,16 +6,18 @@ $idUtente = $_SESSION['utente_id'] ?? 0;
 $idFamiglia = isset($_POST['id_famiglia_gestione']) ? (int)$_POST['id_famiglia_gestione'] : 0;
 
 if ($idUtente && $idFamiglia) {
-    $stmt = $conn->prepare('SELECT 1 FROM utenti2famiglie WHERE id_utente = ? AND id_famiglia = ?');
+    $stmt = $conn->prepare('SELECT userlevelid FROM utenti2famiglie WHERE id_utente = ? AND id_famiglia = ?');
     $stmt->bind_param('ii', $idUtente, $idFamiglia);
     $stmt->execute();
     $res = $stmt->get_result();
-    if ($res && $res->num_rows === 1) {
+    if ($row = $res->fetch_assoc()) {
         $_SESSION['id_famiglia_gestione'] = $idFamiglia;
+        $_SESSION['userlevelid'] = $row['userlevelid'];
         $upd = $conn->prepare('UPDATE utenti SET id_famiglia_gestione = ? WHERE id = ?');
         $upd->bind_param('ii', $idFamiglia, $idUtente);
         $upd->execute();
     }
+    $stmt->close();
 }
 
 $redirect = $_SERVER['HTTP_REFERER'] ?? 'index.php';

--- a/credito_utente.php
+++ b/credito_utente.php
@@ -4,6 +4,8 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:credito_utente.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
 include 'includes/header.php';
 setlocale(LC_TIME, 'it_IT.UTF-8');
 
@@ -12,8 +14,8 @@ $loggedUserId = $_SESSION['utente_id'] ?? 0;
 $famigliaId   = $_SESSION['id_famiglia_gestione'] ?? 0;
 
 // Verifica permessi dell'utente loggato per cambiare utente
-$stmtPerm = $conn->prepare('SELECT u.userlevelid AS lvl, u.admin FROM utenti u WHERE u.id = ?');
-$stmtPerm->bind_param('i', $loggedUserId);
+$stmtPerm = $conn->prepare('SELECT u2f.userlevelid AS lvl, u.admin FROM utenti2famiglie u2f JOIN utenti u ON u.id = u2f.id_utente WHERE u.id = ? AND u2f.id_famiglia = ?');
+$stmtPerm->bind_param('ii', $loggedUserId, $famigliaId);
 $stmtPerm->execute();
 $perm = $stmtPerm->get_result()->fetch_assoc();
 $stmtPerm->close();

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/permissions.php'; ?>
 <!DOCTYPE html>
 <html lang="it">
 <head>
@@ -29,92 +30,155 @@
     <form method="post" action="cambia_famiglia.php" class="mb-3">
       <select name="id_famiglia_gestione" class="form-select bg-dark text-white border-secondary" onchange="this.form.submit()">
         <?php
-        $stmt = $conn->prepare('SELECT f.id_famiglia, f.nome_famiglia FROM famiglie f JOIN utenti2famiglie u2f ON f.id_famiglia = u2f.id_famiglia WHERE u2f.id_utente = ?');
+        $stmt = $conn->prepare('SELECT f.id_famiglia, f.nome_famiglia, u2f.userlevelid FROM famiglie f JOIN utenti2famiglie u2f ON f.id_famiglia = u2f.id_famiglia WHERE u2f.id_utente = ?');
         $stmt->bind_param('i', $_SESSION['utente_id']);
         $stmt->execute();
         $resFam = $stmt->get_result();
-        while ($fam = $resFam->fetch_assoc()): ?>
+        while ($fam = $resFam->fetch_assoc()):
+          if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == $fam['id_famiglia']) {
+              $_SESSION['userlevelid'] = $fam['userlevelid'];
+          }
+        ?>
           <option value="<?= (int)$fam['id_famiglia'] ?>" <?= (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == $fam['id_famiglia']) ? 'selected' : '' ?>><?= htmlspecialchars($fam['nome_famiglia']) ?></option>
         <?php endwhile; $stmt->close(); ?>
       </select>
     </form>
     <?php endif; ?>
     <ul class="list-unstyled">
+      <?php if (has_permission($conn, 'page:index.php', 'view')): ?>
       <li class="mb-3">
         <a href="/Gestionale25/index.php" class="btn btn-outline-light w-100 text-start">
           🏠 Home
         </a>
       </li>
-      <?php if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == 1): ?>
+      <?php endif; ?>
+      <?php if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == 1 && has_permission($conn, 'page:etichette_lista.php', 'view')): ?>
       <li class="mb-3">
         <a href="/Gestionale25/etichette_lista.php" class="btn btn-outline-light w-100 text-start">
           🏷️ Etichette
         </a>
       </li>
       <?php endif; ?>
+      <?php if (has_permission($conn, 'page:credito_utente.php', 'view')): ?>
       <li class="mb-3">
         <a href="/Gestionale25/credito_utente.php" class="btn btn-outline-light w-100 text-start">
           💰 Saldo personale
         </a>
       </li>
+      <?php endif; ?>
+      <?php if (has_permission($conn, 'page:password.php', 'view')): ?>
       <li class="mb-3">
         <a href="/Gestionale25/password.php" class="btn btn-outline-light w-100 text-start">
           🔐 Siti e password
         </a>
       </li>
-      <?php if (isset($_SESSION['utente_id']) && $_SESSION['utente_id'] == 1): ?>
+      <?php endif; ?>
+      <?php if (has_permission($conn, 'page:storia.php', 'view')): ?>
       <li class="mb-3">
         <a href="/Gestionale25/storia.php" class="btn btn-outline-light w-100 text-start">
           📜 Storia
         </a>
       </li>
       <?php endif; ?>
+      <?php $showSecurity = has_permission($conn, 'page:change_password.php', 'view') || has_permission($conn, 'page:setup_passcode.php', 'view');
+      if ($showSecurity): ?>
       <li class="mb-3">
         <div class="dropdown w-100">
-          <button class="btn btn-outline-light w-100 text-start dropdown-toggle"
-                  data-bs-toggle="dropdown" aria-expanded="false">
+          <button class="btn btn-outline-light w-100 text-start dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
             🔐 Sicurezza
           </button>
           <ul class="dropdown-menu dropdown-menu-dark w-100">
+            <?php if (has_permission($conn, 'page:change_password.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/change_password.php">🔑 Cambia Password</a></li>
+            <?php endif; ?>
+            <?php if (has_permission($conn, 'page:setup_passcode.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/setup_passcode.php">🔒 Imposta Passcode</a></li>
+            <?php endif; ?>
             <li><a class="dropdown-item text-white" href="/Gestionale">Torna al vecchio</a></li>
           </ul>
         </div>
       </li>
+      <?php endif; ?>
+      <?php
+        $tables = [
+          'bilancio_descrizione2id' => 'Descrizioni',
+          'bilancio_entrate' => 'Entrate',
+          'bilancio_gruppi_categorie' => 'Gruppi categorie',
+          'bilancio_gruppi_transazione' => 'Gruppi transazione',
+          'bilancio_uscite' => 'Uscite',
+          'codici_2fa' => 'Codici 2FA',
+          'dispositivi_riconosciuti' => 'Dispositivi riconosciuti',
+          'famiglie' => 'Famiglie',
+          'userlevels' => 'User Levels',
+          'utenti' => 'Utenti',
+          'utenti2famiglie' => 'Utenti-Famiglie',
+          'utenti2ip' => 'Utenti-IP'
+        ];
+        $tableLinks = [];
+        foreach ($tables as $tbl => $label) {
+            if (has_permission($conn, 'table:' . $tbl, 'view')) {
+                $tableLinks[$tbl] = $label;
+            }
+        }
+        if (!empty($tableLinks)):
+      ?>
       <li class="mb-3">
         <div class="dropdown w-100">
-          <button class="btn btn-outline-light w-100 text-start dropdown-toggle"
-                  data-bs-toggle="dropdown" aria-expanded="false">
+          <button class="btn btn-outline-light w-100 text-start dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
             🗃️ Tabelle
           </button>
           <ul class="dropdown-menu dropdown-menu-dark w-100">
             <li><h6 class="dropdown-header">Bilancio</h6></li>
+            <?php if (isset($tableLinks['bilancio_descrizione2id'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=bilancio_descrizione2id">Descrizioni</a></li>
+            <?php endif; ?>
+            <?php if (isset($tableLinks['bilancio_entrate'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=bilancio_entrate">Entrate</a></li>
+            <?php endif; ?>
+            <?php if (isset($tableLinks['bilancio_gruppi_categorie'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=bilancio_gruppi_categorie">Gruppi categorie</a></li>
+            <?php endif; ?>
+            <?php if (isset($tableLinks['bilancio_gruppi_transazione'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=bilancio_gruppi_transazione">Gruppi transazione</a></li>
+            <?php endif; ?>
+            <?php if (isset($tableLinks['bilancio_uscite'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=bilancio_uscite">Uscite</a></li>
+            <?php endif; ?>
             <li><hr class="dropdown-divider"></li>
             <li><h6 class="dropdown-header">Sicurezza</h6></li>
+            <?php if (isset($tableLinks['codici_2fa'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=codici_2fa">Codici 2FA</a></li>
+            <?php endif; ?>
+            <?php if (isset($tableLinks['dispositivi_riconosciuti'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=dispositivi_riconosciuti">Dispositivi riconosciuti</a></li>
+            <?php endif; ?>
             <li><hr class="dropdown-divider"></li>
             <li><h6 class="dropdown-header">Utenti</h6></li>
+            <?php if (isset($tableLinks['famiglie'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=famiglie">Famiglie</a></li>
+            <?php endif; ?>
+            <?php if (isset($tableLinks['userlevels'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=userlevels">User Levels</a></li>
+            <?php endif; ?>
+            <?php if (isset($tableLinks['utenti'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=utenti">Utenti</a></li>
+            <?php endif; ?>
+            <?php if (isset($tableLinks['utenti2famiglie'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=utenti2famiglie">Utenti-Famiglie</a></li>
+            <?php endif; ?>
+            <?php if (isset($tableLinks['utenti2ip'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/pages/table_manager.php?table=utenti2ip">Utenti-IP</a></li>
+            <?php endif; ?>
           </ul>
         </div>
       </li>
+      <?php endif; ?>
       <li>
         <a href="/Gestionale25/logout.php" class="btn btn-outline-danger w-100 text-start">
           ⎋ Logout
         </a>
       </li>
-      
+
     </ul>
   </div>
 </div>

--- a/includes/permissions.php
+++ b/includes/permissions.php
@@ -1,0 +1,32 @@
+<?php
+function has_permission(mysqli $conn, string $resource, string $action): bool {
+    if (!isset($_SESSION['userlevelid'])) {
+        return false;
+    }
+    $stmt = $conn->prepare(
+        'SELECT up.can_view, up.can_insert, up.can_update, up.can_delete '
+        . 'FROM userlevel_permissions up '
+        . 'JOIN resources r ON up.resource_id = r.id '
+        . 'WHERE up.userlevelid = ? AND r.name = ?'
+    );
+    $stmt->bind_param('is', $_SESSION['userlevelid'], $resource);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $row = $res->fetch_assoc();
+    $stmt->close();
+    if (!$row) {
+        return false;
+    }
+    $map = [
+        'view' => 'can_view',
+        'insert' => 'can_insert',
+        'update' => 'can_update',
+        'delete' => 'can_delete'
+    ];
+    $field = $map[$action] ?? null;
+    if (!$field) {
+        return false;
+    }
+    return (bool)$row[$field];
+}
+?>

--- a/includes/table_config.php
+++ b/includes/table_config.php
@@ -42,7 +42,7 @@ return [
     ],
     'utenti2famiglie' => [
         'primary_key' => 'id_u2f',
-        'columns' => ['id_u2f','id_utente','id_famiglia']
+        'columns' => ['id_u2f','id_utente','id_famiglia','userlevelid']
     ],
     'utenti2ip' => [
         'primary_key' => 'id_u2i',

--- a/index.php
+++ b/index.php
@@ -1,10 +1,11 @@
 <?php include 'includes/session_check.php'; ?>
 <?php
 include 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:index.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
 require_once 'includes/render_movimento.php';
 include 'includes/header.php';
 
-require_once 'includes/render_movimento.php';
 
 if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == 1): ?>
 

--- a/js/table_crud.js
+++ b/js/table_crud.js
@@ -1,8 +1,12 @@
-function initTableManager(table, columns, primaryKey, lookups, boolCols = []) {
+function initTableManager(table, columns, primaryKey, lookups, boolCols = [], perms = {}) {
     const tbody = document.querySelector('#data-table tbody');
     const searchInput = document.getElementById('search');
     const form = document.getElementById('record-form');
     const addBtn = document.getElementById('addBtn');
+    const canInsert = perms.canInsert ?? false;
+    const canUpdate = perms.canUpdate ?? false;
+    const canDelete = perms.canDelete ?? false;
+    if (!canInsert) addBtn.classList.add('d-none');
     const cancelBtn = document.getElementById('cancelBtn');
     const idField = form.querySelector(`input[name="${primaryKey}"]`);
     let rows = [];
@@ -31,22 +35,27 @@ function initTableManager(table, columns, primaryKey, lookups, boolCols = []) {
                     tr.appendChild(td);
                 });
                 const actions = document.createElement('td');
-                const editBtn = document.createElement('button');
-                editBtn.className = 'btn btn-sm btn-link text-white me-2';
-                editBtn.innerHTML = '<i class="bi bi-pencil"></i>';
-                editBtn.addEventListener('click', () => showForm(r));
-                const delBtn = document.createElement('button');
-                delBtn.className = 'btn btn-sm btn-link text-danger';
-                delBtn.innerHTML = '<i class="bi bi-trash"></i>';
-                delBtn.addEventListener('click', () => deleteRow(r[primaryKey]));
-                actions.appendChild(editBtn);
-                actions.appendChild(delBtn);
+                if (canUpdate) {
+                    const editBtn = document.createElement('button');
+                    editBtn.className = 'btn btn-sm btn-link text-white me-2';
+                    editBtn.innerHTML = '<i class="bi bi-pencil"></i>';
+                    editBtn.addEventListener('click', () => showForm(r));
+                    actions.appendChild(editBtn);
+                }
+                if (canDelete) {
+                    const delBtn = document.createElement('button');
+                    delBtn.className = 'btn btn-sm btn-link text-danger';
+                    delBtn.innerHTML = '<i class="bi bi-trash"></i>';
+                    delBtn.addEventListener('click', () => deleteRow(r[primaryKey]));
+                    actions.appendChild(delBtn);
+                }
                 tr.appendChild(actions);
                 tbody.appendChild(tr);
             });
     }
 
     function showForm(data = null) {
+        if ((data && !canUpdate) || (!data && !canInsert)) return;
         form.reset();
         if (data) {
             form.dataset.mode = 'edit';
@@ -82,12 +91,14 @@ function initTableManager(table, columns, primaryKey, lookups, boolCols = []) {
         const formData = new FormData(form);
         formData.append('table', table);
         formData.append('action', form.dataset.mode === 'edit' ? 'update' : 'insert');
+        if ((form.dataset.mode === 'edit' && !canUpdate) || (form.dataset.mode === 'insert' && !canInsert)) return;
         fetch('../ajax/table_crud.php', { method: 'POST', body: formData })
             .then(r => r.json())
             .then(() => { form.classList.add('d-none'); load(); });
     });
 
     function deleteRow(id) {
+        if (!canDelete) return;
         if (!confirm('Eliminare il record?')) return;
         const formData = new FormData();
         formData.append('action', 'delete');

--- a/pages/table_manager.php
+++ b/pages/table_manager.php
@@ -5,6 +5,11 @@ $config = include __DIR__ . '/../includes/table_config.php';
 $foreignMap = include __DIR__ . '/../includes/foreign_keys.php';
 
 $table = $_GET['table'] ?? '';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'table:' . $table, 'view')) { http_response_code(403); exit('Accesso negato'); }
+$canInsert = has_permission($conn, 'table:' . $table, 'insert');
+$canUpdate = has_permission($conn, 'table:' . $table, 'update');
+$canDelete = has_permission($conn, 'table:' . $table, 'delete');
 if (!isset($config[$table])) {
     die('Tabella non valida');
 }
@@ -52,7 +57,7 @@ include '../includes/header.php';
 ?>
 <div class="d-flex mb-3 justify-content-between">
   <h4><?= htmlspecialchars($table) ?></h4>
-  <button id="addBtn" class="btn btn-outline-light btn-sm">Aggiungi nuovo</button>
+  <button id="addBtn" class="btn btn-outline-light btn-sm <?= $canInsert ? '' : 'd-none' ?>">Aggiungi nuovo</button>
 </div>
 <input type="text" id="search" class="form-control bg-dark text-white border-secondary mb-3" placeholder="Cerca...">
 <table class="table table-dark table-striped" id="data-table">
@@ -100,6 +105,6 @@ include '../includes/header.php';
 
 <script src="../js/table_crud.js"></script>
 <script>
-initTableManager('<?= $table ?>', <?= json_encode($displayColumns) ?>, '<?= $primaryKey ?>', <?= json_encode($lookups) ?>, <?= json_encode($booleanColumns) ?>);
+initTableManager('<?= $table ?>', <?= json_encode($displayColumns) ?>, '<?= $primaryKey ?>', <?= json_encode($lookups) ?>, <?= json_encode($booleanColumns) ?>, {canInsert: <?= $canInsert ? 'true' : 'false' ?>, canUpdate: <?= $canUpdate ? 'true' : 'false' ?>, canDelete: <?= $canDelete ? 'true' : 'false' ?>});
 </script>
 <?php include '../includes/footer.php'; ?>

--- a/sql/add_userlevelid_to_utenti2famiglie.sql
+++ b/sql/add_userlevelid_to_utenti2famiglie.sql
@@ -1,2 +1,7 @@
 ALTER TABLE `utenti2famiglie`
   ADD COLUMN `userlevelid` int(11) NOT NULL DEFAULT '0' AFTER `id_famiglia`;
+
+ALTER TABLE `utenti2famiglie`
+  ADD CONSTRAINT `fk_u2f_userlevels` FOREIGN KEY (`userlevelid`) REFERENCES `userlevels` (`userlevelid`),
+  ADD UNIQUE KEY `uq_u2f` (`id_utente`,`id_famiglia`),
+  ADD INDEX `idx_userlevelid` (`userlevelid`);

--- a/sql/resources.sql
+++ b/sql/resources.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `resources` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(100) NOT NULL,
+  `type` enum('table','file') NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/sql/userlevel_permissions.sql
+++ b/sql/userlevel_permissions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `userlevel_permissions` (
+  `userlevelid` int(11) NOT NULL,
+  `resource_id` int(11) NOT NULL,
+  `can_view` tinyint(1) NOT NULL DEFAULT 0,
+  `can_insert` tinyint(1) NOT NULL DEFAULT 0,
+  `can_update` tinyint(1) NOT NULL DEFAULT 0,
+  `can_delete` tinyint(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`userlevelid`,`resource_id`),
+  CONSTRAINT `fk_ulperm_userlevels` FOREIGN KEY (`userlevelid`) REFERENCES `userlevels` (`userlevelid`) ON DELETE CASCADE,
+  CONSTRAINT `fk_ulperm_resources` FOREIGN KEY (`resource_id`) REFERENCES `resources` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- Define `resources` table to catalog application resources with type info
- Reference resources by ID in `userlevel_permissions` and enforce FK integrity
- Join `resources` in `has_permission` to resolve resource names for permission checks

## Testing
- `php -l includes/permissions.php`


------
https://chatgpt.com/codex/tasks/task_e_6894c09668008331be829628f93da0db