### PR TITLE
Harden foreign key lookup identifiers in table_manager

### DIFF
--- a/pages/table_manager.php
+++ b/pages/table_manager.php
@@ -38,7 +38,18 @@ $lookups = [];
 foreach ($displayColumns as $col) {
     if (isset($foreignMap[$col])) {
         $fk = $foreignMap[$col];
-        $sql = "SELECT {$fk['key']} AS id, {$fk['label']} AS label FROM {$fk['table']}";
+        $table = $fk['table'];
+        $key   = $fk['key'];
+        $label = $fk['label'];
+        if (!preg_match('/^[A-Za-z0-9_]+$/', $table) ||
+            !preg_match('/^[A-Za-z0-9_]+$/', $key) ||
+            !preg_match("/^[A-Za-z0-9_(),\\s']+$/", $label)) {
+            continue;
+        }
+        $table = $conn->real_escape_string($table);
+        $key   = $conn->real_escape_string($key);
+        $label = $conn->real_escape_string($label);
+        $sql = "SELECT `{$key}` AS id, {$label} AS label FROM `{$table}`";
         $res = $conn->query($sql);
         if ($res) {
             while ($row = $res->fetch_assoc()) {


### PR DESCRIPTION
## Summary
- quote and validate foreign key table and column names before building lookup queries
- escape dynamic identifiers and skip invalid mappings to prevent injection via configuration

## Testing
- `php -l pages/table_manager.php`
- `php -r 'chdir("pages"); session_start(); $_SESSION["utente_id"]=1; $_GET["table"]="utenti"; include "table_manager.php";'` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6895927a2c308331840cef746b8496aa