### PR TITLE
Add admin-only user impersonation

### DIFF
--- a/impersonate.php
+++ b/impersonate.php
@@ -1,0 +1,52 @@
+<?php
+include 'includes/session_check.php';
+require_once 'includes/db.php';
+
+$loggedId = $_SESSION['utente_id'] ?? 0;
+
+// verify admin
+$stmt = $conn->prepare('SELECT admin FROM utenti WHERE id = ? LIMIT 1');
+$stmt->bind_param('i', $loggedId);
+$stmt->execute();
+$adminRow = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if (($adminRow['admin'] ?? 0) != 1) {
+    http_response_code(403);
+    exit('Accesso negato');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $targetId = (int)($_POST['id_utente'] ?? 0);
+    $stmt = $conn->prepare('SELECT id, nome, id_famiglia_gestione FROM utenti WHERE id = ? LIMIT 1');
+    $stmt->bind_param('i', $targetId);
+    $stmt->execute();
+    if ($user = $stmt->get_result()->fetch_assoc()) {
+        $_SESSION['impersonator_id'] = $loggedId;
+        $_SESSION['utente_id'] = $user['id'];
+        $_SESSION['utente_nome'] = $user['nome'];
+        $_SESSION['id_famiglia_gestione'] = $user['id_famiglia_gestione'] ?? 0;
+    }
+    $stmt->close();
+    header('Location: index.php');
+    exit;
+}
+
+$stmt = $conn->query('SELECT id, nome, cognome FROM utenti WHERE attivo = 1 ORDER BY nome');
+$users = $stmt ? $stmt->fetch_all(MYSQLI_ASSOC) : [];
+?>
+<?php include 'includes/header.php'; ?>
+<div class="text-white">
+  <h4 class="mb-3">Impersona utente</h4>
+  <form method="post" class="mb-3">
+    <select name="id_utente" class="form-select w-auto d-inline">
+      <?php foreach ($users as $u): ?>
+        <option value="<?= (int)$u['id'] ?>" <?= $u['id']==$loggedId ? 'disabled' : '' ?>><?= htmlspecialchars(trim(($u['nome'] ?? '') . ' ' . ($u['cognome'] ?? ''))) ?></option>
+      <?php endforeach; ?>
+    </select>
+    <button type="submit" class="btn btn-primary ms-2">Impersona</button>
+  </form>
+  <?php if (isset($_SESSION['impersonator_id'])): ?>
+  <a href="stop_impersonate.php" class="btn btn-secondary">Torna al tuo account</a>
+  <?php endif; ?>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -44,6 +44,17 @@
       </select>
     </form>
     <?php endif; ?>
+    <?php
+      $isAdmin = false;
+      if (isset($_SESSION['utente_id'])) {
+          $stmtAdm = $conn->prepare('SELECT admin FROM utenti WHERE id = ?');
+          $stmtAdm->bind_param('i', $_SESSION['utente_id']);
+          $stmtAdm->execute();
+          $isAdmin = ($stmtAdm->get_result()->fetch_assoc()['admin'] ?? 0) == 1;
+          $stmtAdm->close();
+      }
+      $canImpersonate = $isAdmin && !isset($_SESSION['impersonator_id']);
+    ?>
     <ul class="list-unstyled">
       <?php if (has_permission($conn, 'page:index.php', 'view')): ?>
       <li class="mb-3">
@@ -171,6 +182,20 @@
             <?php endif; ?>
           </ul>
         </div>
+      </li>
+      <?php endif; ?>
+      <?php if ($canImpersonate): ?>
+      <li class="mb-3">
+        <a href="/Gestionale25/impersonate.php" class="btn btn-outline-light w-100 text-start">
+          👤 Impersona utente
+        </a>
+      </li>
+      <?php endif; ?>
+      <?php if (isset($_SESSION['impersonator_id'])): ?>
+      <li class="mb-3">
+        <a href="/Gestionale25/stop_impersonate.php" class="btn btn-outline-warning w-100 text-start">
+          ⏪ Torna al tuo account
+        </a>
       </li>
       <?php endif; ?>
       <li>

--- a/stop_impersonate.php
+++ b/stop_impersonate.php
@@ -1,0 +1,22 @@
+<?php
+include 'includes/session_check.php';
+require_once 'includes/db.php';
+
+if (isset($_SESSION['impersonator_id'])) {
+    $originalId = (int)$_SESSION['impersonator_id'];
+    unset($_SESSION['impersonator_id']);
+
+    $stmt = $conn->prepare('SELECT id, nome, id_famiglia_gestione FROM utenti WHERE id = ? LIMIT 1');
+    $stmt->bind_param('i', $originalId);
+    $stmt->execute();
+    if ($user = $stmt->get_result()->fetch_assoc()) {
+        $_SESSION['utente_id'] = $user['id'];
+        $_SESSION['utente_nome'] = $user['nome'];
+        $_SESSION['id_famiglia_gestione'] = $user['id_famiglia_gestione'] ?? 0;
+    }
+    $stmt->close();
+}
+
+header('Location: index.php');
+exit;
+?>


### PR DESCRIPTION
## Summary
- Allow administrators to impersonate another user for testing
- Provide a route to end impersonation and return to original account
- Expose impersonation controls in the navigation menu for admins

## Testing
- `php -l impersonate.php`
- `php -l stop_impersonate.php`
- `php -l includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_6895b3ee16608331b27277805f893da1