### PR TITLE
Set user level in session during login

### DIFF
--- a/login_passcode.php
+++ b/login_passcode.php
@@ -37,6 +37,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['utente_id'] = $user['id'];
             $_SESSION['utente_nome'] = $user['nome'];
             $_SESSION['id_famiglia_gestione'] = $user['id_famiglia_gestione'] ?? 0;
+
+            $lvlStmt = $conn->prepare('SELECT userlevelid FROM utenti2famiglie WHERE id_utente = ? AND id_famiglia = ? LIMIT 1');
+            $lvlStmt->bind_param('ii', $_SESSION['utente_id'], $_SESSION['id_famiglia_gestione']);
+            $lvlStmt->execute();
+            $lvlRes = $lvlStmt->get_result();
+            $_SESSION['userlevelid'] = ($lvlRes->num_rows === 1) ? intval($lvlRes->fetch_assoc()['userlevelid']) : 0;
+
             $newExp = date('Y-m-d H:i:s', time() + 60*60*24*30);
             $upd = $conn->prepare('UPDATE dispositivi_riconosciuti SET scadenza = ? WHERE token_dispositivo = ?');
             $upd->bind_param('ss', $newExp, $token);

--- a/verifica_2fa.php
+++ b/verifica_2fa.php
@@ -28,6 +28,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['utente_id'] = $_SESSION['2fa_user_id'];
         $_SESSION['utente_nome'] = $_SESSION['2fa_user_nome'];
         $_SESSION['id_famiglia_gestione'] = $_SESSION['2fa_id_famiglia_gestione'] ?? 0;
+
+        $lvlStmt = $conn->prepare('SELECT userlevelid FROM utenti2famiglie WHERE id_utente = ? AND id_famiglia = ? LIMIT 1');
+        $lvlStmt->bind_param('ii', $_SESSION['utente_id'], $_SESSION['id_famiglia_gestione']);
+        $lvlStmt->execute();
+        $lvlRes = $lvlStmt->get_result();
+        $_SESSION['userlevelid'] = ($lvlRes->num_rows === 1) ? intval($lvlRes->fetch_assoc()['userlevelid']) : 0;
+
         unset($_SESSION['2fa_user_id'], $_SESSION['2fa_user_nome'], $_SESSION['2fa_attempts'], $_SESSION['2fa_id_famiglia_gestione']);
         header('Location: setup_passcode.php');
         exit;


### PR DESCRIPTION
## Summary
- Load and store userlevelid during 2FA verification
- Load and store userlevelid when logging in via passcode

## Testing
- `php -l verifica_2fa.php`
- `php -l login_passcode.php`


------
https://chatgpt.com/codex/tasks/task_e_6895b7b93b54833195c90ee5d5a1c8bc