### PR TITLE
Clean up tags when deleting entries

### DIFF
--- a/ajax/table_crud.php
+++ b/ajax/table_crud.php
@@ -3,6 +3,7 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/../includes/session_check.php';
 require_once __DIR__ . '/../includes/db.php';
 require_once __DIR__ . '/../includes/permissions.php';
+require_once __DIR__ . '/../includes/etichette_utils.php';
 $config = include __DIR__ . '/../includes/table_config.php';
 
 $table = $_GET['table'] ?? $_POST['table'] ?? '';
@@ -89,8 +90,12 @@ switch ($action) {
         $sql = "DELETE FROM `$table` WHERE `$primaryKey`=?";
         $stmt = $conn->prepare($sql);
         $stmt->bind_param('i', $id);
-        $stmt->execute();
-        echo json_encode(['success' => true]);
+        $success = $stmt->execute();
+        if ($success && in_array($table, ['bilancio_entrate','bilancio_uscite'], true)) {
+            $tabellaMap = ['bilancio_entrate' => 'entrate', 'bilancio_uscite' => 'uscite'];
+            eliminaEtichetteCollegate($tabellaMap[$table], (int)$id);
+        }
+        echo json_encode(['success' => $success]);
         break;
     default:
         http_response_code(400);


### PR DESCRIPTION
## Summary
- remove associated labels when deleting records from bilancio_entrate or bilancio_uscite
- share etichette_utils within delete endpoints and table manager

## Testing
- `php -l ajax/delete_movimento.php`
- `php -l ajax/table_crud.php`


------
https://chatgpt.com/codex/tasks/task_e_6895b56d1494833193f8284a253abd60