### PR TITLE
Aggiungi pagina permessi userlevel al menu

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -91,6 +91,13 @@
         </a>
       </li>
       <?php endif; ?>
+      <?php if (has_permission($conn, 'page:userlevel_permissions.php', 'view')): ?>
+      <li class="mb-3">
+        <a href="/Gestionale25/userlevel_permissions.php" class="btn btn-outline-light w-100 text-start">
+          🛡️ Permessi Userlevel
+        </a>
+      </li>
+      <?php endif; ?>
       <?php $showSecurity = has_permission($conn, 'page:change_password.php', 'view') || has_permission($conn, 'page:setup_passcode.php', 'view');
       if ($showSecurity): ?>
       <li class="mb-3">


### PR DESCRIPTION
## Summary
- Mostra link a `userlevel_permissions.php` nel menù laterale quando l'utente ha i relativi permessi

## Testing
- `php -l includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_6895bcfe45f88331b2730d4ffc9f3136