### PR TITLE
Add user management page with family assignments

### DIFF
--- a/ajax/gestione_utenti.php
+++ b/ajax/gestione_utenti.php
@@ -1,0 +1,72 @@
+<?php
+header('Content-Type: application/json');
+require_once __DIR__ . '/../includes/session_check.php';
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/permissions.php';
+$action = $_GET['action'] ?? $_POST['action'] ?? '';
+switch ($action) {
+    case 'list':
+        if (!has_permission($conn, 'table:utenti', 'view')) { http_response_code(403); echo json_encode(['error'=>'Permesso negato']); exit; }
+        $username = $_GET['username'] ?? '';
+        $userlevelid = $_GET['userlevelid'] ?? '';
+        $id_famiglia = $_GET['id_famiglia'] ?? '';
+        $sql = "SELECT u.id, u.username, u.nome, u.cognome, u.soprannome, u.email, u.id_famiglia_attuale, u.id_famiglia_gestione, u.attivo, u.userlevelid,
+                       ul.userlevelname, f.nome_famiglia AS famiglia_attuale,
+                       GROUP_CONCAT(CONCAT(f2.nome_famiglia, ' (', ul2.userlevelname, ')') ORDER BY f2.nome_famiglia SEPARATOR ', ') AS famiglie
+                FROM utenti u
+                LEFT JOIN userlevels ul ON u.userlevelid = ul.userlevelid
+                LEFT JOIN famiglie f ON u.id_famiglia_attuale = f.id_famiglia
+                LEFT JOIN utenti2famiglie u2f ON u.id = u2f.id_utente
+                LEFT JOIN famiglie f2 ON u2f.id_famiglia = f2.id_famiglia
+                LEFT JOIN userlevels ul2 ON u2f.userlevelid = ul2.userlevelid
+                WHERE 1=1";
+        $params = [];
+        $types = '';
+        if ($username !== '') { $sql .= " AND u.username LIKE ?"; $params[] = "%$username%"; $types .= 's'; }
+        if ($userlevelid !== '') { $sql .= " AND u.userlevelid = ?"; $params[] = $userlevelid; $types .= 'i'; }
+        if ($id_famiglia !== '') {
+            $sql .= " AND (u.id_famiglia_attuale = ? OR EXISTS (SELECT 1 FROM utenti2famiglie u2 WHERE u2.id_utente = u.id AND u2.id_famiglia = ?))";
+            $params[] = $id_famiglia; $params[] = $id_famiglia; $types .= 'ii';
+        }
+        $sql .= " GROUP BY u.id";
+        $stmt = $conn->prepare($sql);
+        if ($params) { $stmt->bind_param($types, ...$params); }
+        $stmt->execute();
+        $res = $stmt->get_result();
+        echo json_encode($res->fetch_all(MYSQLI_ASSOC));
+        break;
+    case 'families':
+        if (!has_permission($conn, 'table:utenti2famiglie', 'view')) { http_response_code(403); echo json_encode(['error'=>'Permesso negato']); exit; }
+        $id = intval($_GET['id'] ?? 0);
+        $stmt = $conn->prepare("SELECT f.id_famiglia, f.nome_famiglia, u2f.userlevelid FROM famiglie f LEFT JOIN utenti2famiglie u2f ON f.id_famiglia = u2f.id_famiglia AND u2f.id_utente = ? ORDER BY f.nome_famiglia");
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        echo json_encode($res->fetch_all(MYSQLI_ASSOC));
+        break;
+    case 'save_families':
+        if (!has_permission($conn, 'table:utenti2famiglie', 'update')) { http_response_code(403); echo json_encode(['error'=>'Permesso negato']); exit; }
+        $id = intval($_POST['id'] ?? 0);
+        $famiglie = $_POST['famiglie'] ?? [];
+        $userlevels = $_POST['userlevels'] ?? [];
+        if (!is_array($famiglie) || !is_array($userlevels) || count($famiglie) !== count($userlevels)) { http_response_code(400); echo json_encode(['error'=>'Dati invalidi']); exit; }
+        $conn->begin_transaction();
+        $del = $conn->prepare("DELETE FROM utenti2famiglie WHERE id_utente=?");
+        $del->bind_param('i', $id);
+        $del->execute();
+        if (!empty($famiglie)) {
+            $ins = $conn->prepare("INSERT INTO utenti2famiglie (id_utente, id_famiglia, userlevelid) VALUES (?,?,?)");
+            for ($i=0; $i<count($famiglie); $i++) {
+                $fid = intval($famiglie[$i]);
+                $ul = intval($userlevels[$i]);
+                $ins->bind_param('iii', $id, $fid, $ul);
+                $ins->execute();
+            }
+        }
+        $conn->commit();
+        echo json_encode(['success'=>true]);
+        break;
+    default:
+        http_response_code(400);
+        echo json_encode(['error'=>'Azione non valida']);
+}

--- a/gestione_utenti.php
+++ b/gestione_utenti.php
@@ -1,0 +1,163 @@
+<?php
+include 'includes/session_check.php';
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:gestione_utenti.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+
+$config = include __DIR__ . '/includes/table_config.php';
+$foreignMap = include __DIR__ . '/includes/foreign_keys.php';
+$table = 'utenti';
+$columns = $config[$table]['columns'];
+$primaryKey = $config[$table]['primary_key'];
+$displayColumns = array_values(array_filter($columns, function($c) use ($primaryKey) {
+    return $c !== $primaryKey;
+}));
+$booleanColumns = ['attivo'];
+$lookups = [];
+foreach ($displayColumns as $col) {
+    if (isset($foreignMap[$col])) {
+        $fk = $foreignMap[$col];
+        $tablefk = $fk['table'];
+        $key = $fk['key'];
+        $label = $fk['label'];
+        if (!preg_match('/^[A-Za-z0-9_]+$/', $tablefk) ||
+            !preg_match('/^[A-Za-z0-9_]+$/', $key) ||
+            !preg_match("/^[A-Za-z0-9_(),\\s']+$/", $label)) {
+            continue;
+        }
+        $sql = "SELECT `$key` AS id, $label AS label FROM `$tablefk`";
+        if ($res = $conn->query($sql)) {
+            while ($row = $res->fetch_assoc()) {
+                $lookups[$col][$row['id']] = trim((string)$row['label']);
+            }
+        }
+    }
+}
+$canInsert = has_permission($conn, 'table:utenti', 'insert');
+$canUpdate = has_permission($conn, 'table:utenti', 'update');
+$canDelete = has_permission($conn, 'table:utenti', 'delete');
+$canManageFamilies = has_permission($conn, 'table:utenti2famiglie', 'update');
+include 'includes/header.php';
+?>
+<div class="d-flex mb-3 justify-content-between">
+  <h4>Gestione Utenti</h4>
+  <button id="addBtn" class="btn btn-outline-light btn-sm">Aggiungi nuovo</button>
+</div>
+<div class="row mb-3">
+  <div class="col">
+    <input type="text" id="search" class="form-control bg-dark text-white border-secondary" placeholder="Cerca utente">
+  </div>
+  <div class="col">
+    <select id="userlevelFilter" class="form-select bg-dark text-white border-secondary">
+      <option value="">Tutti i livelli</option>
+      <?php if(isset($lookups['userlevelid'])): foreach($lookups['userlevelid'] as $id => $label): ?>
+      <option value="<?= (int)$id ?>"><?= htmlspecialchars($label) ?></option>
+      <?php endforeach; endif; ?>
+    </select>
+  </div>
+  <div class="col">
+    <select id="familyFilter" class="form-select bg-dark text-white border-secondary">
+      <option value="">Tutte le famiglie</option>
+      <?php
+      $resFam = $conn->query("SELECT id_famiglia, nome_famiglia FROM famiglie ORDER BY nome_famiglia");
+      while($fam = $resFam->fetch_assoc()): ?>
+      <option value="<?= (int)$fam['id_famiglia'] ?>"><?= htmlspecialchars($fam['nome_famiglia']) ?></option>
+      <?php endwhile; ?>
+    </select>
+  </div>
+</div>
+<table class="table table-dark table-striped" id="data-table">
+  <thead>
+    <tr>
+      <th>Username</th>
+      <th>Userlevel</th>
+      <th>Famiglia attuale</th>
+      <th>Famiglie abilitate</th>
+      <th>Azioni</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<div class="modal fade" id="recordModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable">
+    <div class="modal-content bg-dark text-white">
+      <form id="record-form">
+        <div class="modal-header">
+          <h5 class="modal-title">Record</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Chiudi"></button>
+        </div>
+        <div class="modal-body">
+          <input type="hidden" name="<?= htmlspecialchars($primaryKey) ?>">
+          <?php foreach ($displayColumns as $col): ?>
+            <div class="mb-3">
+              <label class="form-label"><?= htmlspecialchars(str_replace('_',' ', $col)) ?></label>
+              <?php if (isset($lookups[$col])): ?>
+                <select name="<?= htmlspecialchars($col) ?>" class="form-select bg-dark text-white border-secondary">
+                  <?php foreach ($lookups[$col] as $id => $label): ?>
+                    <option value="<?= htmlspecialchars($id) ?>"><?= htmlspecialchars($label) ?></option>
+                  <?php endforeach; ?>
+                </select>
+              <?php elseif (in_array($col,$booleanColumns)): ?>
+                <div>
+                  <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="<?= htmlspecialchars($col) ?>" id="<?= htmlspecialchars($col) ?>_si" value="1">
+                    <label class="form-check-label" for="<?= htmlspecialchars($col) ?>_si">Si</label>
+                  </div>
+                  <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="<?= htmlspecialchars($col) ?>" id="<?= htmlspecialchars($col) ?>_no" value="0">
+                    <label class="form-check-label" for="<?= htmlspecialchars($col) ?>_no">No</label>
+                  </div>
+                </div>
+              <?php else: ?>
+                <input type="text" name="<?= htmlspecialchars($col) ?>" class="form-control bg-dark text-white border-secondary">
+              <?php endif; ?>
+            </div>
+          <?php endforeach; ?>
+        </div>
+        <div class="modal-footer">
+          <button type="button" id="cancelBtn" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+          <button type="submit" class="btn btn-primary">Salva</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<div class="modal fade" id="deleteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content bg-dark text-white">
+      <div class="modal-header">
+        <h5 class="modal-title">Conferma eliminazione</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Chiudi"></button>
+      </div>
+      <div class="modal-body">
+        Sei sicuro di voler eliminare questo utente?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+        <button type="button" id="confirmDeleteBtn" class="btn btn-danger">Elimina</button>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal fade" id="familiesModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content bg-dark text-white">
+      <form id="families-form">
+        <div class="modal-header">
+          <h5 class="modal-title">Assegna famiglie</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Chiudi"></button>
+        </div>
+        <div class="modal-body" id="familiesList"></div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+          <button type="submit" class="btn btn-primary">Salva</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<script src="js/gestione_utenti.js"></script>
+<script>
+initUserManager('<?= $table ?>', <?= json_encode($displayColumns) ?>, '<?= $primaryKey ?>', <?= json_encode($lookups) ?>, <?= json_encode($booleanColumns) ?>, {canInsert: <?= $canInsert ? 'true':'false' ?>, canUpdate: <?= $canUpdate ? 'true':'false' ?>, canDelete: <?= $canDelete ? 'true':'false' ?>, canManageFamilies: <?= $canManageFamilies ? 'true':'false' ?>});
+</script>
+<?php include 'includes/footer.php'; ?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -98,6 +98,13 @@
         </a>
       </li>
       <?php endif; ?>
+      <?php if (has_permission($conn, 'page:gestione_utenti.php', 'view')): ?>
+      <li class="mb-3">
+        <a href="/Gestionale25/gestione_utenti.php" class="btn btn-outline-light w-100 text-start">
+          👥 Gestione Utenti
+        </a>
+      </li>
+      <?php endif; ?>
       <?php $showSecurity = has_permission($conn, 'page:change_password.php', 'view') || has_permission($conn, 'page:setup_passcode.php', 'view');
       if ($showSecurity): ?>
       <li class="mb-3">

--- a/includes/table_config.php
+++ b/includes/table_config.php
@@ -38,7 +38,7 @@ return [
     ],
     'utenti' => [
         'primary_key' => 'id',
-        'columns' => ['id','username','nome','cognome','soprannome','email','id_famiglia_attuale','id_famiglia_gestione','attivo']
+        'columns' => ['id','username','nome','cognome','soprannome','email','id_famiglia_attuale','id_famiglia_gestione','attivo','userlevelid']
     ],
     'utenti2famiglie' => [
         'primary_key' => 'id_u2f',

--- a/js/gestione_utenti.js
+++ b/js/gestione_utenti.js
@@ -1,0 +1,173 @@
+function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [], perms = {}) {
+    const tbody = document.querySelector('#data-table tbody');
+    const searchInput = document.getElementById('search');
+    const userlevelFilter = document.getElementById('userlevelFilter');
+    const familyFilter = document.getElementById('familyFilter');
+    const form = document.getElementById('record-form');
+    const addBtn = document.getElementById('addBtn');
+    const modalTitle = document.querySelector('#recordModal .modal-title');
+    const idField = form.querySelector(`input[name="${primaryKey}"]`);
+    const deleteModalEl = document.getElementById('deleteModal');
+    const confirmDeleteBtn = document.getElementById('confirmDeleteBtn');
+    const familiesModalEl = document.getElementById('familiesModal');
+    const familiesList = document.getElementById('familiesList');
+    const familiesForm = document.getElementById('families-form');
+    const canInsert = perms.canInsert ?? false;
+    const canUpdate = perms.canUpdate ?? false;
+    const canDelete = perms.canDelete ?? false;
+    const canManageFamilies = perms.canManageFamilies ?? false;
+    if (!canInsert) addBtn.classList.add('d-none');
+    let rows = [];
+    let recordModal, deleteModal, familiesModal;
+    let deleteId = null;
+    let currentUserId = null;
+    function load() {
+        const params = new URLSearchParams();
+        params.append('action', 'list');
+        params.append('username', searchInput.value);
+        params.append('userlevelid', userlevelFilter.value);
+        params.append('id_famiglia', familyFilter.value);
+        fetch('ajax/gestione_utenti.php?' + params.toString())
+            .then(r => r.json())
+            .then(data => { rows = data; render(); });
+    }
+    function render() {
+        tbody.innerHTML = '';
+        rows.forEach(r => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${r.username ?? ''}</td>
+                <td>${r.userlevelname ?? ''}</td>
+                <td>${r.famiglia_attuale ?? ''}</td>
+                <td>${r.famiglie ?? ''}</td>
+            `;
+            const actions = document.createElement('td');
+            if (canManageFamilies) {
+                const famBtn = document.createElement('button');
+                famBtn.className = 'btn btn-sm btn-link text-white me-2';
+                famBtn.innerHTML = '<i class="bi bi-people"></i>';
+                famBtn.addEventListener('click', () => manageFamilies(r[primaryKey]));
+                actions.appendChild(famBtn);
+            }
+            if (canUpdate) {
+                const editBtn = document.createElement('button');
+                editBtn.className = 'btn btn-sm btn-link text-white me-2';
+                editBtn.innerHTML = '<i class="bi bi-pencil"></i>';
+                editBtn.addEventListener('click', () => showForm(r));
+                actions.appendChild(editBtn);
+            }
+            if (canDelete) {
+                const delBtn = document.createElement('button');
+                delBtn.className = 'btn btn-sm btn-link text-danger';
+                delBtn.innerHTML = '<i class="bi bi-trash"></i>';
+                delBtn.addEventListener('click', () => confirmDelete(r[primaryKey]));
+                actions.appendChild(delBtn);
+            }
+            tr.appendChild(actions);
+            tbody.appendChild(tr);
+        });
+    }
+    function showForm(data = null) {
+        if ((data && !canUpdate) || (!data && !canInsert)) return;
+        form.reset();
+        if (!recordModal) recordModal = new bootstrap.Modal(document.getElementById('recordModal'));
+        if (data) {
+            form.dataset.mode = 'edit';
+            modalTitle.textContent = 'Modifica utente';
+            idField.value = data[primaryKey];
+            formColumns.forEach(c => {
+                if (boolCols.includes(c)) {
+                    const radios = form.querySelectorAll(`input[name="${c}"]`);
+                    radios.forEach(r => r.checked = String(data[c]) === r.value);
+                } else {
+                    const field = form.querySelector(`[name="${c}"]`);
+                    if (field) field.value = data[c] ?? '';
+                }
+            });
+        } else {
+            form.dataset.mode = 'insert';
+            modalTitle.textContent = 'Nuovo utente';
+            idField.value = '';
+            formColumns.forEach(c => {
+                if (boolCols.includes(c)) {
+                    const radios = form.querySelectorAll(`input[name="${c}"]`);
+                    radios.forEach(r => r.checked = false);
+                }
+            });
+        }
+        recordModal.show();
+    }
+    addBtn.addEventListener('click', () => showForm());
+    document.getElementById('cancelBtn').addEventListener('click', () => recordModal.hide());
+    form.addEventListener('submit', e => {
+        e.preventDefault();
+        const fd = new FormData(form);
+        fd.append('table', table);
+        fd.append('action', form.dataset.mode === 'edit' ? 'update' : 'insert');
+        fetch('ajax/table_crud.php', { method: 'POST', body: fd })
+            .then(r => r.json())
+            .then(() => { recordModal.hide(); load(); });
+    });
+    function confirmDelete(id) {
+        deleteId = id;
+        if (!deleteModal) deleteModal = new bootstrap.Modal(deleteModalEl);
+        deleteModal.show();
+    }
+    confirmDeleteBtn.addEventListener('click', () => {
+        if (!canDelete || deleteId === null) return;
+        const fd = new FormData();
+        fd.append('action', 'delete');
+        fd.append('table', table);
+        fd.append(primaryKey, deleteId);
+        fetch('ajax/table_crud.php', { method: 'POST', body: fd })
+            .then(r => r.json())
+            .then(() => { deleteModal.hide(); load(); });
+    });
+    function manageFamilies(id) {
+        currentUserId = id;
+        if (!familiesModal) familiesModal = new bootstrap.Modal(familiesModalEl);
+        familiesList.innerHTML = '';
+        fetch(`ajax/gestione_utenti.php?action=families&id=${id}`)
+            .then(r => r.json())
+            .then(data => {
+                data.forEach(f => {
+                    const div = document.createElement('div');
+                    div.className = 'mb-2';
+                    const chkId = `fam_${f.id_famiglia}`;
+                    div.innerHTML = `
+                        <div class="form-check">
+                          <input class="form-check-input" type="checkbox" id="${chkId}" value="${f.id_famiglia}" ${f.userlevelid ? 'checked' : ''}>
+                          <label class="form-check-label" for="${chkId}">${f.nome_famiglia}</label>
+                        </div>
+                        <select class="form-select form-select-sm bg-dark text-white border-secondary mt-1" data-family="${f.id_famiglia}">
+                          ${Object.entries(lookups.userlevelid || {}).map(([ulid, ulname]) => `<option value="${ulid}">${ulname}</option>`).join('')}
+                        </select>
+                    `;
+                    familiesList.appendChild(div);
+                    const sel = div.querySelector('select');
+                    if (f.userlevelid) sel.value = f.userlevelid;
+                });
+                familiesModal.show();
+            });
+    }
+    familiesForm.addEventListener('submit', e => {
+        e.preventDefault();
+        const fd = new FormData();
+        fd.append('action', 'save_families');
+        fd.append('id', currentUserId);
+        familiesList.querySelectorAll('input[type="checkbox"]').forEach(chk => {
+            if (chk.checked) {
+                const sel = familiesList.querySelector(`select[data-family="${chk.value}"]`);
+                fd.append('famiglie[]', chk.value);
+                fd.append('userlevels[]', sel.value);
+            }
+        });
+        fetch('ajax/gestione_utenti.php', { method: 'POST', body: fd })
+            .then(r => r.json())
+            .then(() => { familiesModal.hide(); load(); });
+    });
+    searchInput.addEventListener('input', load);
+    userlevelFilter.addEventListener('change', load);
+    familyFilter.addEventListener('change', load);
+    load();
+}


### PR DESCRIPTION
## Summary
- add Gestione Utenti page with filters and CRUD operations
- allow assigning user roles to families via new AJAX endpoints
- expose page from main menu and extend utenti table config

## Testing
- `php -l gestione_utenti.php`
- `php -l ajax/gestione_utenti.php`


------
https://chatgpt.com/codex/tasks/task_e_6895bf1a6c8c8331b15a15a0a6eae03d