### PR TITLE
Auto-save permissions on checkbox toggle

### DIFF
--- a/js/userlevel_permissions.js
+++ b/js/userlevel_permissions.js
@@ -21,4 +21,13 @@ document.addEventListener('DOMContentLoaded', () => {
   userlevelFilter.addEventListener('change', filter);
   resourceFilter.addEventListener('change', filter);
   filter();
+
+  // Auto-submit permission form when a checkbox is toggled
+  document
+    .querySelectorAll('.permission-card input[type="checkbox"]')
+    .forEach(cb => {
+      cb.addEventListener('change', () => {
+        cb.form.submit();
+      });
+    });
 });

--- a/userlevel_permissions.php
+++ b/userlevel_permissions.php
@@ -92,9 +92,7 @@ $permRes = $conn->query($sql);
         </div>
       </div>
     </div>
-    <div class="ms-2 text-nowrap">
-      <button type="submit" class="btn btn-outline-light btn-sm">Salva</button>
-    </div>
+    <!-- Auto-save on checkbox change; button removed -->
     <input type="hidden" name="action" value="update">
     <input type="hidden" name="userlevelid" value="<?= (int)$row['userlevelid'] ?>">
     <input type="hidden" name="resource_id" value="<?= (int)$row['resource_id'] ?>">


### PR DESCRIPTION
## Summary
- Remove manual save button from existing permission entries.
- Automatically submit permission updates when checkboxes are toggled.

## Testing
- `php -l userlevel_permissions.php`
- `node --check js/userlevel_permissions.js`


------
https://chatgpt.com/codex/tasks/task_e_6895c3e212648331954e7df2f33142d8