### PR TITLE
Use AJAX for permission checkbox updates

### DIFF
--- a/js/userlevel_permissions.js
+++ b/js/userlevel_permissions.js
@@ -22,12 +22,18 @@ document.addEventListener('DOMContentLoaded', () => {
   resourceFilter.addEventListener('change', filter);
   filter();
 
-  // Auto-submit permission form when a checkbox is toggled
+  // Save permission changes via AJAX when a checkbox is toggled
   document
     .querySelectorAll('.permission-card input[type="checkbox"]')
     .forEach(cb => {
       cb.addEventListener('change', () => {
-        cb.form.submit();
+        const form = cb.form;
+        const formData = new FormData(form);
+        fetch('userlevel_permissions.php', {
+          method: 'POST',
+          headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          body: formData
+        }).catch(err => console.error('Errore salvataggio permesso', err));
       });
     });
 });

--- a/userlevel_permissions.php
+++ b/userlevel_permissions.php
@@ -18,6 +18,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'updat
     $stmt->bind_param('iiiiii', $userlevelid, $resource_id, $can_view, $can_insert, $can_update, $can_delete);
     $stmt->execute();
     $stmt->close();
+
+    // Return JSON for AJAX requests; fallback to redirect for normal requests
+    $isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+    if ($isAjax) {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => true]);
+        exit;
+    }
+
     header('Location: userlevel_permissions.php');
     exit;
 }


### PR DESCRIPTION
## Summary
- Return JSON for permission updates when request is sent via AJAX.
- Update permission checkbox handler to submit changes with fetch and avoid page reload.

## Testing
- `php -l userlevel_permissions.php`
- `node --check js/userlevel_permissions.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_6895c60728288331b133879b62700014