### PR TITLE
Limit movements to current user and family

### DIFF
--- a/ajax/load_movimenti_mese.php
+++ b/ajax/load_movimenti_mese.php
@@ -6,8 +6,12 @@ setlocale(LC_TIME, 'it_IT.UTF-8');
 
 $mese = $_GET['mese'] ?? date('Y-m');
 
- $sql = "SELECT * FROM (
-            SELECT id_movimento_revolut AS id, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, bm.descrizione_extra,
+$idUtente = $_SESSION['utente_id'] ?? 0;
+
+$movimenti_revolut = "";
+if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == 1) {
+    $movimenti_revolut =
+        "SELECT id_movimento_revolut AS id, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, bm.descrizione_extra,
                    started_date AS data_operazione, amount,
                    (SELECT GROUP_CONCAT(CONCAT(e.id_etichetta, ':', e.descrizione) SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
@@ -15,7 +19,11 @@ $mese = $_GET['mese'] ?? date('Y-m');
                      WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette,
                    bm.id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella, null as mezzo
             FROM v_movimenti_revolut_filtrati bm
-            UNION ALL
+            UNION ALL";
+}
+
+$sql = "SELECT * FROM (
+            {$movimenti_revolut}
             SELECT be.id_entrata AS id, be.descrizione_operazione AS descrizione, be.descrizione_extra,
                    be.data_operazione, be.importo AS amount,
                    (SELECT GROUP_CONCAT(CONCAT(e.id_etichetta, ':', e.descrizione) SEPARATOR ',')
@@ -24,6 +32,7 @@ $mese = $_GET['mese'] ?? date('Y-m');
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
                    be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
             FROM bilancio_entrate be
+            WHERE be.id_utente = {$idUtente}
             UNION ALL
             SELECT bu.id_uscita AS id, bu.descrizione_operazione AS descrizione, bu.descrizione_extra,
                    bu.data_operazione, -bu.importo AS amount,
@@ -33,6 +42,7 @@ $mese = $_GET['mese'] ?? date('Y-m');
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
                    bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
             FROM bilancio_uscite bu
+            WHERE bu.id_utente = {$idUtente}
         ) t
         WHERE DATE_FORMAT(data_operazione, '%Y-%m') = ?
         ORDER BY data_operazione DESC";

--- a/index.php
+++ b/index.php
@@ -6,6 +6,9 @@ if (!has_permission($conn, 'page:index.php', 'view')) { http_response_code(403);
 require_once 'includes/render_movimento.php';
 include 'includes/header.php';
 
+// Limit data to the current user when fetching personal balances
+$idUtente = $_SESSION['utente_id'] ?? 0;
+
 if (has_permission($conn, 'page:index.php-movmenti', 'view')): ?>
 
 <div class="mb-3">
@@ -42,6 +45,7 @@ if (has_permission($conn, 'page:index.php-movmenti', 'view')): ?>
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
                    be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
             FROM bilancio_entrate be
+            WHERE be.id_utente = {$idUtente}
             UNION ALL
             SELECT bu.id_uscita AS id, COALESCE(NULLIF(bu.descrizione_extra,''), bu.descrizione_operazione) AS descrizione, bu.descrizione_extra,
                    bu.data_operazione, -bu.importo AS amount,
@@ -51,6 +55,7 @@ if (has_permission($conn, 'page:index.php-movmenti', 'view')): ?>
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
                    bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
             FROM bilancio_uscite bu
+            WHERE bu.id_utente = {$idUtente}
         ) t
         ORDER BY data_operazione DESC LIMIT 5";
 

--- a/tutti_movimenti.php
+++ b/tutti_movimenti.php
@@ -4,6 +4,8 @@ require_once 'includes/db.php';
 include 'includes/header.php';
 setlocale(LC_TIME, 'it_IT.UTF-8');
 
+$idUtente = $_SESSION['utente_id'] ?? 0;
+
 $movimenti_revolut1 = "";
 if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == 1)
 {
@@ -16,9 +18,9 @@ $mesi = [];
 $sql = "SELECT DATE_FORMAT(data_operazione, '%Y-%m') AS ym
          FROM (
             ".$movimenti_revolut1."
-            SELECT data_operazione FROM bilancio_entrate
+            SELECT data_operazione FROM bilancio_entrate WHERE id_utente = {$idUtente}
             UNION ALL
-            SELECT data_operazione FROM bilancio_uscite
+            SELECT data_operazione FROM bilancio_uscite WHERE id_utente = {$idUtente}
          ) t
          GROUP BY ym ORDER BY ym ASC";
 $result = $conn->query($sql);


### PR DESCRIPTION
## Summary
- Restrict `bilancio_entrate` and `bilancio_uscite` queries to the current session user.
- Only include Revolut movements for family 1 in the AJAX loader and main views.

## Testing
- `php -l index.php`
- `php -l tutti_movimenti.php`
- `php -l ajax/load_movimenti_mese.php`


------
https://chatgpt.com/codex/tasks/task_e_6895e937ca3483319af1530ab0cb55f3