### PR TITLE
Lock account for 15 minutes after three passcode failures

### DIFF
--- a/sql/add_passcode_attempts_to_utenti.sql
+++ b/sql/add_passcode_attempts_to_utenti.sql
@@ -1,0 +1,1 @@
+ALTER TABLE utenti ADD COLUMN passcode_attempts INT DEFAULT 0;

--- a/sql/add_passcode_locked_until_to_utenti.sql
+++ b/sql/add_passcode_locked_until_to_utenti.sql
@@ -1,0 +1,1 @@
+ALTER TABLE utenti ADD COLUMN passcode_locked_until DATETIME DEFAULT NULL;


### PR DESCRIPTION
## Summary
- Temporarily lock passcode login for 15 minutes after three failed attempts
- Add SQL migration for `passcode_locked_until` timestamp

## Testing
- `php -l login_passcode.php`
- `php -l setup_passcode.php`


------
https://chatgpt.com/codex/tasks/task_e_6895e8a77b2483318af0449c23c65c66