### PR TITLE
Expand user management view with personal details

### DIFF
--- a/ajax/gestione_utenti.php
+++ b/ajax/gestione_utenti.php
@@ -7,7 +7,7 @@ $action = $_GET['action'] ?? $_POST['action'] ?? '';
 switch ($action) {
     case 'list':
         if (!has_permission($conn, 'table:utenti', 'view')) { http_response_code(403); echo json_encode(['error'=>'Permesso negato']); exit; }
-        $username = $_GET['username'] ?? '';
+        $search = $_GET['search'] ?? ($_GET['username'] ?? '');
         $userlevelid = $_GET['userlevelid'] ?? '';
         $id_famiglia = $_GET['id_famiglia'] ?? '';
         $sql = "SELECT u.id, u.username, u.nome, u.cognome, u.soprannome, u.email, u.id_famiglia_attuale, u.id_famiglia_gestione, u.attivo, u.userlevelid,
@@ -22,7 +22,12 @@ switch ($action) {
                 WHERE 1=1";
         $params = [];
         $types = '';
-        if ($username !== '') { $sql .= " AND u.username LIKE ?"; $params[] = "%$username%"; $types .= 's'; }
+        if ($search !== '') {
+            $sql .= " AND (u.username LIKE ? OR u.nome LIKE ? OR u.cognome LIKE ? OR u.email LIKE ?)";
+            $wild = "%$search%";
+            $params[] = $wild; $params[] = $wild; $params[] = $wild; $params[] = $wild;
+            $types .= 'ssss';
+        }
         if ($userlevelid !== '') { $sql .= " AND u.userlevelid = ?"; $params[] = $userlevelid; $types .= 'i'; }
         if ($id_famiglia !== '') {
             $sql .= " AND (u.id_famiglia_attuale = ? OR EXISTS (SELECT 1 FROM utenti2famiglie u2 WHERE u2.id_utente = u.id AND u2.id_famiglia = ?))";

--- a/gestione_utenti.php
+++ b/gestione_utenti.php
@@ -70,7 +70,9 @@ include 'includes/header.php';
   <thead>
     <tr>
       <th>Username</th>
-      <th>Userlevel</th>
+      <th>Nome</th>
+      <th>Cognome</th>
+      <th>Email</th>
       <th>Famiglia attuale</th>
       <th>Famiglie abilitate</th>
       <th>Azioni</th>

--- a/js/gestione_utenti.js
+++ b/js/gestione_utenti.js
@@ -24,7 +24,7 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
     function load() {
         const params = new URLSearchParams();
         params.append('action', 'list');
-        params.append('username', searchInput.value);
+        params.append('search', searchInput.value);
         params.append('userlevelid', userlevelFilter.value);
         params.append('id_famiglia', familyFilter.value);
         fetch('ajax/gestione_utenti.php?' + params.toString())
@@ -37,7 +37,9 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
             const tr = document.createElement('tr');
             tr.innerHTML = `
                 <td>${r.username ?? ''}</td>
-                <td>${r.userlevelname ?? ''}</td>
+                <td>${r.nome ?? ''}</td>
+                <td>${r.cognome ?? ''}</td>
+                <td>${r.email ?? ''}</td>
                 <td>${r.famiglia_attuale ?? ''}</td>
                 <td>${r.famiglie ?? ''}</td>
             `;


### PR DESCRIPTION
## Summary
- Show user name, surname, and email in the user management table
- Remove userlevel column from the listing
- Allow search filter to match username, name, surname, and email

## Testing
- `php -l gestione_utenti.php`
- `php -l ajax/gestione_utenti.php`
- `node --check js/gestione_utenti.js`


------
https://chatgpt.com/codex/tasks/task_e_6895f3817f608331b927cc958f379d0f