### PR TITLE
Enable passcode unlock from user management

### DIFF
--- a/ajax/gestione_utenti.php
+++ b/ajax/gestione_utenti.php
@@ -11,6 +11,7 @@ switch ($action) {
         $userlevelid = $_GET['userlevelid'] ?? '';
         $id_famiglia = $_GET['id_famiglia'] ?? '';
         $sql = "SELECT u.id, u.username, u.nome, u.cognome, u.soprannome, u.email, u.id_famiglia_attuale, u.id_famiglia_gestione, u.attivo, u.userlevelid,
+                       u.passcode_locked_until,
                        ul.userlevelname, f.nome_famiglia AS famiglia_attuale,
                        GROUP_CONCAT(CONCAT(f2.nome_famiglia, ' (', ul2.userlevelname, ')') ORDER BY f2.nome_famiglia SEPARATOR ', ') AS famiglie
                 FROM utenti u
@@ -70,6 +71,14 @@ switch ($action) {
         }
         $conn->commit();
         echo json_encode(['success'=>true]);
+        break;
+    case 'unlock_passcode':
+        if (!has_permission($conn, 'table:utenti', 'update')) { http_response_code(403); echo json_encode(['error'=>'Permesso negato']); exit; }
+        $id = intval($_POST['id'] ?? 0);
+        $stmt = $conn->prepare("UPDATE utenti SET passcode_locked_until = NULL WHERE id = ?");
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        echo json_encode(['success' => true]);
         break;
     default:
         http_response_code(400);

--- a/js/gestione_utenti.js
+++ b/js/gestione_utenti.js
@@ -52,6 +52,13 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
                 actions.appendChild(famBtn);
             }
             if (canUpdate) {
+                if (r.passcode_locked_until) {
+                    const unlockBtn = document.createElement('button');
+                    unlockBtn.className = 'btn btn-sm btn-link text-warning me-2';
+                    unlockBtn.innerHTML = '<i class="bi bi-unlock"></i>';
+                    unlockBtn.addEventListener('click', () => unlockPasscode(r[primaryKey]));
+                    actions.appendChild(unlockBtn);
+                }
                 const editBtn = document.createElement('button');
                 editBtn.className = 'btn btn-sm btn-link text-white me-2';
                 editBtn.innerHTML = '<i class="bi bi-pencil"></i>';
@@ -125,6 +132,14 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
             .then(r => r.json())
             .then(() => { deleteModal.hide(); load(); });
     });
+    function unlockPasscode(id) {
+        const fd = new FormData();
+        fd.append('action', 'unlock_passcode');
+        fd.append('id', id);
+        fetch('ajax/gestione_utenti.php', { method: 'POST', body: fd })
+            .then(r => r.json())
+            .then(() => load());
+    }
     function manageFamilies(id) {
         currentUserId = id;
         if (!familiesModal) familiesModal = new bootstrap.Modal(familiesModalEl);


### PR DESCRIPTION
## Summary
- show an unlock icon for users whose passcode is locked
- add backend endpoint to clear `passcode_locked_until`
- include lock field in user list retrieval

## Testing
- `php -l ajax/gestione_utenti.php`
- `php -l gestione_utenti.php`


------
https://chatgpt.com/codex/tasks/task_e_6895f51814b48331b9495b12dea3a719