### PR TITLE
Add link to classic login from passcode page

### DIFF
--- a/login_passcode.php
+++ b/login_passcode.php
@@ -100,6 +100,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           <input type="password" name="passcode" class="form-control" required pattern="\d{6}" autofocus>
         </div>
         <button type="submit" class="btn btn-primary">Accedi</button>
+        <a href="login.php" class="btn btn-link text-light">Login con utente e password</a>
       </form>
       <?php endif; ?>
     </div>


### PR DESCRIPTION
## Summary
- Allow users to access the username/password login from the passcode login page

## Testing
- `php -l login_passcode.php`


------
https://chatgpt.com/codex/tasks/task_e_6895f57b3900833194d5c67130b89d05