### PR TITLE
Improve mobile view for user management

### DIFF
--- a/gestione_utenti.php
+++ b/gestione_utenti.php
@@ -39,15 +39,15 @@ $canDelete = has_permission($conn, 'table:utenti', 'delete');
 $canManageFamilies = has_permission($conn, 'table:utenti2famiglie', 'update');
 include 'includes/header.php';
 ?>
-<div class="d-flex mb-3 justify-content-between">
-  <h4>Gestione Utenti</h4>
-  <button id="addBtn" class="btn btn-outline-light btn-sm">Aggiungi nuovo</button>
+<div class="d-flex flex-column flex-sm-row mb-3 justify-content-between align-items-sm-center">
+  <h4 class="mb-2 mb-sm-0">Gestione Utenti</h4>
+  <button id="addBtn" class="btn btn-outline-light btn-sm align-self-start align-self-sm-auto">Aggiungi nuovo</button>
 </div>
-<div class="row mb-3">
-  <div class="col">
+<div class="row g-2 mb-3">
+  <div class="col-12 col-md">
     <input type="text" id="search" class="form-control bg-dark text-white border-secondary" placeholder="Cerca utente">
   </div>
-  <div class="col">
+  <div class="col-12 col-md">
     <select id="userlevelFilter" class="form-select bg-dark text-white border-secondary">
       <option value="">Tutti i livelli</option>
       <?php if(isset($lookups['userlevelid'])): foreach($lookups['userlevelid'] as $id => $label): ?>
@@ -55,7 +55,7 @@ include 'includes/header.php';
       <?php endforeach; endif; ?>
     </select>
   </div>
-  <div class="col">
+  <div class="col-12 col-md">
     <select id="familyFilter" class="form-select bg-dark text-white border-secondary">
       <option value="">Tutte le famiglie</option>
       <?php
@@ -66,20 +66,7 @@ include 'includes/header.php';
     </select>
   </div>
 </div>
-<table class="table table-dark table-striped" id="data-table">
-  <thead>
-    <tr>
-      <th>Username</th>
-      <th>Nome</th>
-      <th>Cognome</th>
-      <th>Email</th>
-      <th>Famiglia attuale</th>
-      <th>Famiglie abilitate</th>
-      <th>Azioni</th>
-    </tr>
-  </thead>
-  <tbody></tbody>
-</table>
+<div id="userList"></div>
 <div class="modal fade" id="recordModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-scrollable">
     <div class="modal-content bg-dark text-white">

--- a/js/gestione_utenti.js
+++ b/js/gestione_utenti.js
@@ -1,5 +1,5 @@
 function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [], perms = {}) {
-    const tbody = document.querySelector('#data-table tbody');
+    const list = document.getElementById('userList');
     const searchInput = document.getElementById('search');
     const userlevelFilter = document.getElementById('userlevelFilter');
     const familyFilter = document.getElementById('familyFilter');
@@ -32,23 +32,28 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
             .then(data => { rows = data; render(); });
     }
     function render() {
-        tbody.innerHTML = '';
+        list.innerHTML = '';
         rows.forEach(r => {
-            const tr = document.createElement('tr');
-            tr.innerHTML = `
-                <td>${r.username ?? ''}</td>
-                <td>${r.nome ?? ''}</td>
-                <td>${r.cognome ?? ''}</td>
-                <td>${r.email ?? ''}</td>
-                <td>${r.famiglia_attuale ?? ''}</td>
-                <td>${r.famiglie ?? ''}</td>
+            const card = document.createElement('div');
+            card.className = 'movement user-card d-flex justify-content-between align-items-start text-white mb-2';
+
+            const info = document.createElement('div');
+            info.className = 'flex-grow-1';
+            info.innerHTML = `
+                <div class="fw-semibold">${r.username ?? ''}</div>
+                <div class="small">${r.nome ?? ''} ${r.cognome ?? ''}</div>
+                <div class="small">${r.email ?? ''}</div>
+                <div class="small">${r.famiglia_attuale ?? ''}</div>
             `;
-            const actions = document.createElement('td');
+            card.appendChild(info);
+
+            const actions = document.createElement('div');
+            actions.className = 'ms-2 text-nowrap';
             if (canManageFamilies) {
                 const famBtn = document.createElement('button');
                 famBtn.className = 'btn btn-sm btn-link text-white me-2';
                 famBtn.innerHTML = '<i class="bi bi-people"></i>';
-                famBtn.addEventListener('click', () => manageFamilies(r[primaryKey]));
+                famBtn.addEventListener('click', e => { e.stopPropagation(); manageFamilies(r[primaryKey]); });
                 actions.appendChild(famBtn);
             }
             if (canUpdate) {
@@ -56,24 +61,28 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
                     const unlockBtn = document.createElement('button');
                     unlockBtn.className = 'btn btn-sm btn-link text-warning me-2';
                     unlockBtn.innerHTML = '<i class="bi bi-unlock"></i>';
-                    unlockBtn.addEventListener('click', () => unlockPasscode(r[primaryKey]));
+                    unlockBtn.addEventListener('click', e => { e.stopPropagation(); unlockPasscode(r[primaryKey]); });
                     actions.appendChild(unlockBtn);
                 }
                 const editBtn = document.createElement('button');
                 editBtn.className = 'btn btn-sm btn-link text-white me-2';
                 editBtn.innerHTML = '<i class="bi bi-pencil"></i>';
-                editBtn.addEventListener('click', () => showForm(r));
+                editBtn.addEventListener('click', e => { e.stopPropagation(); showForm(r); });
                 actions.appendChild(editBtn);
             }
             if (canDelete) {
                 const delBtn = document.createElement('button');
                 delBtn.className = 'btn btn-sm btn-link text-danger';
                 delBtn.innerHTML = '<i class="bi bi-trash"></i>';
-                delBtn.addEventListener('click', () => confirmDelete(r[primaryKey]));
+                delBtn.addEventListener('click', e => { e.stopPropagation(); confirmDelete(r[primaryKey]); });
                 actions.appendChild(delBtn);
             }
-            tr.appendChild(actions);
-            tbody.appendChild(tr);
+            card.appendChild(actions);
+
+            if (canUpdate) {
+                card.addEventListener('click', () => showForm(r));
+            }
+            list.appendChild(card);
         });
     }
     function showForm(data = null) {


### PR DESCRIPTION
## Summary
- Replace table-based user list with mobile-friendly card layout
- Update user management JavaScript to render cards and keep action buttons

## Testing
- `php -l gestione_utenti.php`
- `node --check js/gestione_utenti.js`

------
https://chatgpt.com/codex/tasks/task_e_6895fb9e50748331955fced2de24be09