### PR TITLE
Add mobile-first events list with permission-controlled actions

### DIFF
--- a/eventi.php
+++ b/eventi.php
@@ -1,0 +1,29 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:eventi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+require_once 'includes/render_evento.php';
+include 'includes/header.php';
+
+$stmt = $conn->prepare("SELECT e.*, t.tipo_evento, t.colore FROM eventi e LEFT JOIN eventi_tipi_eventi t ON e.id_tipo_evento = t.id ORDER BY e.data_evento DESC, e.ora_evento DESC");
+$stmt->execute();
+$res = $stmt->get_result();
+$canInsert = has_permission($conn, 'table:eventi', 'insert');
+?>
+<div class="d-flex mb-3 justify-content-between">
+  <h4>Eventi</h4>
+  <?php if ($canInsert): ?>
+  <a href="eventi_dettaglio.php" class="btn btn-outline-light btn-sm">Aggiungi nuovo</a>
+  <?php endif; ?>
+</div>
+<div class="d-flex mb-3 align-items-center">
+  <input type="text" id="search" class="form-control bg-dark text-white border-secondary" placeholder="Cerca">
+</div>
+<div id="eventiList">
+<?php while ($row = $res->fetch_assoc()): ?>
+  <?php render_evento($row); ?>
+<?php endwhile; ?>
+</div>
+<script src="js/eventi.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/includes/render_evento.php
+++ b/includes/render_evento.php
@@ -1,0 +1,24 @@
+<?php
+function render_evento(array $row): void {
+    $search = strtolower(trim(($row['titolo'] ?? '') . ' ' . ($row['descrizione'] ?? '') . ' ' . ($row['tipo_evento'] ?? '')));
+    $searchAttr = htmlspecialchars($search, ENT_QUOTES);
+    $data = !empty($row['data_evento']) ? date('d/m/Y', strtotime($row['data_evento'])) : '';
+    $ora = $row['ora_evento'] ?? '';
+    echo '<div class="event-card movement d-flex justify-content-between align-items-start text-white text-decoration-none" data-search="' . $searchAttr . '">';
+    echo '  <div class="flex-grow-1">';
+    echo '    <div class="fw-semibold">' . htmlspecialchars($row['titolo']) . '</div>';
+    if ($data || $ora) {
+        $dataOra = trim($data . ' ' . $ora);
+        echo '    <div class="small">' . htmlspecialchars($dataOra) . '</div>';
+    }
+    if (!empty($row['descrizione'])) {
+        echo '    <div class="small text-muted">' . htmlspecialchars($row['descrizione']) . '</div>';
+    }
+    echo '  </div>';
+    if (!empty($row['tipo_evento'])) {
+        $color = htmlspecialchars($row['colore'] ?? '#71843f', ENT_QUOTES);
+        echo '  <span class="badge ms-2" style="background-color: ' . $color . '">' . htmlspecialchars($row['tipo_evento']) . '</span>';
+    }
+    echo '</div>';
+}
+?>

--- a/js/eventi.js
+++ b/js/eventi.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const search = document.getElementById('search');
+  const cards = Array.from(document.querySelectorAll('.event-card'));
+  function filter() {
+    const q = search.value.trim().toLowerCase();
+    cards.forEach(card => {
+      const text = card.dataset.search || '';
+      const visible = text.includes(q);
+      if (visible) {
+        card.style.removeProperty('display');
+      } else {
+        card.style.setProperty('display', 'none', 'important');
+      }
+    });
+  }
+  search.addEventListener('input', filter);
+  filter();
+});


### PR DESCRIPTION
## Summary
- add `eventi.php` mobile-first page listing events from database
- render each event via new `render_evento` helper
- enable real-time filtering with `eventi.js` and protect "Aggiungi nuovo" button with permissions

## Testing
- `php -l eventi.php`
- `php -l includes/render_evento.php`


------
https://chatgpt.com/codex/tasks/task_e_6895fd0bc5a88331ae95b7dc84fa0c36