### PR TITLE
Add vehicle management pages with permission checks

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -84,6 +84,13 @@
         </a>
       </li>
       <?php endif; ?>
+      <?php if (has_permission($conn, 'page:mezzi.php', 'view')): ?>
+      <li class="mb-3">
+        <a href="/Gestionale25/mezzi.php" class="btn btn-outline-light w-100 text-start">
+          🚗 Mezzi
+        </a>
+      </li>
+      <?php endif; ?>
       <?php if (has_permission($conn, 'page:storia.php', 'view')): ?>
       <li class="mb-3">
         <a href="/Gestionale25/storia.php" class="btn btn-outline-light w-100 text-start">

--- a/includes/render_mezzo.php
+++ b/includes/render_mezzo.php
@@ -1,0 +1,25 @@
+<?php
+function render_mezzo(array $row) {
+    $isActive = (int)($row['attivo'] ?? 0) === 1;
+    $classes = 'mezzo-card movement d-flex justify-content-between align-items-start text-white text-decoration-none';
+    if (!$isActive) {
+        $classes .= ' inactive';
+    }
+    $search = strtolower(($row['nome_mezzo'] ?? '') . ' ' . ($row['data_immatricolazione'] ?? ''));
+    $searchAttr = htmlspecialchars($search, ENT_QUOTES);
+    $url = 'mezzo_dettaglio.php?id=' . (int)($row['id_mezzo'] ?? 0);
+    $style = $isActive ? '' : ' style="display:none;"';
+    echo '<div class="' . $classes . '" data-search="' . $searchAttr . '"' . $style . ' onclick="window.location.href=\'' . $url . '\'">';
+    echo '  <div class="flex-grow-1">';
+    echo '    <div class="fw-semibold">' . htmlspecialchars($row['nome_mezzo'] ?? '') . '</div>';
+    if (!empty($row['data_immatricolazione'])) {
+        echo '    <div class="small">Immatricolazione: ' . htmlspecialchars($row['data_immatricolazione']) . '</div>';
+    }
+    echo '  </div>';
+    $icons = $isActive
+        ? '<i class="bi bi-check-circle-fill text-success"></i>'
+        : '<i class="bi bi-x-circle-fill text-danger"></i>';
+    echo '  <div class="ms-2 text-nowrap">' . $icons . '</div>';
+    echo '</div>';
+}
+?>

--- a/js/mezzi.js
+++ b/js/mezzi.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const search = document.getElementById('search');
+  const showInactive = document.getElementById('showInactive');
+  const cards = Array.from(document.querySelectorAll('.mezzo-card'));
+
+  function filter() {
+    const q = search.value.trim().toLowerCase();
+    cards.forEach(card => {
+      const text = card.dataset.search || '';
+      const isInactive = card.classList.contains('inactive');
+      const match = text.includes(q);
+      const visible = match && (!isInactive || showInactive.checked || q !== '');
+      if (visible) {
+        card.style.removeProperty('display');
+      } else {
+        card.style.setProperty('display', 'none', 'important');
+      }
+    });
+  }
+
+  search.addEventListener('input', filter);
+  showInactive.addEventListener('input', filter);
+  filter();
+});

--- a/mezzi.php
+++ b/mezzi.php
@@ -1,0 +1,36 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+require_once 'includes/permissions.php';
+require_once 'includes/render_mezzo.php';
+if (!has_permission($conn, 'page:mezzi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+include 'includes/header.php';
+
+$idUtente = $_SESSION['utente_id'] ?? ($_SESSION['id_utente'] ?? 0);
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+
+$stmt = $conn->prepare("SELECT * FROM mezzi WHERE id_famiglia = ?");
+$stmt->bind_param('i', $idFamiglia);
+$stmt->execute();
+$res = $stmt->get_result();
+?>
+<div class="d-flex mb-3 justify-content-between">
+  <h4>Mezzi</h4>
+  <?php if (has_permission($conn, 'table:mezzi', 'insert')): ?>
+  <a href="mezzo_dettaglio.php" class="btn btn-outline-light btn-sm">Aggiungi nuovo</a>
+  <?php endif; ?>
+</div>
+<div class="d-flex mb-3 align-items-center">
+  <input type="text" id="search" class="form-control bg-dark text-white border-secondary me-2" placeholder="Cerca">
+  <div class="form-check form-switch text-nowrap">
+    <input class="form-check-input" type="checkbox" id="showInactive">
+    <label class="form-check-label" for="showInactive">Mostra non attivi</label>
+  </div>
+</div>
+<div id="mezziList">
+<?php while ($row = $res->fetch_assoc()): ?>
+  <?php render_mezzo($row); ?>
+<?php endwhile; ?>
+</div>
+<script src="js/mezzi.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/mezzo_dettaglio.php
+++ b/mezzo_dettaglio.php
@@ -1,0 +1,92 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+require_once 'includes/permissions.php';
+include 'includes/header.php';
+
+$idUtente = $_SESSION['utente_id'] ?? ($_SESSION['id_utente'] ?? 0);
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$data = [
+    'nome_mezzo' => '',
+    'data_immatricolazione' => '',
+    'attivo' => 1,
+    'id_mezzo' => 0,
+    'id_utente' => $idUtente
+];
+
+if ($id > 0) {
+    $stmt = $conn->prepare("SELECT * FROM mezzi WHERE id_mezzo = ? AND id_famiglia = ?");
+    $stmt->bind_param('ii', $id, $idFamiglia);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($res && $res->num_rows > 0) {
+        $data = $res->fetch_assoc();
+    } else {
+        echo '<p class="text-danger">Record non trovato.</p>';
+        include 'includes/footer.php';
+        exit;
+    }
+}
+$isOwner = ($data['id_utente'] ?? $idUtente) == $idUtente;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id_mezzo = isset($_POST['id_mezzo']) ? (int)$_POST['id_mezzo'] : 0;
+    $nome_mezzo = $_POST['nome_mezzo'] ?? '';
+    $data_immatricolazione = $_POST['data_immatricolazione'] ?? '';
+    $attivo = isset($_POST['attivo']) ? 1 : 0;
+
+    if ($id_mezzo > 0) {
+        $stmt = $conn->prepare("SELECT id_utente FROM mezzi WHERE id_mezzo=? AND id_famiglia=?");
+        $stmt->bind_param('ii', $id_mezzo, $idFamiglia);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $row = $res->fetch_assoc();
+        $stmt->close();
+        if (!$row || (int)$row['id_utente'] !== $idUtente) {
+            echo '<p class="text-danger">Operazione non autorizzata.</p>';
+            include 'includes/footer.php';
+            exit;
+        }
+        $stmt = $conn->prepare("UPDATE mezzi SET nome_mezzo=?, data_immatricolazione=?, attivo=? WHERE id_mezzo=? AND id_famiglia=?");
+        $stmt->bind_param('ssiii', $nome_mezzo, $data_immatricolazione, $attivo, $id_mezzo, $idFamiglia);
+        $stmt->execute();
+        $stmt->close();
+    } else {
+        $stmt = $conn->prepare("INSERT INTO mezzi (id_utente, id_famiglia, nome_mezzo, data_immatricolazione, attivo) VALUES (?,?,?,?,?)");
+        $stmt->bind_param('iissi', $idUtente, $idFamiglia, $nome_mezzo, $data_immatricolazione, $attivo);
+        $stmt->execute();
+        $stmt->close();
+    }
+    header('Location: mezzi.php');
+    exit;
+}
+?>
+<div class="container text-white">
+  <a href="javascript:history.back()" class="btn btn-outline-light mb-3">← Indietro</a>
+  <h4 class="mb-4">Dettaglio Mezzo</h4>
+</div>
+<form method="post" class="bg-dark text-white p-3 rounded">
+  <div class="mb-3">
+    <label class="form-label">Nome mezzo</label>
+    <input type="text" name="nome_mezzo" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['nome_mezzo']) ?>" <?= $isOwner ? '' : 'disabled' ?>>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Data immatricolazione</label>
+    <input type="date" name="data_immatricolazione" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['data_immatricolazione']) ?>" <?= $isOwner ? '' : 'disabled' ?>>
+  </div>
+  <div class="form-check form-switch mb-3">
+    <input class="form-check-input" type="checkbox" id="attivo" name="attivo" <?= $data['attivo'] ? 'checked' : '' ?> <?= $isOwner ? '' : 'disabled' ?>>
+    <label class="form-check-label" for="attivo">Attivo</label>
+  </div>
+  <input type="hidden" name="id_utente" value="<?= (int)$idUtente ?>">
+  <input type="hidden" name="id_famiglia" value="<?= (int)$idFamiglia ?>">
+  <?php if ($data['id_mezzo']): ?>
+    <input type="hidden" name="id_mezzo" value="<?= (int)$data['id_mezzo'] ?>">
+  <?php endif; ?>
+  <?php if ($isOwner): ?>
+    <button type="submit" class="btn btn-primary w-100">Salva</button>
+  <?php endif; ?>
+</form>
+<?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Implement mezzi.php listing page with permission-controlled add button and card rendering
- Add mezzo_dettaglio.php for creating and editing vehicles with session-based ownership
- Introduce render_mezzo helper, filtering script, and navigation link

## Testing
- `php -l includes/render_mezzo.php mezzi.php mezzo_dettaglio.php includes/header.php`

------
https://chatgpt.com/codex/tasks/task_e_6895fefbc1d88331bae90a90622b8f6e