### PR TITLE
Sposta modifica utenti in pagina dedicata e rimuovi azioni dalla lista

### DIFF
--- a/gestione_utenti.php
+++ b/gestione_utenti.php
@@ -35,7 +35,6 @@ foreach ($displayColumns as $col) {
 }
 $canInsert = has_permission($conn, 'table:utenti', 'insert');
 $canUpdate = has_permission($conn, 'table:utenti', 'update');
-$canDelete = has_permission($conn, 'table:utenti', 'delete');
 $canManageFamilies = has_permission($conn, 'table:utenti2famiglie', 'update');
 include 'includes/header.php';
 ?>
@@ -67,67 +66,6 @@ include 'includes/header.php';
   </div>
 </div>
 <div id="userList"></div>
-<div class="modal fade" id="recordModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-scrollable">
-    <div class="modal-content bg-dark text-white">
-      <form id="record-form">
-        <div class="modal-header">
-          <h5 class="modal-title">Record</h5>
-          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Chiudi"></button>
-        </div>
-        <div class="modal-body">
-          <input type="hidden" name="<?= htmlspecialchars($primaryKey) ?>">
-          <?php foreach ($displayColumns as $col): ?>
-            <div class="mb-3">
-              <label class="form-label"><?= htmlspecialchars(str_replace('_',' ', $col)) ?></label>
-              <?php if (isset($lookups[$col])): ?>
-                <select name="<?= htmlspecialchars($col) ?>" class="form-select bg-dark text-white border-secondary">
-                  <?php foreach ($lookups[$col] as $id => $label): ?>
-                    <option value="<?= htmlspecialchars($id) ?>"><?= htmlspecialchars($label) ?></option>
-                  <?php endforeach; ?>
-                </select>
-              <?php elseif (in_array($col,$booleanColumns)): ?>
-                <div>
-                  <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="<?= htmlspecialchars($col) ?>" id="<?= htmlspecialchars($col) ?>_si" value="1">
-                    <label class="form-check-label" for="<?= htmlspecialchars($col) ?>_si">Si</label>
-                  </div>
-                  <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="<?= htmlspecialchars($col) ?>" id="<?= htmlspecialchars($col) ?>_no" value="0">
-                    <label class="form-check-label" for="<?= htmlspecialchars($col) ?>_no">No</label>
-                  </div>
-                </div>
-              <?php else: ?>
-                <input type="text" name="<?= htmlspecialchars($col) ?>" class="form-control bg-dark text-white border-secondary">
-              <?php endif; ?>
-            </div>
-          <?php endforeach; ?>
-        </div>
-        <div class="modal-footer">
-          <button type="button" id="cancelBtn" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
-          <button type="submit" class="btn btn-primary">Salva</button>
-        </div>
-      </form>
-    </div>
-  </div>
-</div>
-<div class="modal fade" id="deleteModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content bg-dark text-white">
-      <div class="modal-header">
-        <h5 class="modal-title">Conferma eliminazione</h5>
-        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Chiudi"></button>
-      </div>
-      <div class="modal-body">
-        Sei sicuro di voler eliminare questo utente?
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
-        <button type="button" id="confirmDeleteBtn" class="btn btn-danger">Elimina</button>
-      </div>
-    </div>
-  </div>
-</div>
 <div class="modal fade" id="familiesModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content bg-dark text-white">
@@ -147,6 +85,6 @@ include 'includes/header.php';
 </div>
 <script src="js/gestione_utenti.js"></script>
 <script>
-initUserManager('<?= $table ?>', <?= json_encode($displayColumns) ?>, '<?= $primaryKey ?>', <?= json_encode($lookups) ?>, <?= json_encode($booleanColumns) ?>, {canInsert: <?= $canInsert ? 'true':'false' ?>, canUpdate: <?= $canUpdate ? 'true':'false' ?>, canDelete: <?= $canDelete ? 'true':'false' ?>, canManageFamilies: <?= $canManageFamilies ? 'true':'false' ?>});
+initUserManager('<?= $table ?>', <?= json_encode($displayColumns) ?>, '<?= $primaryKey ?>', <?= json_encode($lookups) ?>, <?= json_encode($booleanColumns) ?>, {canInsert: <?= $canInsert ? 'true':'false' ?>, canUpdate: <?= $canUpdate ? 'true':'false' ?>, canManageFamilies: <?= $canManageFamilies ? 'true':'false' ?>});
 </script>
 <?php include 'includes/footer.php'; ?>

--- a/gestione_utenti_dettaglio.php
+++ b/gestione_utenti_dettaglio.php
@@ -1,0 +1,125 @@
+<?php
+include 'includes/session_check.php';
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'table:utenti', 'update')) { http_response_code(403); exit('Accesso negato'); }
+
+$config = include __DIR__ . '/includes/table_config.php';
+$foreignMap = include __DIR__ . '/includes/foreign_keys.php';
+$table = 'utenti';
+$columns = $config[$table]['columns'];
+$primaryKey = $config[$table]['primary_key'];
+$displayColumns = array_values(array_filter($columns, fn($c) => $c !== $primaryKey));
+$booleanColumns = ['attivo'];
+$lookups = [];
+foreach ($displayColumns as $col) {
+    if (isset($foreignMap[$col])) {
+        $fk = $foreignMap[$col];
+        $tablefk = $fk['table'];
+        $key = $fk['key'];
+        $label = $fk['label'];
+        if (!preg_match('/^[A-Za-z0-9_]+$/', $tablefk) ||
+            !preg_match('/^[A-Za-z0-9_]+$/', $key) ||
+            !preg_match("/^[A-Za-z0-9_(),\\s']+$/", $label)) {
+            continue;
+        }
+        $sql = "SELECT `$key` AS id, $label AS label FROM `$tablefk`";
+        if ($res = $conn->query($sql)) {
+            while ($row = $res->fetch_assoc()) {
+                $lookups[$col][$row['id']] = trim((string)$row['label']);
+            }
+        }
+    }
+}
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$data = [];
+if ($id) {
+    $stmt = $conn->prepare("SELECT * FROM utenti WHERE id = ?");
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $data = $res->fetch_assoc() ?: [];
+    $stmt->close();
+}
+$canDelete = has_permission($conn, 'table:utenti', 'delete');
+include 'includes/header.php';
+?>
+<div class="container text-white">
+  <a href="gestione_utenti.php" class="btn btn-outline-light mb-3">&larr; Indietro</a>
+  <h4 class="mb-4"><?= $id ? 'Modifica' : 'Nuovo' ?> Utente</h4>
+</div>
+<form id="user-form" class="bg-dark text-white p-3 rounded">
+  <?php foreach ($displayColumns as $col): ?>
+    <div class="mb-3">
+      <label class="form-label"><?= htmlspecialchars(str_replace('_',' ', $col)) ?></label>
+      <?php if (isset($lookups[$col])): ?>
+        <select name="<?= htmlspecialchars($col) ?>" class="form-select bg-dark text-white border-secondary">
+          <?php foreach ($lookups[$col] as $idOpt => $label): ?>
+            <option value="<?= htmlspecialchars($idOpt) ?>" <?= (($data[$col] ?? '') == $idOpt) ? 'selected' : '' ?>><?= htmlspecialchars($label) ?></option>
+          <?php endforeach; ?>
+        </select>
+      <?php elseif (in_array($col, $booleanColumns)): ?>
+        <div>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="<?= htmlspecialchars($col) ?>" id="<?= htmlspecialchars($col) ?>_si" value="1" <?= (($data[$col] ?? '') == '1') ? 'checked' : '' ?>>
+            <label class="form-check-label" for="<?= htmlspecialchars($col) ?>_si">Si</label>
+          </div>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="<?= htmlspecialchars($col) ?>" id="<?= htmlspecialchars($col) ?>_no" value="0" <?= (($data[$col] ?? '') == '0') ? 'checked' : '' ?>>
+            <label class="form-check-label" for="<?= htmlspecialchars($col) ?>_no">No</label>
+          </div>
+        </div>
+      <?php else: ?>
+        <input type="text" name="<?= htmlspecialchars($col) ?>" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data[$col] ?? '') ?>">
+      <?php endif; ?>
+    </div>
+  <?php endforeach; ?>
+  <?php if ($id): ?>
+    <input type="hidden" name="<?= htmlspecialchars($primaryKey) ?>" value="<?= (int)$id ?>">
+  <?php endif; ?>
+  <button type="submit" class="btn btn-primary w-100 mb-2">Salva</button>
+</form>
+<?php if ($id): ?>
+  <button type="button" id="resetPasscodeBtn" class="btn btn-warning w-100 mb-2">Reset passcode lock</button>
+  <?php if ($canDelete): ?>
+    <button type="button" id="deleteBtn" class="btn btn-danger w-100">Elimina</button>
+  <?php endif; ?>
+<?php endif; ?>
+<script>
+const id = <?= (int)$id ?>;
+const form = document.getElementById('user-form');
+form.addEventListener('submit', e => {
+  e.preventDefault();
+  const fd = new FormData(form);
+  fd.append('table', '<?= $table ?>');
+  fd.append('action', id ? 'update' : 'insert');
+  fetch('ajax/table_crud.php', { method: 'POST', body: fd })
+    .then(r => r.json())
+    .then(() => { window.location.href = 'gestione_utenti.php'; });
+});
+<?php if ($id): ?>
+const resetBtn = document.getElementById('resetPasscodeBtn');
+resetBtn.addEventListener('click', () => {
+  const fd = new FormData();
+  fd.append('action','unlock_passcode');
+  fd.append('id', id);
+  fetch('ajax/gestione_utenti.php', { method: 'POST', body: fd })
+    .then(r => r.json())
+    .then(() => location.reload());
+});
+<?php if ($canDelete): ?>
+const deleteBtn = document.getElementById('deleteBtn');
+deleteBtn.addEventListener('click', () => {
+  if (!confirm('Sei sicuro di voler eliminare questo utente?')) return;
+  const fd = new FormData();
+  fd.append('action','delete');
+  fd.append('table','<?= $table ?>');
+  fd.append('<?= $primaryKey ?>', id);
+  fetch('ajax/table_crud.php', { method:'POST', body: fd })
+    .then(r => r.json())
+    .then(() => { window.location.href = 'gestione_utenti.php'; });
+});
+<?php endif; ?>
+<?php endif; ?>
+</script>
+<?php include 'includes/footer.php'; ?>

--- a/js/gestione_utenti.js
+++ b/js/gestione_utenti.js
@@ -3,23 +3,16 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
     const searchInput = document.getElementById('search');
     const userlevelFilter = document.getElementById('userlevelFilter');
     const familyFilter = document.getElementById('familyFilter');
-    const form = document.getElementById('record-form');
     const addBtn = document.getElementById('addBtn');
-    const modalTitle = document.querySelector('#recordModal .modal-title');
-    const idField = form.querySelector(`input[name="${primaryKey}"]`);
-    const deleteModalEl = document.getElementById('deleteModal');
-    const confirmDeleteBtn = document.getElementById('confirmDeleteBtn');
     const familiesModalEl = document.getElementById('familiesModal');
     const familiesList = document.getElementById('familiesList');
     const familiesForm = document.getElementById('families-form');
     const canInsert = perms.canInsert ?? false;
     const canUpdate = perms.canUpdate ?? false;
-    const canDelete = perms.canDelete ?? false;
     const canManageFamilies = perms.canManageFamilies ?? false;
     if (!canInsert) addBtn.classList.add('d-none');
     let rows = [];
-    let recordModal, deleteModal, familiesModal;
-    let deleteId = null;
+    let familiesModal;
     let currentUserId = null;
     function load() {
         const params = new URLSearchParams();
@@ -56,99 +49,26 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
                 famBtn.addEventListener('click', e => { e.stopPropagation(); manageFamilies(r[primaryKey]); });
                 actions.appendChild(famBtn);
             }
-            if (canUpdate) {
-                if (r.passcode_locked_until) {
-                    const unlockBtn = document.createElement('button');
-                    unlockBtn.className = 'btn btn-sm btn-link text-warning me-2';
-                    unlockBtn.innerHTML = '<i class="bi bi-unlock"></i>';
-                    unlockBtn.addEventListener('click', e => { e.stopPropagation(); unlockPasscode(r[primaryKey]); });
-                    actions.appendChild(unlockBtn);
-                }
-                const editBtn = document.createElement('button');
-                editBtn.className = 'btn btn-sm btn-link text-white me-2';
-                editBtn.innerHTML = '<i class="bi bi-pencil"></i>';
-                editBtn.addEventListener('click', e => { e.stopPropagation(); showForm(r); });
-                actions.appendChild(editBtn);
-            }
-            if (canDelete) {
-                const delBtn = document.createElement('button');
-                delBtn.className = 'btn btn-sm btn-link text-danger';
-                delBtn.innerHTML = '<i class="bi bi-trash"></i>';
-                delBtn.addEventListener('click', e => { e.stopPropagation(); confirmDelete(r[primaryKey]); });
-                actions.appendChild(delBtn);
+            if (canUpdate && r.passcode_locked_until) {
+                const unlockBtn = document.createElement('button');
+                unlockBtn.className = 'btn btn-sm btn-link text-warning me-2';
+                unlockBtn.innerHTML = '<i class="bi bi-unlock"></i>';
+                unlockBtn.disabled = true;
+                actions.appendChild(unlockBtn);
             }
             card.appendChild(actions);
 
             if (canUpdate) {
-                card.addEventListener('click', () => showForm(r));
+                card.addEventListener('click', () => {
+                    window.location.href = `gestione_utenti_dettaglio.php?id=${r[primaryKey]}`;
+                });
             }
             list.appendChild(card);
         });
     }
-    function showForm(data = null) {
-        if ((data && !canUpdate) || (!data && !canInsert)) return;
-        form.reset();
-        if (!recordModal) recordModal = new bootstrap.Modal(document.getElementById('recordModal'));
-        if (data) {
-            form.dataset.mode = 'edit';
-            modalTitle.textContent = 'Modifica utente';
-            idField.value = data[primaryKey];
-            formColumns.forEach(c => {
-                if (boolCols.includes(c)) {
-                    const radios = form.querySelectorAll(`input[name="${c}"]`);
-                    radios.forEach(r => r.checked = String(data[c]) === r.value);
-                } else {
-                    const field = form.querySelector(`[name="${c}"]`);
-                    if (field) field.value = data[c] ?? '';
-                }
-            });
-        } else {
-            form.dataset.mode = 'insert';
-            modalTitle.textContent = 'Nuovo utente';
-            idField.value = '';
-            formColumns.forEach(c => {
-                if (boolCols.includes(c)) {
-                    const radios = form.querySelectorAll(`input[name="${c}"]`);
-                    radios.forEach(r => r.checked = false);
-                }
-            });
-        }
-        recordModal.show();
-    }
-    addBtn.addEventListener('click', () => showForm());
-    document.getElementById('cancelBtn').addEventListener('click', () => recordModal.hide());
-    form.addEventListener('submit', e => {
-        e.preventDefault();
-        const fd = new FormData(form);
-        fd.append('table', table);
-        fd.append('action', form.dataset.mode === 'edit' ? 'update' : 'insert');
-        fetch('ajax/table_crud.php', { method: 'POST', body: fd })
-            .then(r => r.json())
-            .then(() => { recordModal.hide(); load(); });
+    addBtn.addEventListener('click', () => {
+        window.location.href = 'gestione_utenti_dettaglio.php';
     });
-    function confirmDelete(id) {
-        deleteId = id;
-        if (!deleteModal) deleteModal = new bootstrap.Modal(deleteModalEl);
-        deleteModal.show();
-    }
-    confirmDeleteBtn.addEventListener('click', () => {
-        if (!canDelete || deleteId === null) return;
-        const fd = new FormData();
-        fd.append('action', 'delete');
-        fd.append('table', table);
-        fd.append(primaryKey, deleteId);
-        fetch('ajax/table_crud.php', { method: 'POST', body: fd })
-            .then(r => r.json())
-            .then(() => { deleteModal.hide(); load(); });
-    });
-    function unlockPasscode(id) {
-        const fd = new FormData();
-        fd.append('action', 'unlock_passcode');
-        fd.append('id', id);
-        fetch('ajax/gestione_utenti.php', { method: 'POST', body: fd })
-            .then(r => r.json())
-            .then(() => load());
-    }
     function manageFamilies(id) {
         currentUserId = id;
         if (!familiesModal) familiesModal = new bootstrap.Modal(familiesModalEl);


### PR DESCRIPTION
## Summary
- Rimuove le icone di modifica e cancellazione dalla lista utenti e disabilita l'icona di reset del passcode
- Elimina il modal di gestione utenti sostituendolo con reindirizzamento alla nuova pagina di dettaglio
- Aggiunge la pagina `gestione_utenti_dettaglio.php` con pulsanti per salvataggio, reset passcode e cancellazione

## Testing
- `php -l gestione_utenti.php`
- `php -l gestione_utenti_dettaglio.php`
- `node --check js/gestione_utenti.js`


------
https://chatgpt.com/codex/tasks/task_e_6896038227ac8331af414b6b6e728e0b