### PR TITLE
Add event creation modal and detail page

### DIFF
--- a/ajax/add_evento.php
+++ b/ajax/add_evento.php
@@ -1,0 +1,25 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$titolo = trim($_POST['titolo'] ?? '');
+$descrizione = trim($_POST['descrizione'] ?? '');
+$data_evento = $_POST['data_evento'] ?? null;
+$ora_evento = $_POST['ora_evento'] ?? null;
+$id_tipo_evento = (int)($_POST['id_tipo_evento'] ?? 0);
+
+if ($titolo === '') {
+    echo json_encode(['success' => false, 'error' => 'Titolo mancante']);
+    exit;
+}
+
+$stmt = $conn->prepare('INSERT INTO eventi (titolo, descrizione, data_evento, ora_evento, id_tipo_evento) VALUES (?,?,?,?,?)');
+$stmt->bind_param('ssssi', $titolo, $descrizione, $data_evento, $ora_evento, $id_tipo_evento);
+$ok = $stmt->execute();
+
+if ($ok) {
+    echo json_encode(['success' => true, 'id' => $conn->insert_id]);
+} else {
+    echo json_encode(['success' => false, 'error' => 'Errore durante l\'inserimento']);
+}

--- a/eventi.php
+++ b/eventi.php
@@ -10,11 +10,13 @@ $stmt = $conn->prepare("SELECT e.*, t.tipo_evento, t.colore FROM eventi e LEFT J
 $stmt->execute();
 $res = $stmt->get_result();
 $canInsert = has_permission($conn, 'table:eventi', 'insert');
+$tipiRes = $conn->query('SELECT id, tipo_evento FROM eventi_tipi_eventi ORDER BY tipo_evento');
+$tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
 ?>
 <div class="d-flex mb-3 justify-content-between">
   <h4>Eventi</h4>
   <?php if ($canInsert): ?>
-  <a href="eventi_dettaglio.php" class="btn btn-outline-light btn-sm">Aggiungi nuovo</a>
+  <button type="button" class="btn btn-outline-light btn-sm" onclick="openEventoModal()">Aggiungi nuovo</button>
   <?php endif; ?>
 </div>
 <div class="d-flex mb-3 align-items-center">
@@ -25,5 +27,47 @@ $canInsert = has_permission($conn, 'table:eventi', 'insert');
   <?php render_evento($row); ?>
 <?php endwhile; ?>
 </div>
+<?php if ($canInsert): ?>
+<div class="modal fade" id="eventoModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="eventoForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Nuovo evento</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Titolo</label>
+          <input type="text" name="titolo" class="form-control bg-secondary text-white" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Descrizione</label>
+          <textarea name="descrizione" class="form-control bg-secondary text-white"></textarea>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Data</label>
+          <input type="date" name="data_evento" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Ora</label>
+          <input type="time" name="ora_evento" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Tipo evento</label>
+          <select name="id_tipo_evento" class="form-select bg-secondary text-white">
+            <option value="">-- nessuno --</option>
+            <?php foreach ($tipi as $tipo): ?>
+              <option value="<?= (int)$tipo['id'] ?>"><?= htmlspecialchars($tipo['tipo_evento']) ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+<?php endif; ?>
 <script src="js/eventi.js"></script>
 <?php include 'includes/footer.php'; ?>

--- a/eventi_dettaglio.php
+++ b/eventi_dettaglio.php
@@ -1,0 +1,93 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:eventi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+
+$stmt = $conn->prepare("SELECT e.*, t.tipo_evento, t.colore FROM eventi e LEFT JOIN eventi_tipi_eventi t ON e.id_tipo_evento = t.id WHERE e.id = ?");
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$res = $stmt->get_result();
+$evento = $res->fetch_assoc();
+$stmt->close();
+
+if (!$evento) {
+    include 'includes/header.php';
+    echo '<p class="text-danger">Record non trovato.</p>';
+    include 'includes/footer.php';
+    exit;
+}
+
+$invitati = [];
+$stmtInv = $conn->prepare("SELECT i.nome, i.cognome FROM eventi_eventi2invitati e2i JOIN eventi_invitati i ON e2i.id_invitato = i.id WHERE e2i.id_evento = ? ORDER BY i.cognome, i.nome");
+$stmtInv->bind_param('i', $id);
+$stmtInv->execute();
+$resInv = $stmtInv->get_result();
+while ($row = $resInv->fetch_assoc()) { $invitati[] = $row; }
+$stmtInv->close();
+
+$cibi = [];
+$stmtCibo = $conn->prepare("SELECT c.piatto, c.um, e2c.quantita FROM eventi_eventi2cibo e2c JOIN eventi_cibo c ON e2c.id_cibo = c.id WHERE e2c.id_evento = ? ORDER BY c.piatto");
+$stmtCibo->bind_param('i', $id);
+$stmtCibo->execute();
+$resCibo = $stmtCibo->get_result();
+while ($row = $resCibo->fetch_assoc()) { $cibi[] = $row; }
+$stmtCibo->close();
+
+include 'includes/header.php';
+?>
+<div class="container text-white">
+  <a href="javascript:history.back()" class="btn btn-outline-light mb-3">← Indietro</a>
+  <h4 class="mb-3"><?= htmlspecialchars($evento['titolo'] ?? '') ?></h4>
+  <?php if (!empty($evento['data_evento']) || !empty($evento['ora_evento'])): ?>
+    <div class="mb-3"><?= htmlspecialchars(trim(($evento['data_evento'] ?? '') . ' ' . ($evento['ora_evento'] ?? ''))) ?></div>
+  <?php endif; ?>
+  <?php if (!empty($evento['descrizione'])): ?>
+    <p><?= nl2br(htmlspecialchars($evento['descrizione'])) ?></p>
+  <?php endif; ?>
+
+  <div class="d-flex justify-content-between align-items-center mb-2">
+    <div class="d-flex align-items-center">
+      <h5 class="mb-0 me-3">Invitati</h5>
+      <?php if (count($invitati) > 3): ?>
+        <button id="toggleInvitati" class="btn btn-link p-0">Mostra tutti</button>
+      <?php endif; ?>
+    </div>
+  </div>
+  <ul class="list-group list-group-flush bg-dark" id="invitatiList">
+    <?php foreach ($invitati as $idx => $row): ?>
+      <li class="list-group-item bg-dark text-white <?= $idx >= 3 ? 'd-none extra-row' : '' ?>">
+        <?= htmlspecialchars($row['nome'] . ' ' . $row['cognome']) ?>
+      </li>
+    <?php endforeach; ?>
+  </ul>
+
+  <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
+    <div class="d-flex align-items-center">
+      <h5 class="mb-0 me-3">Cibo</h5>
+      <?php if (count($cibi) > 3): ?>
+        <button id="toggleCibo" class="btn btn-link p-0">Mostra tutti</button>
+      <?php endif; ?>
+    </div>
+  </div>
+  <ul class="list-group list-group-flush bg-dark" id="ciboList">
+    <?php foreach ($cibi as $idx => $row): ?>
+      <li class="list-group-item bg-dark text-white <?= $idx >= 3 ? 'd-none extra-row' : '' ?>">
+        <?= htmlspecialchars($row['piatto']) ?><?php if ($row['quantita'] !== null) echo ' - ' . htmlspecialchars($row['quantita']) . ' ' . htmlspecialchars($row['um']); ?>
+      </li>
+    <?php endforeach; ?>
+  </ul>
+</div>
+<script>
+document.getElementById('toggleInvitati')?.addEventListener('click', function(){
+  document.querySelectorAll('#invitatiList .extra-row').forEach(el=>el.classList.toggle('d-none'));
+  this.textContent = this.textContent === 'Mostra tutti' ? 'Mostra meno' : 'Mostra tutti';
+});
+document.getElementById('toggleCibo')?.addEventListener('click', function(){
+  document.querySelectorAll('#ciboList .extra-row').forEach(el=>el.classList.toggle('d-none'));
+  this.textContent = this.textContent === 'Mostra tutti' ? 'Mostra meno' : 'Mostra tutti';
+});
+</script>
+<?php include 'includes/footer.php'; ?>

--- a/includes/render_evento.php
+++ b/includes/render_evento.php
@@ -4,7 +4,8 @@ function render_evento(array $row): void {
     $searchAttr = htmlspecialchars($search, ENT_QUOTES);
     $data = !empty($row['data_evento']) ? date('d/m/Y', strtotime($row['data_evento'])) : '';
     $ora = $row['ora_evento'] ?? '';
-    echo '<div class="event-card movement d-flex justify-content-between align-items-start text-white text-decoration-none" data-search="' . $searchAttr . '">';
+    $url = 'eventi_dettaglio.php?id=' . (int)($row['id'] ?? 0);
+    echo '<div class="event-card movement d-flex justify-content-between align-items-start text-white text-decoration-none" data-search="' . $searchAttr . '" onclick="window.location.href=\'' . $url . '\'">';
     echo '  <div class="flex-grow-1">';
     echo '    <div class="fw-semibold">' . htmlspecialchars($row['titolo']) . '</div>';
     if ($data || $ora) {

--- a/js/eventi.js
+++ b/js/eventi.js
@@ -15,4 +15,21 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   search.addEventListener('input', filter);
   filter();
+
+  const form = document.getElementById('eventoForm');
+  form?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const formData = new FormData(form);
+    fetch('ajax/add_evento.php', {method:'POST', body:formData})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success){ location.reload(); } else { alert(res.error||'Errore'); }});
+  });
 });
+
+function openEventoModal(){
+  const form = document.getElementById('eventoForm');
+  if(form){
+    form.reset();
+    new bootstrap.Modal(document.getElementById('eventoModal')).show();
+  }
+}


### PR DESCRIPTION
## Summary
- Allow creation of new events via modal with AJAX backend
- Make event cards link to a new detail page
- Show invited guests and food on detail page with expandable lists

## Testing
- `php -l eventi.php && php -l includes/render_evento.php && php -l ajax/add_evento.php && php -l eventi_dettaglio.php`
- `node --check js/eventi.js`


------
https://chatgpt.com/codex/tasks/task_e_689616b137408331b99dc6a95a834bbb