### PR TITLE
Enhance credit page with tag links and movement details modal

### DIFF
--- a/ajax/get_movimento.php
+++ b/ajax/get_movimento.php
@@ -1,0 +1,33 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$tabella = $_GET['tabella'] ?? '';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$allowed = ['movimenti_revolut','bilancio_entrate','bilancio_uscite'];
+if (!in_array($tabella, $allowed, true) || $id <= 0) {
+    echo json_encode(['success' => false, 'error' => 'Parametri non validi']);
+    exit;
+}
+
+if ($tabella === 'bilancio_entrate') {
+    $stmt = $conn->prepare("SELECT COALESCE(NULLIF(descrizione_extra,''), descrizione_operazione) AS descrizione, note, importo AS amount, data_operazione FROM bilancio_entrate WHERE id_entrata = ?");
+} elseif ($tabella === 'bilancio_uscite') {
+    $stmt = $conn->prepare("SELECT COALESCE(NULLIF(descrizione_extra,''), descrizione_operazione) AS descrizione, note, -importo AS amount, data_operazione FROM bilancio_uscite WHERE id_uscita = ?");
+} else {
+    $stmt = $conn->prepare("SELECT description AS descrizione, note, amount, started_date AS data_operazione FROM movimenti_revolut WHERE id_movimento_revolut = ?");
+}
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$data = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+
+if (!$data) {
+    echo json_encode(['success' => false, 'error' => 'Movimento non trovato']);
+    exit;
+}
+
+$data['amount'] = (float)$data['amount'];
+
+echo json_encode(['success' => true, 'data' => $data]);

--- a/credito_utente.php
+++ b/credito_utente.php
@@ -47,8 +47,9 @@ if (!$utente) {
 // Recupera eventuale lista utenti per la select
 $utentiFam = [];
 if ($canChangeUser) {
-    $stmtList = $conn->prepare('SELECT u.id, u.nome, u.cognome
+    $stmtList = $conn->prepare('SELECT DISTINCT u.id, u.nome, u.cognome
                                  FROM utenti u
+                                 JOIN bilancio_utenti2operazioni_etichettate u2o ON u.id = u2o.id_utente
                                  WHERE u.attivo = 1
                                  ORDER BY u.nome');
     $stmtList->execute();
@@ -59,7 +60,10 @@ if ($canChangeUser) {
 $sqlMov = "SELECT
                 u2o.id_u2o,
                 u2o.id_e2o,
-                CONCAT(ifnull(v.descrizione_extra,v.descrizione_operazione), ' (', v.importo_totale_operazione, ')') AS descrizione,
+                e2o.id_tabella,
+                e2o.tabella_operazione AS tabella,
+                e2o.id_etichetta,
+                CONCAT(IFNULL(v.descrizione_extra,v.descrizione_operazione), ' (', v.importo_totale_operazione, ')') AS descrizione,
                 v.data_operazione,
                 v.descrizione AS etichetta_descrizione,
                 (CASE
@@ -79,6 +83,7 @@ $sqlMov = "SELECT
                 END) AS saldo_utente
            FROM bilancio_utenti2operazioni_etichettate u2o
            JOIN v_bilancio_etichette2operazioni_a_testa v ON u2o.id_e2o = v.id_e2o
+           JOIN bilancio_etichette2operazioni e2o ON e2o.id_e2o = u2o.id_e2o
            WHERE u2o.id_utente = ? AND u2o.saldata = 0
            ORDER BY v.data_operazione DESC";
 
@@ -153,14 +158,14 @@ $stmtMov->close();
    <?php if (!empty($movimenti)): ?>
     <?php foreach ($movimenti as $mov): ?>
       <?php $rowsAttr = $isAdmin ? htmlspecialchars(json_encode($mov['rows'] ?? []), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : ''; ?>
-      <div class="movement d-flex justify-content-between align-items-start text-white mb-2" <?php if ($isAdmin): ?>data-rows='<?= $rowsAttr ?>' onclick="openDettaglio(this)" style="cursor:pointer"<?php endif; ?>>
+      <div class="movement d-flex justify-content-between align-items-start text-white mb-2" data-tabella="<?= htmlspecialchars($mov['tabella']) ?>" data-id-tabella="<?= (int)$mov['id_tabella'] ?>" <?php if ($isAdmin): ?>data-rows='<?= $rowsAttr ?>'<?php endif; ?> onclick="openMovimento(this)" style="cursor:pointer">
         <?php if ($isAdmin): ?>
           <input type="checkbox" class="form-check-input me-2 flex-shrink-0" style="width:1.25rem;height:1.25rem;" data-id-u2o="<?= $mov['id_u2o'] ?>" onclick="event.stopPropagation();">
         <?php endif; ?>
         <div class="flex-grow-1 me-3" style="max-width:calc(100% - 8rem);">
           <div class="descr fw-semibold text-break"><?= htmlspecialchars($mov['descrizione']) ?></div>
           <div class="small"><?= date('d/m/Y H:i', strtotime($mov['data_operazione'])) ?></div>
-          <div class="mt-1"><span class="badge bg-secondary"><?= htmlspecialchars($mov['etichetta_descrizione']) ?></span></div>
+          <div class="mt-1"><a href="etichetta.php?id_etichetta=<?= urlencode($mov['id_etichetta']) ?>" class="badge bg-secondary text-decoration-none" onclick="event.stopPropagation();"><?= htmlspecialchars($mov['etichetta_descrizione']) ?></a></div>
         </div>
         <div class="text-end flex-shrink-0">
           <div class="amount"><?= ($mov['saldo_utente']>=0?'+':'') . number_format($mov['saldo_utente'], 2, ',', '.') ?> €</div>
@@ -172,7 +177,6 @@ $stmtMov->close();
   <?php endif; ?>
 </div>
 
-  <?php if ($isAdmin): ?>
   <div class="modal fade" id="movModal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content bg-dark text-white">
@@ -180,11 +184,18 @@ $stmtMov->close();
           <h5 class="modal-title">Dettaglio movimento</h5>
           <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
         </div>
-        <div class="modal-body" id="movRows"></div>
+        <div class="modal-body">
+          <div id="movInfo"></div>
+          <?php if ($isAdmin): ?><div id="movRows" class="mt-3"></div><?php endif; ?>
+        </div>
+        <div class="modal-footer">
+          <a href="#" target="_blank" class="btn btn-primary" id="linkDettaglio">Vai al dettaglio</a>
+        </div>
       </div>
     </div>
   </div>
 
+  <?php if ($isAdmin): ?>
   <div class="modal fade" id="confirmModal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content bg-dark text-white">
@@ -200,22 +211,43 @@ $stmtMov->close();
       </div>
     </div>
   </div>
+  <?php endif; ?>
 
   <script>
-  function openDettaglio(div) {
-    const rows = JSON.parse(div.dataset.rows || '[]');
-    const container = document.getElementById('movRows');
-    container.innerHTML = '';
-    rows.forEach(r => {
-      const imp = Number(r.importo).toLocaleString('it-IT', {minimumFractionDigits:2, maximumFractionDigits:2});
-      const status = r.saldata == 1 ? '✔' : '✖';
-      const p = document.createElement('div');
-      p.textContent = `${r.nome} ${r.cognome}: ${imp} € ${status}`;
-      container.appendChild(p);
-    });
-    new bootstrap.Modal(document.getElementById('movModal')).show();
+  function openMovimento(div) {
+    const tabella = div.dataset.tabella;
+    const id = div.dataset.idTabella;
+    fetch(`ajax/get_movimento.php?tabella=${encodeURIComponent(tabella)}&id=${id}`)
+      .then(r => r.json())
+      .then(res => {
+        if (!res.success) { alert(res.error || 'Errore'); return; }
+        const d = res.data;
+        const info = document.getElementById('movInfo');
+        const imp = Number(d.amount).toLocaleString('it-IT', {minimumFractionDigits:2, maximumFractionDigits:2});
+        const date = new Date(d.data_operazione.replace(' ', 'T'));
+        let html = `<div><strong>${d.descrizione}</strong></div>`;
+        html += `<div>${date.toLocaleString('it-IT')}</div>`;
+        html += `<div>${(d.amount>=0?'+':'')}${imp} €</div>`;
+        if (d.note) html += `<div class="mt-2">${d.note}</div>`;
+        info.innerHTML = html;
+        <?php if ($isAdmin): ?>
+        const rows = JSON.parse(div.dataset.rows || '[]');
+        const container = document.getElementById('movRows');
+        container.innerHTML = '';
+        rows.forEach(r => {
+          const imp2 = Number(r.importo).toLocaleString('it-IT', {minimumFractionDigits:2, maximumFractionDigits:2});
+          const status = r.saldata == 1 ? '✔' : '✖';
+          const p = document.createElement('div');
+          p.textContent = `${r.nome} ${r.cognome}: ${imp2} € ${status}`;
+          container.appendChild(p);
+        });
+        <?php endif; ?>
+        document.getElementById('linkDettaglio').href = `dettaglio.php?src=${tabella}&id=${id}`;
+        new bootstrap.Modal(document.getElementById('movModal')).show();
+      });
   }
 
+  <?php if ($isAdmin): ?>
   document.getElementById('saldaBtn').addEventListener('click', () => {
     const checked = document.querySelectorAll('.movement input[type="checkbox"]:checked');
     if (checked.length === 0) {
@@ -241,7 +273,7 @@ $stmtMov->close();
       bootstrap.Modal.getInstance(document.getElementById('confirmModal')).hide();
     });
   });
-  </script>
   <?php endif; ?>
+  </script>
 
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Link movement tags on `credito_utente.php` directly to their respective `etichetta.php` pages.
- Display movement details in a modal with a shortcut to `dettaglio.php` and load info via new `ajax/get_movimento.php`.
- Limit user dropdown to active users that have at least one labeled operation.

## Testing
- `php -l credito_utente.php`
- `php -l ajax/get_movimento.php`

------
https://chatgpt.com/codex/tasks/task_e_6896357829808331bac33d0179f4e574