### PR TITLE
Improve movements navigation and layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -48,9 +48,9 @@ body {
   flex: 0 0 auto;
 }
 .months-scroll .btn.active {
-  background-color: #0d6efd;
-  border-color: #0d6efd;
-  color: #fff;
+  background-color: #fff;
+  border-color: #fff;
+  color: #000;
 }
 .day-header {
   font-size: .85rem;
@@ -68,11 +68,25 @@ body {
   background-color: #2b2b2b;
   cursor: pointer;
 }
+.movement .flex-grow-1 {
+  min-width: 0;
+}
+.movement .descr {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .amount {
   min-width: 80px;
   text-align: right;
   font-weight: 500;
   color: #fff;
+  white-space: nowrap;
+}
+.movement .text-end {
+  flex-shrink: 0;
 }
 #search::placeholder {
   color: rgba(255, 255, 255, 0.5);

--- a/includes/render_movimento.php
+++ b/includes/render_movimento.php
@@ -15,7 +15,8 @@ function render_movimento(array $mov) {
 
     $url = 'dettaglio.php?id=' . (int)$mov['id'] . '&src=' . urlencode($mov['tabella']);
 
-    echo '<div class="movement d-flex justify-content-between align-items-start text-white text-decoration-none" data-id="' . (int)$mov['id'] . '" data-src="' . htmlspecialchars($mov['tabella'], ENT_QUOTES) . '" style="cursor:pointer" onclick="window.location.href=\'' . $url . '\'">';
+    $mese = substr($mov['data_operazione'], 0, 7);
+    echo '<div class="movement d-flex justify-content-between align-items-start text-white text-decoration-none" data-id="' . (int)$mov['id'] . '" data-src="' . htmlspecialchars($mov['tabella'], ENT_QUOTES) . '" data-mese="' . htmlspecialchars($mese, ENT_QUOTES) . '" data-href="' . htmlspecialchars($url, ENT_QUOTES) . '" style="cursor:pointer">';
     echo '  <img src="' . htmlspecialchars($icon) . '" alt="src" class="me-2" style="width:24px;height:24px">';
     echo '  <div class="flex-grow-1 me-3">';
     echo '    <div class="descr fw-semibold">' . htmlspecialchars($mov['descrizione']) . '</div>';

--- a/tutti_movimenti.php
+++ b/tutti_movimenti.php
@@ -38,7 +38,21 @@ while ($row = $result->fetch_assoc()) {
     ];
 }
 $ultimoIndice = count($mesi) - 1;
+$anni = [];
+foreach ($mesi as $m) {
+    $y = substr($m['ym'], 0, 4);
+    if (!in_array($y, $anni)) {
+        $anni[] = $y;
+    }
+}
 ?>
+<div class="mb-2">
+    <select id="yearSelector" class="form-select bg-dark text-white border-secondary w-auto">
+        <?php foreach ($anni as $anno): ?>
+            <option value="<?= htmlspecialchars($anno) ?>" <?= $anno == $annoCorrente ? 'selected' : '' ?>><?= htmlspecialchars($anno) ?></option>
+        <?php endforeach; ?>
+    </select>
+</div>
 <div class="months-scroll d-flex mb-3" id="monthsContainer">
     <?php foreach ($mesi as $idx => $m): ?>
         <button class="btn btn-outline-light me-2 <?= $idx === $ultimoIndice ? 'active' : '' ?>" data-mese="<?= htmlspecialchars($m['ym']) ?>">


### PR DESCRIPTION
## Summary
- Make active month buttons white for easier visibility
- Truncate movement descriptions and keep euro symbol with amount
- Add year selector and restore scroll position when returning from details

## Testing
- `php -l tutti_movimenti.php`
- `php -l includes/render_movimento.php`
- `node --check js/tutti_movimenti.js`


------
https://chatgpt.com/codex/tasks/task_e_6896ec8422608331a40768ed22b7462c