### PR TITLE
Add etichetta movement detail page and fix split calculations

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -64,6 +64,13 @@ body {
   margin-bottom: 10px;
   padding: 16px;
 }
+
+.movement .descr {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
 .movement:hover {
   background-color: #2b2b2b;
   cursor: pointer;

--- a/etichetta_dettaglio_movimento.php
+++ b/etichetta_dettaglio_movimento.php
@@ -1,0 +1,149 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+include 'includes/header.php';
+
+$idE2o = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if ($idE2o <= 0) {
+    echo '<p class="text-danger">Movimento non trovato.</p>';
+    include 'includes/footer.php';
+    exit;
+}
+
+$stmt = $conn->prepare("SELECT e2o.*, e.descrizione AS etichetta_descrizione FROM bilancio_etichette2operazioni e2o JOIN bilancio_etichette e ON e.id_etichetta = e2o.id_etichetta WHERE e2o.id_e2o = ?");
+$stmt->bind_param('i', $idE2o);
+$stmt->execute();
+$e2o = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if (!$e2o) {
+    echo '<p class="text-danger">Movimento non trovato.</p>';
+    include 'includes/footer.php';
+    exit;
+}
+
+// Dati del movimento originale
+$mov = null;
+switch ($e2o['tabella_operazione']) {
+    case 'movimenti_revolut':
+        $stmtM = $conn->prepare("SELECT COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, descrizione_extra, started_date AS data_operazione, amount FROM v_movimenti_revolut WHERE id_movimento_revolut = ?");
+        $stmtM->bind_param('i', $e2o['id_tabella']);
+        break;
+    case 'bilancio_entrate':
+        $stmtM = $conn->prepare("SELECT descrizione_operazione AS descrizione, descrizione_extra, data_operazione, importo AS amount FROM bilancio_entrate WHERE id_entrata = ?");
+        $stmtM->bind_param('i', $e2o['id_tabella']);
+        break;
+    case 'bilancio_uscite':
+        $stmtM = $conn->prepare("SELECT descrizione_operazione AS descrizione, descrizione_extra, data_operazione, -importo AS amount FROM bilancio_uscite WHERE id_uscita = ?");
+        $stmtM->bind_param('i', $e2o['id_tabella']);
+        break;
+    default:
+        $stmtM = null;
+}
+if ($stmtM && $stmtM->execute()) {
+    $mov = $stmtM->get_result()->fetch_assoc();
+    $stmtM->close();
+}
+if (!$mov) {
+    echo '<p class="text-danger">Movimento non trovato.</p>';
+    include 'includes/footer.php';
+    exit;
+}
+
+// Dati per gli utenti
+$stmtU = $conn->prepare("SELECT u2o.*, u.nome, u.cognome FROM bilancio_utenti2operazioni_etichettate u2o JOIN utenti u ON u.id = u2o.id_utente WHERE u2o.id_e2o = ?");
+$stmtU->bind_param('i', $idE2o);
+$stmtU->execute();
+$resU = $stmtU->get_result();
+$u2oRows = [];
+while ($r = $resU->fetch_assoc()) {
+    $u2oRows[] = $r;
+}
+$stmtU->close();
+
+$total = $e2o['importo'] !== null ? (float)$e2o['importo'] : abs($mov['amount']);
+$count = count($u2oRows) ?: 1;
+foreach ($u2oRows as &$r) {
+    $imp = $r['importo_utente'];
+    if ($imp === null) {
+        if ($r['quote'] !== null) {
+            $imp = $total * $r['quote'];
+        } else {
+            $imp = $total / $count;
+        }
+    }
+    if ($r['utente_pagante']) {
+        $imp = -$imp;
+    }
+    $r['calc_importo'] = $imp;
+}
+unset($r);
+
+$descrizione = $e2o['descrizione_extra'] ?: ($mov['descrizione'] ?? '');
+$amountValue = $e2o['importo'] !== null ? (float)$e2o['importo'] : $mov['amount'];
+if ($e2o['tabella_operazione'] === 'bilancio_uscite' && $amountValue >= 0) {
+    $amountValue *= -1;
+}
+$importo = number_format($amountValue, 2, ',', '.');
+$dataOra = date('d/m/Y H:i', strtotime($mov['data_operazione']));
+?>
+<div class="container text-white">
+  <a href="javascript:history.back()" class="btn btn-outline-light mb-3">← Indietro</a>
+  <h4 class="mb-3">
+    <span id="movDescr"><?= htmlspecialchars($descrizione) ?></span>
+    <i class="bi bi-pencil ms-2" role="button" onclick="openE2oModal()"></i>
+  </h4>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="small"><?= $dataOra ?></div>
+    <div class="fw-semibold"><?= ($amountValue >= 0 ? '+' : '') . $importo ?> €</div>
+  </div>
+  <h5 class="mb-2">Quote utenti</h5>
+  <ul class="list-group list-group-flush bg-dark mb-3" id="u2oList">
+    <?php foreach ($u2oRows as $row): ?>
+      <li class="list-group-item bg-dark text-white d-flex justify-content-between align-items-center">
+        <div class="flex-grow-1"><?= htmlspecialchars($row['nome'] . ' ' . $row['cognome']) ?></div>
+        <div class="text-end me-2" style="min-width:80px;"><?= number_format($row['calc_importo'], 2, ',', '.') ?> €</div>
+        <button class="btn btn-danger btn-sm ms-2" onclick="deleteU2o(<?= (int)$row['id_u2o'] ?>)">✕</button>
+      </li>
+    <?php endforeach; ?>
+  </ul>
+  <button class="btn btn-danger w-100" onclick="deleteE2o()">Elimina</button>
+</div>
+
+<div class="modal fade" id="editE2oModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="editE2oForm" enctype="multipart/form-data">
+      <div class="modal-header">
+        <h5 class="modal-title">Modifica movimento</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Descrizione extra</label>
+          <input type="text" name="descrizione_extra" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Importo</label>
+          <input type="number" step="0.01" name="importo" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Allegato</label>
+          <input type="file" name="allegato" class="form-control bg-secondary text-white">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+const e2oData = {
+  id: <?= (int)$e2o['id_e2o'] ?>,
+  id_etichetta: <?= (int)$e2o['id_etichetta'] ?>,
+  descrizione_extra: <?= json_encode($e2o['descrizione_extra']) ?>,
+  importo: <?= $e2o['importo'] !== null ? json_encode((float)$e2o['importo']) : 'null' ?>
+};
+</script>
+<script src="js/etichetta_dettaglio_movimento.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/includes/etichette_utils.php
+++ b/includes/etichette_utils.php
@@ -83,17 +83,18 @@ function get_saldo_e_movimenti_utente($idUtente)
                     v.data_operazione,
                     v.descrizione AS etichetta_descrizione,
                     (CASE
-                        WHEN v.id_utente_operazione = u2o.id_utente THEN -(
+                        WHEN u2o.utente_pagante = 1 THEN -(
                             CASE
                                 WHEN IFNULL(u2o.importo_utente, 0) <> 0 THEN u2o.importo_utente
-                                WHEN v.importo_etichetta <> 0 THEN (v.importo * u2o.quote)
-                                ELSE (v.importo_totale_operazione - (v.importo * u2o.quote))
+                                WHEN v.importo_etichetta <> 0 THEN (v.importo_etichetta * u2o.quote)
+                                ELSE (v.importo_totale_operazione - (v.importo_totale_operazione * u2o.quote))
                             END
                         )
                         ELSE (
                             CASE
                                 WHEN IFNULL(u2o.importo_utente, 0) <> 0 THEN u2o.importo_utente
-                                ELSE (v.importo * u2o.quote)
+                                WHEN v.importo_etichetta <> 0 THEN (v.importo_etichetta * u2o.quote)
+                                ELSE (v.importo_totale_operazione * u2o.quote)
                             END
                         )
                     END) AS saldo_utente
@@ -114,17 +115,18 @@ function get_saldo_e_movimenti_utente($idUtente)
         if ($isAdmin) {
             $stmtDet = $conn->prepare("SELECT u2o.id_u2o, u.nome, u.cognome,
                     (CASE
-                        WHEN v.id_utente_operazione = u2o.id_utente THEN -(
+                        WHEN u2o.utente_pagante = 1 THEN -(
                             CASE
                                 WHEN IFNULL(u2o.importo_utente, 0) <> 0 THEN u2o.importo_utente
-                                WHEN v.importo_etichetta <> 0 THEN (v.importo * u2o.quote)
-                                ELSE (v.importo_totale_operazione - (v.importo * u2o.quote))
+                                WHEN v.importo_etichetta <> 0 THEN (v.importo_etichetta * u2o.quote)
+                                ELSE (v.importo_totale_operazione - (v.importo_totale_operazione * u2o.quote))
                             END
                         )
                         ELSE (
                             CASE
                                 WHEN IFNULL(u2o.importo_utente, 0) <> 0 THEN u2o.importo_utente
-                                ELSE (v.importo * u2o.quote)
+                                WHEN v.importo_etichetta <> 0 THEN (v.importo_etichetta * u2o.quote)
+                                ELSE (v.importo_totale_operazione * u2o.quote)
                             END
                         )
                     END) AS importo,

--- a/includes/render_movimento_etichetta.php
+++ b/includes/render_movimento_etichetta.php
@@ -40,7 +40,6 @@ function render_movimento_etichetta(array $mov, int $id_etichetta) {
           WHERE e2o.id_tabella = ? AND e2o.tabella_operazione = ? AND e2o.id_etichetta = ?"
     );
     $stmtU->bind_param('isi', $mov['id'], $mov['tabella'], $id_etichetta);
-    $rowsJson = '[]';
     $perUser = [];
     if ($stmtU->execute()) {
         $resU = $stmtU->get_result();
@@ -94,22 +93,21 @@ function render_movimento_etichetta(array $mov, int $id_etichetta) {
                         $perUser[$uid]['saldata'] = false;
                     }
                 }
-                if (!empty($mov['id_e2o']) && $mov['id_e2o'] == $idE2o) {
-                    $rowsJson = htmlspecialchars(json_encode($rows, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP));
-                }
             }
         }
     }
     $stmtU->close();
 
     $rowId = 'mov-' . $mov['tabella'] . '-' . $mov['id'];
-    echo '<div id="' . $rowId . '" class="movement d-flex align-items-start text-white text-decoration-none" style="cursor:pointer" data-id-e2o="' . htmlspecialchars($mov['id_e2o'] ?? '', ENT_QUOTES) . '" data-rows="' . $rowsJson . '" onclick="openU2oModal(this)">';
+    $idE2o = $mov['id_e2o'] ?? ($info['id_e2o'] ?? 0);
+    $dest = 'etichetta_dettaglio_movimento.php?id=' . (int)$idE2o;
+    echo '<div id="' . $rowId . '" class="movement d-flex align-items-start text-white text-decoration-none" style="cursor:pointer" onclick="window.location.href=\'' . $dest . '\'">';
     if ($isAdmin) {
         echo '<input type="checkbox" class="form-check-input me-2 settle-checkbox d-none d-md-inline" onclick="event.stopPropagation();">';
     }
     echo '  <img src="' . htmlspecialchars($icon) . '" alt="src" class="me-2 flex-shrink-0" style="width:24px;height:24px">';
     echo '  <div class="flex-grow-1 me-3" style="min-width:0">';
-    echo '    <div class="descr fw-semibold text-truncate">' . htmlspecialchars($descrizione) . '</div>';
+    echo '    <div class="descr fw-semibold">' . htmlspecialchars($descrizione) . '</div>';
     echo '    <div class="small">' . $dataOra . '</div>';
     if ($perUser) {
         echo '    <div class="mt-1">';
@@ -125,13 +123,6 @@ function render_movimento_etichetta(array $mov, int $id_etichetta) {
     echo '  </div>';
     echo '  <div class="text-end">';
     echo '    <div class="amount text-white text-nowrap">' . ($amountValue >= 0 ? '+' : '') . $importo . ' €</div>';
-    $idE2oAttr = htmlspecialchars($info['id_e2o'] ?? '', ENT_QUOTES);
-    $descAttr = htmlspecialchars($info['descrizione_extra'] ?? '', ENT_QUOTES);
-    $impAttr = htmlspecialchars($info['importo'] ?? '', ENT_QUOTES);
-    $allAttr = htmlspecialchars($info['allegato'] ?? '', ENT_QUOTES);
-    $rowAttr = htmlspecialchars($rowId, ENT_QUOTES);
-    echo '    <button class="btn btn-sm btn-link text-white edit-e2o" data-id-e2o="' . $idE2oAttr . '" data-descrizione-extra="' . $descAttr . '" data-importo="' . $impAttr . '" data-allegato="' . $allAttr . '" data-row-id="' . $rowAttr . '" onclick="event.stopPropagation();"><i class="bi bi-pencil"></i></button>';
-    echo '    <button class="btn btn-sm btn-link text-danger delete-e2o" data-id-e2o="' . $idE2oAttr . '" data-row-id="' . $rowAttr . '" onclick="event.stopPropagation();"><i class="bi bi-trash"></i></button>';
     echo '  </div>';
     echo '</div>';
 

--- a/js/etichetta_dettaglio_movimento.js
+++ b/js/etichetta_dettaglio_movimento.js
@@ -1,0 +1,29 @@
+function openE2oModal(){
+  const form = document.getElementById('editE2oForm');
+  form.descrizione_extra.value = e2oData.descrizione_extra || '';
+  form.importo.value = e2oData.importo !== null ? e2oData.importo : '';
+  new bootstrap.Modal(document.getElementById('editE2oModal')).show();
+}
+
+document.getElementById('editE2oForm')?.addEventListener('submit', function(e){
+  e.preventDefault();
+  const formData = new FormData(this);
+  formData.append('id_e2o', e2oData.id);
+  fetch('ajax/update_e2o.php', {method:'POST', body:formData})
+    .then(r=>r.json())
+    .then(res=>{ if(res.success) location.reload(); });
+});
+
+function deleteU2o(id){
+  if(!confirm('Eliminare questa riga?')) return;
+  fetch('ajax/delete_u2o.php', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:'id_u2o='+id})
+    .then(r=>r.json())
+    .then(res=>{ if(res.success) location.reload(); });
+}
+
+function deleteE2o(){
+  if(!confirm('Eliminare questo movimento?')) return;
+  fetch('ajax/delete_e2o.php', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:'id_e2o='+e2oData.id})
+    .then(r=>r.json())
+    .then(res=>{ if(res.success) window.location.href = 'etichetta.php?id_etichetta='+e2oData.id_etichetta; });
+}


### PR DESCRIPTION
## Summary
- Navigate to a movement detail page when clicking rows and allow descriptions to span two lines
- Provide dedicated page to edit movement labels and manage user splits
- Correct user balance calculations by honoring paying user flag

## Testing
- `php -l includes/render_movimento_etichetta.php`
- `php -l includes/etichette_utils.php`
- `php -l etichetta_dettaglio_movimento.php`


------
https://chatgpt.com/codex/tasks/task_e_6896efc6609c8331b8939d351ec8113d