### PR TITLE
Reuse verification email template for reset

### DIFF
--- a/assets/html/codice_verifica.html
+++ b/assets/html/codice_verifica.html
@@ -12,14 +12,14 @@
       </tr>
       <tr>
         <td align="center" style="font-size:24px;font-weight:bold;color:#d32f2f;padding:30px 0;">
-          [code]
+          [content]
         </td>
       </tr>
       <tr>
         <td style="font-size:14px;line-height:20px;">
           <p>Ciao,</p>
-          <p>ecco il codice per accedere.</p>
-          <p>Se non hai richiesto questo codice, puoi ignorare questa email.</p>
+          <p>[message]</p>
+          <p>Se non hai richiesto questa email, puoi ignorarla.</p>
         </td>
       </tr>
       <tr>

--- a/forgot_password.php
+++ b/forgot_password.php
@@ -49,7 +49,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $mail->isHTML(true);
             $link = (isset($_SERVER['HTTPS']) ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . dirname($_SERVER['PHP_SELF']) . '/reset_password.php?token=' . urlencode($token);
             $mail->Subject = 'Reset password';
-            $mail->Body = '<p>Per reimpostare la password, clicca <a href="' . $link . '">qui</a></p>';
+            $html = file_get_contents(__DIR__ . '/assets/html/codice_verifica.html');
+            $resetButton = '<a href="' . $link . '" style="display:inline-block;padding:15px 25px;background-color:#d32f2f;color:#ffffff;text-decoration:none;border-radius:4px;">Reimposta password</a>';
+            $html = str_replace(['[content]', '[message]'], [$resetButton, 'Per reimpostare la password, clicca sul pulsante seguente:'], $html);
+            $mail->Body = $html;
             $mail->send();
             $success = 'Controlla la tua email per le istruzioni.';
         } catch (Exception $e) {

--- a/login.php
+++ b/login.php
@@ -80,8 +80,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 $mail->Subject = 'Codice di verifica';
                 //$mail->Body = '<p>Il tuo codice di verifica &egrave;: <strong>' . $code . '</strong></p>';
                 $html = file_get_contents(__DIR__ . '/assets/html/codice_verifica.html');
-                // Sostituisci il segnaposto [code] con il codice reale
-                $html = str_replace('[code]', $code, $html);                
+                // Sostituisci i segnaposto con il contenuto reale
+                $html = str_replace(['[content]', '[message]'], [$code, 'ecco il codice per accedere.'], $html);
                 // Imposta il body dell'email
                 $mail->Body = $html;
                 $mail->send();


### PR DESCRIPTION
## Summary
- generalize verification HTML template to accept custom message and content
- use the common template for both 2FA code and password reset emails

## Testing
- `php -l login.php`
- `php -l forgot_password.php`


------
https://chatgpt.com/codex/tasks/task_e_6896f868dbd083319ecbe9de6e61e153