### PR TITLE
Add live page search to user level permissions

### DIFF
--- a/js/userlevel_permissions.js
+++ b/js/userlevel_permissions.js
@@ -1,14 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
   const userlevelFilter = document.getElementById('filterUserlevel');
-  const resourceFilter = document.getElementById('filterResource');
+  const resourceSearch = document.getElementById('searchResource');
   const cards = Array.from(document.querySelectorAll('.permission-card'));
 
   function filter() {
     const ul = userlevelFilter.value;
-    const res = resourceFilter.value;
+    const query = resourceSearch.value.toLowerCase();
     cards.forEach(card => {
       const matchUl = !ul || card.dataset.userlevel === ul;
-      const matchRes = !res || card.dataset.resource === res;
+      const matchRes = !query || card.dataset.resourceName.includes(query);
       const visible = matchUl && matchRes;
       if (visible) {
         card.style.removeProperty('display');
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   userlevelFilter.addEventListener('change', filter);
-  resourceFilter.addEventListener('change', filter);
+  resourceSearch.addEventListener('input', filter);
   filter();
 
   // Save permission changes via AJAX when a checkbox is toggled

--- a/userlevel_permissions.php
+++ b/userlevel_permissions.php
@@ -48,7 +48,7 @@ if ($res = $conn->query("SELECT id, name FROM resources ORDER BY name")) {
     $res->free();
 }
 
-$sql = "SELECT up.*, ul.userlevelname, r.name FROM userlevel_permissions up JOIN userlevels ul ON up.userlevelid = ul.userlevelid JOIN resources r ON up.resource_id = r.id ORDER BY ul.userlevelname, r.name";
+$sql = "SELECT up.*, ul.userlevelname, r.name FROM userlevel_permissions up JOIN userlevels ul ON up.userlevelid = ul.userlevelid JOIN resources r ON up.resource_id = r.id ORDER BY r.name, ul.userlevelname";
 $permRes = $conn->query($sql);
 ?>
 
@@ -67,18 +67,13 @@ $permRes = $conn->query($sql);
     </select>
   </div>
   <div class="col">
-    <select id="filterResource" class="form-select bg-dark text-white border-secondary">
-      <option value="">Tutte le risorse</option>
-      <?php foreach ($resources as $resItem): ?>
-      <option value="<?= (int)$resItem['id'] ?>"><?= htmlspecialchars($resItem['name']) ?></option>
-      <?php endforeach; ?>
-    </select>
+    <input id="searchResource" type="text" class="form-control bg-dark text-white border-secondary" placeholder="Cerca pagina">
   </div>
 </div>
 
 <div id="permissionsList">
   <?php while ($row = $permRes->fetch_assoc()): ?>
-  <form method="post" class="permission-card movement d-flex justify-content-between align-items-start text-white text-decoration-none bg-dark p-3 mb-2 rounded" data-userlevel="<?= (int)$row['userlevelid'] ?>" data-resource="<?= (int)$row['resource_id'] ?>">
+  <form method="post" class="permission-card movement d-flex justify-content-between align-items-start text-white text-decoration-none bg-dark p-3 mb-2 rounded" data-userlevel="<?= (int)$row['userlevelid'] ?>" data-resource-name="<?= htmlspecialchars(strtolower($row['name'])) ?>">
     <div class="flex-grow-1">
       <div class="fw-semibold"><?= htmlspecialchars($row['userlevelname']) ?></div>
       <div class="small"><?= htmlspecialchars($row['name']) ?></div>


### PR DESCRIPTION
## Summary
- sort user level permissions by page name
- add free-text live search for pages while keeping user level filter

## Testing
- `php -l userlevel_permissions.php`
- `node --check js/userlevel_permissions.js`


------
https://chatgpt.com/codex/tasks/task_e_6896fbec368883318359e32dc448708a