### PR TITLE
Allow editing and adding user share records

### DIFF
--- a/ajax/update_u2o.php
+++ b/ajax/update_u2o.php
@@ -1,0 +1,29 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_u2o = intval($_POST['id_u2o'] ?? 0);
+$id_e2o = intval($_POST['id_e2o'] ?? 0);
+$id_utente = intval($_POST['id_utente'] ?? 0);
+$quote_input = trim($_POST['quote'] ?? '');
+$quote = $quote_input === '' ? null : (float)$quote_input;
+$saldata = !empty($_POST['saldata']) ? 1 : 0;
+$data_saldo = trim($_POST['data_saldo'] ?? '');
+if ($data_saldo === '') {
+    $data_saldo = null;
+}
+
+if ($id_u2o > 0) {
+    $stmt = $conn->prepare("UPDATE bilancio_utenti2operazioni_etichettate SET id_utente = ?, quote = ?, saldata = ?, data_saldo = ? WHERE id_u2o = ?");
+    $stmt->bind_param('idisi', $id_utente, $quote, $saldata, $data_saldo, $id_u2o);
+    $ok = $stmt->execute();
+    $stmt->close();
+} else {
+    $stmt = $conn->prepare("INSERT INTO bilancio_utenti2operazioni_etichettate (id_e2o, id_utente, quote, saldata, data_saldo) VALUES (?, ?, ?, ?, ?)");
+    $stmt->bind_param('iidis', $id_e2o, $id_utente, $quote, $saldata, $data_saldo);
+    $ok = $stmt->execute();
+    $stmt->close();
+}
+
+echo json_encode(['success' => $ok]);

--- a/js/etichetta_dettaglio_movimento.js
+++ b/js/etichetta_dettaglio_movimento.js
@@ -14,6 +14,33 @@ document.getElementById('editE2oForm')?.addEventListener('submit', function(e){
     .then(res=>{ if(res.success) location.reload(); });
 });
 
+function openU2oModal(li){
+  const form = document.getElementById('editU2oForm');
+  if(li){
+    form.id_u2o.value = li.dataset.u2oId;
+    form.id_utente.value = li.dataset.utenteId;
+    form.quote.value = li.dataset.quote || '';
+    form.saldata.checked = li.dataset.saldata === '1';
+    form.data_saldo.value = li.dataset.dataSaldo ? li.dataset.dataSaldo.substring(0,10) : '';
+  } else {
+    form.id_u2o.value = 0;
+    form.id_utente.value = '';
+    form.quote.value = '';
+    form.saldata.checked = false;
+    form.data_saldo.value = '';
+  }
+  new bootstrap.Modal(document.getElementById('editU2oModal')).show();
+}
+
+document.getElementById('editU2oForm')?.addEventListener('submit', function(e){
+  e.preventDefault();
+  const fd = new FormData(this);
+  fd.append('id_e2o', e2oData.id);
+  fetch('ajax/update_u2o.php', {method:'POST', body:fd})
+    .then(r=>r.json())
+    .then(res=>{ if(res.success) location.reload(); });
+});
+
 function deleteU2o(id){
   if(!confirm('Eliminare questa riga?')) return;
   fetch('ajax/delete_u2o.php', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:'id_u2o='+id})


### PR DESCRIPTION
## Summary
- Load active users and render editable list items with an "Aggiungi nuovo" button
- Add modal to create or update user share records
- Handle modal interactions in JS and persist changes via new AJAX endpoint

## Testing
- `php -l etichetta_dettaglio_movimento.php`
- `php -l ajax/update_u2o.php`
- `node --check js/etichetta_dettaglio_movimento.js`


------
https://chatgpt.com/codex/tasks/task_e_68970e833cf883318d9ed9830e3a9cb2