### PR TITLE
Correggi calcolo saldo utente

### DIFF
--- a/includes/etichette_utils.php
+++ b/includes/etichette_utils.php
@@ -83,18 +83,17 @@ function get_saldo_e_movimenti_utente($idUtente)
                     v.data_operazione,
                     v.descrizione AS etichetta_descrizione,
                     (CASE
-                        WHEN u2o.utente_pagante = 1 THEN -(
+                        WHEN v.id_utente_operazione = u2o.id_utente THEN -(
                             CASE
                                 WHEN IFNULL(u2o.importo_utente, 0) <> 0 THEN u2o.importo_utente
-                                WHEN v.importo_etichetta <> 0 THEN (v.importo_etichetta * u2o.quote)
-                                ELSE (v.importo_totale_operazione - (v.importo_totale_operazione * u2o.quote))
+                                WHEN v.importo_etichetta <> 0 THEN (v.importo * u2o.quote)
+                                ELSE (v.importo_totale_operazione - (v.importo * u2o.quote))
                             END
                         )
                         ELSE (
                             CASE
                                 WHEN IFNULL(u2o.importo_utente, 0) <> 0 THEN u2o.importo_utente
-                                WHEN v.importo_etichetta <> 0 THEN (v.importo_etichetta * u2o.quote)
-                                ELSE (v.importo_totale_operazione * u2o.quote)
+                                ELSE (v.importo * u2o.quote)
                             END
                         )
                     END) AS saldo_utente
@@ -115,18 +114,17 @@ function get_saldo_e_movimenti_utente($idUtente)
         if ($isAdmin) {
             $stmtDet = $conn->prepare("SELECT u2o.id_u2o, u.nome, u.cognome,
                     (CASE
-                        WHEN u2o.utente_pagante = 1 THEN -(
+                        WHEN v.id_utente_operazione = u2o.id_utente THEN -(
                             CASE
                                 WHEN IFNULL(u2o.importo_utente, 0) <> 0 THEN u2o.importo_utente
-                                WHEN v.importo_etichetta <> 0 THEN (v.importo_etichetta * u2o.quote)
-                                ELSE (v.importo_totale_operazione - (v.importo_totale_operazione * u2o.quote))
+                                WHEN v.importo_etichetta <> 0 THEN (v.importo * u2o.quote)
+                                ELSE (v.importo_totale_operazione - (v.importo * u2o.quote))
                             END
                         )
                         ELSE (
                             CASE
                                 WHEN IFNULL(u2o.importo_utente, 0) <> 0 THEN u2o.importo_utente
-                                WHEN v.importo_etichetta <> 0 THEN (v.importo_etichetta * u2o.quote)
-                                ELSE (v.importo_totale_operazione * u2o.quote)
+                                ELSE (v.importo * u2o.quote)
                             END
                         )
                     END) AS importo,


### PR DESCRIPTION
## Summary
- Correzione della logica per il calcolo del saldo utente in get_saldo_e_movimenti_utente
- Allineamento della query di dettaglio ai nuovi calcoli

## Testing
- `php -l includes/etichette_utils.php`

------
https://chatgpt.com/codex/tasks/task_e_6897146c1ae88331a409e656c99e4cce