### PR TITLE
Fix month selection and active highlighting

### DIFF
--- a/js/tutti_movimenti.js
+++ b/js/tutti_movimenti.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const observer = new IntersectionObserver((entries) => {
         entries.forEach(entry => {
-            if (entry.isIntersecting && entry.intersectionRatio > 0.5) {
+            if (entry.isIntersecting) {
                 const ym = entry.target.dataset.mese;
                 const idx = mesi.indexOf(ym);
                 if (idx !== -1) {
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
         });
-    }, { threshold: 0.6 });
+    }, { rootMargin: '-50% 0px -50% 0px', threshold: 0 });
 
     const observeSections = () => {
         document.querySelectorAll('.month-section').forEach(sec => {
@@ -79,8 +79,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     buttons.forEach((btn, idx) => {
         btn.addEventListener('click', () => {
+            suppressScrollLoad = true;
             minIdx = maxIdx = idx;
-            loadMovimenti(idx);
+            loadMovimenti(idx).then(() => {
+                setTimeout(() => { suppressScrollLoad = false; }, 100);
+            });
             btn.scrollIntoView({ inline: 'center', behavior: 'smooth' });
         });
     });
@@ -103,6 +106,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const restoreScroll = () => {
         if (savedScroll !== null) {
             window.scrollTo(0, parseFloat(savedScroll));
+            if (savedMonth) {
+                const idx = mesi.indexOf(savedMonth);
+                if (idx !== -1) {
+                    buttons.forEach((btn, i) => btn.classList.toggle('active', i === idx));
+                    if (yearSelect) {
+                        yearSelect.value = mesi[idx].slice(0,4);
+                    }
+                }
+            }
             sessionStorage.removeItem('tmScroll');
             sessionStorage.removeItem('tmMonth');
         }


### PR DESCRIPTION
## Summary
- prevent scroll handler from loading the next month when a month is clicked
- ensure active month button reflects current view when scrolling or returning to the list

## Testing
- `node --check js/tutti_movimenti.js`


------
https://chatgpt.com/codex/tasks/task_e_6897167413c483319d7b517aa9e3d513