### PR TITLE
Allinea calcolo quote etichette

### DIFF
--- a/etichetta.php
+++ b/etichetta.php
@@ -5,6 +5,7 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 require_once 'includes/db.php';
 require_once 'includes/render_movimento_etichetta.php';
+require_once 'includes/etichette_utils.php';
 include 'includes/header.php';
 setlocale(LC_TIME, 'it_IT.UTF-8');
 

--- a/includes/etichette_utils.php
+++ b/includes/etichette_utils.php
@@ -64,8 +64,48 @@ function eliminaEtichetteCollegate(string $tabella_operazione, int $id_tabella):
     }
 }
 
+/**
+ * Calcola l'importo spettante a un utente in base alle quote e al pagante.
+ *
+ * La logica riprende quella utilizzata nella funzione get_saldo_e_movimenti_utente
+ * per determinare il saldo di ciascun utente.
+ *
+ * @param bool  $isPagante        True se l'utente ha effettuato l'operazione.
+ * @param float $importoUtente    Importo specifico assegnato all'utente.
+ * @param float $importoEtichetta Importo complessivo dell'etichetta (se diverso dal totale).
+ * @param float $importoTotale    Importo totale dell'operazione.
+ * @param float $quota            Quota dell'utente.
+ *
+ * @return float Importo calcolato per l'utente (positivo per credito, negativo per debito).
+ */
+function calcola_importo_quota(
+    bool $isPagante,
+    float $importoUtente,
+    float $importoEtichetta,
+    float $importoTotale,
+    float $quota
+): float {
+    if ($isPagante) {
+        if ($importoUtente != 0.0) {
+            return -$importoUtente;
+        }
+        if ($importoEtichetta != 0.0) {
+            return -($importoEtichetta * $quota);
+        }
+        return -($importoTotale - ($importoTotale * $quota));
+    }
+
+    if ($importoUtente != 0.0) {
+        return $importoUtente;
+    }
+    if ($importoEtichetta != 0.0) {
+        return $importoEtichetta * $quota;
+    }
+    return $importoTotale * $quota;
+}
+
 function get_saldo_e_movimenti_utente($idUtente)
-{ 
+{
     global $conn;
     $loggedUserId = $_SESSION['utente_id'] ?? 0;
     $famigliaId   = $_SESSION['id_famiglia_gestione'] ?? 0;


### PR DESCRIPTION
## Summary
- Aggiunge funzione `calcola_importo_quota` per calcolare l'importo per utente in base alle quote
- Usa `id_utente_operazione` per determinare il pagante nei movimenti etichettati
- Allinea il dettaglio movimento etichetta alla stessa logica di calcolo

## Testing
- `php -l includes/etichette_utils.php`
- `php -l includes/render_movimento_etichetta.php`
- `php -l etichetta_dettaglio_movimento.php`
- `php -l etichetta.php`


------
https://chatgpt.com/codex/tasks/task_e_68971717f1cc83319bb63f67c8d8d707