### PR TITLE
Show active users by default with toggle for inactive

### DIFF
--- a/ajax/gestione_utenti.php
+++ b/ajax/gestione_utenti.php
@@ -10,6 +10,7 @@ switch ($action) {
         $search = $_GET['search'] ?? ($_GET['username'] ?? '');
         $userlevelid = $_GET['userlevelid'] ?? '';
         $id_famiglia = $_GET['id_famiglia'] ?? '';
+        $showInactive = $_GET['showInactive'] ?? '';
         $sql = "SELECT u.id, u.username, u.nome, u.cognome, u.soprannome, u.email, u.id_famiglia_attuale, u.id_famiglia_gestione, u.attivo, u.userlevelid,
                        u.passcode_locked_until,
                        ul.userlevelname, f.nome_famiglia AS famiglia_attuale,
@@ -28,6 +29,9 @@ switch ($action) {
             $wild = "%$search%";
             $params[] = $wild; $params[] = $wild; $params[] = $wild; $params[] = $wild;
             $types .= 'ssss';
+        }
+        if ($search === '' && $showInactive !== '1') {
+            $sql .= " AND u.attivo = 1";
         }
         if ($userlevelid !== '') { $sql .= " AND u.userlevelid = ?"; $params[] = $userlevelid; $types .= 'i'; }
         if ($id_famiglia !== '') {

--- a/gestione_utenti.php
+++ b/gestione_utenti.php
@@ -64,6 +64,12 @@ include 'includes/header.php';
       <?php endwhile; ?>
     </select>
   </div>
+  <div class="col-12 col-md-auto d-flex align-items-center">
+    <div class="form-check form-switch text-nowrap">
+      <input class="form-check-input" type="checkbox" id="showInactive">
+      <label class="form-check-label" for="showInactive">Mostra disattivati</label>
+    </div>
+  </div>
 </div>
 <div id="userList"></div>
 <div class="modal fade" id="familiesModal" tabindex="-1" aria-hidden="true">

--- a/js/gestione_utenti.js
+++ b/js/gestione_utenti.js
@@ -3,6 +3,7 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
     const searchInput = document.getElementById('search');
     const userlevelFilter = document.getElementById('userlevelFilter');
     const familyFilter = document.getElementById('familyFilter');
+    const showInactive = document.getElementById('showInactive');
     const addBtn = document.getElementById('addBtn');
     const familiesModalEl = document.getElementById('familiesModal');
     const familiesList = document.getElementById('familiesList');
@@ -20,13 +21,16 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
         params.append('search', searchInput.value);
         params.append('userlevelid', userlevelFilter.value);
         params.append('id_famiglia', familyFilter.value);
+        params.append('showInactive', showInactive.checked ? '1' : '0');
         fetch('ajax/gestione_utenti.php?' + params.toString())
             .then(r => r.json())
             .then(data => { rows = data; render(); });
     }
     function render() {
         list.innerHTML = '';
+        const showAll = showInactive.checked || searchInput.value.trim() !== '';
         rows.forEach(r => {
+            if (!showAll && !r.attivo) return;
             const card = document.createElement('div');
             card.className = 'movement user-card d-flex justify-content-between align-items-start text-white mb-2';
 
@@ -56,6 +60,9 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
                 unlockBtn.disabled = true;
                 actions.appendChild(unlockBtn);
             }
+            const statusIcon = document.createElement('i');
+            statusIcon.className = r.attivo ? 'bi bi-check-circle-fill text-success' : 'bi bi-x-circle-fill text-danger';
+            actions.appendChild(statusIcon);
             card.appendChild(actions);
 
             if (canUpdate) {
@@ -115,5 +122,6 @@ function initUserManager(table, formColumns, primaryKey, lookups, boolCols = [],
     searchInput.addEventListener('input', load);
     userlevelFilter.addEventListener('change', load);
     familyFilter.addEventListener('change', load);
+    showInactive.addEventListener('input', load);
     load();
 }


### PR DESCRIPTION
## Summary
- default user list to only active users with optional checkbox to include deactivated accounts
- add active/inactive status icons and JS filtering logic
- support optional backend filtering with search across all users

## Testing
- `php -l gestione_utenti.php`
- `php -l ajax/gestione_utenti.php`
- `node --check js/gestione_utenti.js && echo 'JS OK'`


------
https://chatgpt.com/codex/tasks/task_e_68974c4ae0a48331b0f0413a58a6758e