### PR TITLE
Consenti modifica etichetta dal dettaglio movimento

### DIFF
--- a/ajax/update_e2o.php
+++ b/ajax/update_e2o.php
@@ -24,6 +24,8 @@ if (!$info) {
     exit;
 }
 
+$id_etichetta = intval($_POST['id_etichetta'] ?? $info['id_etichetta']);
+
 $allegato = $info['allegato'];
 if (!empty($_FILES['allegato']['name'])) {
     $dir = __DIR__ . '/../uploads';
@@ -37,9 +39,9 @@ if (!empty($_FILES['allegato']['name'])) {
     }
 }
 
-$sql = "UPDATE bilancio_etichette2operazioni SET descrizione_extra = ?, importo = ?, allegato = ? WHERE id_e2o = ?";
+$sql = "UPDATE bilancio_etichette2operazioni SET id_etichetta = ?, descrizione_extra = ?, importo = ?, allegato = ? WHERE id_e2o = ?";
 $stmtU = $conn->prepare($sql);
-$stmtU->bind_param('sdsi', $descrizione_extra, $importo, $allegato, $id_e2o);
+$stmtU->bind_param('isdsi', $id_etichetta, $descrizione_extra, $importo, $allegato, $id_e2o);
 $success = $stmtU->execute();
 $stmtU->close();
 
@@ -70,7 +72,7 @@ if ($success) {
 
 if ($mov) {
     ob_start();
-    render_movimento_etichetta($mov, (int)$info['id_etichetta']);
+    render_movimento_etichetta($mov, (int)$id_etichetta);
     $html = ob_get_clean();
     echo json_encode(['success' => true, 'html' => $html, 'rowId' => 'mov-' . $mov['tabella'] . '-' . $mov['id']]);
 } else {

--- a/etichetta_dettaglio_movimento.php
+++ b/etichetta_dettaglio_movimento.php
@@ -74,6 +74,10 @@ $resUt = $stmtUt->get_result();
 $listaUtenti = $resUt->fetch_all(MYSQLI_ASSOC);
 $stmtUt->close();
 
+// Lista etichette per la select del modal
+$resEt = $conn->query('SELECT id_etichetta, descrizione FROM bilancio_etichette ORDER BY descrizione');
+$listaEtichette = $resEt ? $resEt->fetch_all(MYSQLI_ASSOC) : [];
+
 /*
 $count = count($u2oRows) ?: 1;
 foreach ($u2oRows as &$r) {
@@ -139,6 +143,14 @@ $dataOra = date('d/m/Y H:i', strtotime($mov['data_operazione']));
         <div class="mb-3">
           <label class="form-label">Importo</label>
           <input type="number" step="0.01" name="importo" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Etichetta</label>
+          <select name="id_etichetta" class="form-select bg-secondary text-white">
+            <?php foreach ($listaEtichette as $et): ?>
+              <option value="<?= (int)$et['id_etichetta'] ?>" <?= (int)$et['id_etichetta'] === (int)$e2o['id_etichetta'] ? 'selected' : '' ?>><?= htmlspecialchars($et['descrizione']) ?></option>
+            <?php endforeach; ?>
+          </select>
         </div>
         <div class="mb-3">
           <label class="form-label">Allegato</label>

--- a/js/etichetta_dettaglio_movimento.js
+++ b/js/etichetta_dettaglio_movimento.js
@@ -2,6 +2,7 @@ function openE2oModal(){
   const form = document.getElementById('editE2oForm');
   form.descrizione_extra.value = e2oData.descrizione_extra || '';
   form.importo.value = e2oData.importo !== null ? e2oData.importo : '';
+  form.id_etichetta.value = e2oData.id_etichetta || '';
   new bootstrap.Modal(document.getElementById('editE2oModal')).show();
 }
 


### PR DESCRIPTION
## Summary
- Permette di cambiare l'etichetta associata a un movimento direttamente dal modal di modifica
- Aggiorna lo script di salvataggio per gestire il nuovo campo `id_etichetta`
- Imposta il valore dell'etichetta corrente quando si apre il modal

## Testing
- `php -l etichetta_dettaglio_movimento.php`
- `php -l ajax/update_e2o.php`


------
https://chatgpt.com/codex/tasks/task_e_68974e9bcee4833190e2c1698d0643fe