### PR TITLE
Use mysqli prepared statements in upload_movimenti

### DIFF
--- a/upload_movimenti.php
+++ b/upload_movimenti.php
@@ -15,130 +15,102 @@ if ($_FILES && is_uploaded_file($_FILES['fileToUpload']['tmp_name'])) {
         // Leggere e ignorare l'intestazione
         fgetcsv($handle, 1000, ",");
 
-        $tabella = "movimenti_revolut";
-        $query_testata =
-        "INSERT INTO
-            `movimenti_revolut`
-        (
-            `id_gruppo_transazione`,
-            `id_salvadanaio`,
-            `type`,
-            `product`,
-
-            `started_date`,
-            `completed_date`,
-            `description`,
-
-            `amount`,
-            `note`)
-        VALUE ";
-
+        $tabella = 'movimenti_revolut';
         $nuove_descrizioni_inserite = 0;
-        $inserita                   = 0;
+        $inserita = 0;
 
-        while (($data = fgetcsv($handle, 1000, ",")) !== FALSE) {
-            $id_etichetta       = 0;
-            $id_gruppo          = null;
-            $id_salvadanaio     = NULL;
-            $type               = $data[0];
-            $descrizione        = $data[4];
+        $stmtInsert = $conn->prepare(
+            "INSERT INTO movimenti_revolut (
+                id_gruppo_transazione,
+                id_salvadanaio,
+                type,
+                product,
+                started_date,
+                completed_date,
+                description,
+                amount,
+                note
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        );
 
-            if ($type == "TRANSFER") {
-                $descrizione_importazione = str_replace("To EUR", "", $descrizione);
+        while (($data = fgetcsv($handle, 1000, ",")) !== false) {
+            $id_etichetta   = 0;
+            $id_gruppo      = null;
+            $id_salvadanaio = null;
+            $type           = $data[0];
+            $product        = $data[1];
+            $started_date   = $data[2];
+            $descrizione    = $data[4];
+            $amount         = $data[5];
+            $note           = null;
+            $nome           = null;
+
+            if ($type == 'TRANSFER') {
+                $descrizione_importazione = str_replace('To EUR', '', $descrizione);
                 $descrizione_importazione = trim($descrizione_importazione);
 
-                $SQL =
-                "SELECT
-                    `id_mov2salv`,
-                    `id_salvadanaio`,
-                    `descrizione_importazione`,
-                    `inserita_il`,
-                    `aggiornata_il`
-                FROM
-                    `movimenti_revolut2salvadanaio_importazione`
-                WHERE
-                    `descrizione_importazione` = ".QuotedValue($descrizione_importazione, DATATYPE_STRING);
-
-                $ar_salvadanai = ExecuteRow($SQL);
+                $stmt = $conn->prepare(
+                    'SELECT id_mov2salv, id_salvadanaio, descrizione_importazione, inserita_il, aggiornata_il
+                     FROM movimenti_revolut2salvadanaio_importazione
+                     WHERE descrizione_importazione = ?'
+                );
+                $stmt->bind_param('s', $descrizione_importazione);
+                $stmt->execute();
+                $ar_salvadanai = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
 
                 if ($ar_salvadanai) {
                     $id_salvadanaio = $ar_salvadanai['id_salvadanaio'];
                 } else {
-                    $SQL =
-                    "INSERT INTO
-                        `salvadanai`
-                    (
-                        `nome_salvadanaio`)
-                    VALUE (
-                        ".QuotedValue($descrizione_importazione, DATATYPE_STRING)." );";
+                    $stmtIns = $conn->prepare(
+                        'INSERT INTO salvadanai (nome_salvadanaio) VALUES (?)'
+                    );
+                    $stmtIns->bind_param('s', $descrizione_importazione);
+                    $stmtIns->execute();
+                    $id_salvadanaio = $conn->insert_id;
+                    $stmtIns->close();
 
-                    Execute($SQL);
-
-                    $conn = GetConnection();
-                    $id_salvadanaio = $conn->Insert_ID();
-
-                    $SQL =
-                    "INSERT INTO
-                        `movimenti_revolut2salvadanaio_importazione`
-                    (
-                        `id_salvadanaio`,
-                        `descrizione_importazione`)
-                    VALUE (
-                        ".QuotedValue($id_salvadanaio, DATATYPE_STRING).",
-                        ".QuotedValue($descrizione_importazione, DATATYPE_STRING)." );";
-
-                    Execute($SQL);
+                    $stmtIns = $conn->prepare(
+                        'INSERT INTO movimenti_revolut2salvadanaio_importazione (id_salvadanaio, descrizione_importazione) VALUES (?, ?)'
+                    );
+                    $stmtIns->bind_param('is', $id_salvadanaio, $descrizione_importazione);
+                    $stmtIns->execute();
+                    $stmtIns->close();
                     $nuove_descrizioni_inserite++;
                 }
             }
 
-            if ($data[3] != "") {
-                $data_completed = $data[3];
-            } else {
-                $data_completed = null;
-            }
+            $data_completed = $data[3] !== '' ? $data[3] : null;
 
-            $SQL =
-            "SELECT
-                `id_d2id`,
-                `id_utente`,
-                `id_gruppo_transazione`,
-                `id_metodo_pagamento`,
-                `id_etichetta`
-            FROM
-                `bilancio_descrizione2id`
-            WHERE
-                conto = 'revolut' AND
-                (
-                ".QuotedValue($descrizione, DATATYPE_STRING)." LIKE CONCAT('%', descrizione, '%') OR
-                ".QuotedValue($nome, DATATYPE_STRING)." LIKE CONCAT('%', descrizione, '%')
-            )";
-
-            $dati_gruppo = ExecuteRow($SQL);
+            $stmt = $conn->prepare(
+                "SELECT id_d2id, id_utente, id_gruppo_transazione, id_metodo_pagamento, id_etichetta
+                 FROM bilancio_descrizione2id
+                 WHERE conto = 'revolut' AND (? LIKE CONCAT('%', descrizione, '%') OR ? LIKE CONCAT('%', descrizione, '%'))"
+            );
+            $stmt->bind_param('ss', $descrizione, $nome);
+            $stmt->execute();
+            $dati_gruppo = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
 
             if ($dati_gruppo) {
-                $id_gruppo      = $dati_gruppo['id_gruppo_transazione'];
-                $id_etichetta   = $dati_gruppo['id_etichetta'];
+                $id_gruppo    = $dati_gruppo['id_gruppo_transazione'];
+                $id_etichetta = $dati_gruppo['id_etichetta'];
             }
 
-            $query =
-            $query_testata.
-            "(
-            ".QuotedValue($id_gruppo, DATATYPE_NUMBER).",
-            ".QuotedValue($id_salvadanaio, DATATYPE_NUMBER).",
-            ".QuotedValue($type, DATATYPE_STRING).",
-            ".QuotedValue($data[1], DATATYPE_STRING).",
-
-            ".QuotedValue($data[2], DATATYPE_DATE).",
-            ".QuotedValue($data_completed, DATATYPE_DATE).",
-            ".QuotedValue($descrizione, DATATYPE_STRING).",
-
-            ".QuotedValue($data[5], DATATYPE_NUMBER).",
-            NULL);";
-
-            Execute($query);
-            $conn = GetConnection();
-            $id_tabella = $conn->Insert_ID();
+            $stmtInsert->bind_param(
+                'iisssssds',
+                $id_gruppo,
+                $id_salvadanaio,
+                $type,
+                $product,
+                $started_date,
+                $data_completed,
+                $descrizione,
+                $amount,
+                $note
+            );
+            $stmtInsert->execute();
+            $id_tabella = $conn->insert_id;
 
             if ($id_etichetta > 0) {
                 dividi_operazione_per_etichetta($id_etichetta, $tabella, $id_tabella);
@@ -147,15 +119,14 @@ if ($_FILES && is_uploaded_file($_FILES['fileToUpload']['tmp_name'])) {
             $inserita++;
         }
 
+        $stmtInsert->close();
         fclose($handle);
 
-        echo
-        "<div class='alert alert-success'>Inserite ".$inserita." righe</div><br>".
-        "<a class='btn btn-primary btn-sm ml-2' href='index.php'>Torna alla lista</a>";
+        echo "<div class='alert alert-success'>Inserite " . $inserita . " righe</div><br>" .
+            "<a class='btn btn-primary btn-sm ml-2' href='index.php'>Torna alla lista</a>";
 
         if ($nuove_descrizioni_inserite > 0) {
-            echo
-            "<div class='alert alert-warning mt-4'>Sono state inserite ".$nuove_descrizioni_inserite." Nuove descrizioni.</div>";
+            echo "<div class='alert alert-warning mt-4'>Sono state inserite " . $nuove_descrizioni_inserite . " Nuove descrizioni.</div>";
         }
     } else {
         // Importazione bilancio entrate/uscite
@@ -165,11 +136,18 @@ if ($_FILES && is_uploaded_file($_FILES['fileToUpload']['tmp_name'])) {
         $tot_righe  = 0;
         $inserita   = 0;
 
-        while (($data = fgetcsv($handle, 1000, ";")) !== FALSE) {
+        $stmtInsertUscite = $conn->prepare(
+            'INSERT INTO bilancio_uscite (id_utente, id_tipologia, id_gruppo_transazione, id_metodo_pagamento, descrizione_operazione, importo, data_operazione) VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
+        $stmtInsertEntrate = $conn->prepare(
+            'INSERT INTO bilancio_entrate (id_utente, id_tipologia, id_gruppo_transazione, id_metodo_pagamento, descrizione_operazione, importo, data_operazione) VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
 
-            $id_tipologia           = NULL;
-            $id_gruppo_transazione  = NULL;
-            $id_metodo_pagamento    = NULL;
+        while (($data = fgetcsv($handle, 1000, ";")) !== false) {
+
+            $id_tipologia           = null;
+            $id_gruppo_transazione  = null;
+            $id_metodo_pagamento    = null;
             $id_etichetta           = 0;
 
             $data_operazione    = $data[0];
@@ -178,93 +156,70 @@ if ($_FILES && is_uploaded_file($_FILES['fileToUpload']['tmp_name'])) {
             $descrizione        = $data[3];
             $importo            = $data[4];
 
-
-            $SQLtipologia =
-            "SELECT
-                id_tipologia
-            FROM
-                bilancio_tipologie
-            WHERE
-                nome_tipologia = ".QuotedValue($causale, DATATYPE_STRING);
-
-            $id_tipologia = ExecuteScalar($SQLtipologia);
+            $stmt = $conn->prepare('SELECT id_tipologia FROM bilancio_tipologie WHERE nome_tipologia = ?');
+            $stmt->bind_param('s', $causale);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            $id_tipologia = $row['id_tipologia'] ?? null;
 
             if (!$id_tipologia) {
-                $SQltipo =
-                "INSERT INTO
-                  `bilancio_tipologie`
-                (
-                  `nome_tipologia`)
-                VALUE (
-                  ".QuotedValue($causale, DATATYPE_STRING)." );";
-
-                $conn = GetConnection();
-
-                Execute($SQltipo);
-
-                $id_tipologia = $conn->Insert_ID();
+                $stmt = $conn->prepare('INSERT INTO bilancio_tipologie (nome_tipologia) VALUES (?)');
+                $stmt->bind_param('s', $causale);
+                $stmt->execute();
+                $id_tipologia = $conn->insert_id;
+                $stmt->close();
             }
 
             list($giorno, $mese, $anno) = explode('/', $data_operazione);
             $data_operazione_db = $anno . '-' . $mese . '-' . $giorno;
 
-            $importo = str_replace(".", "", $importo);
-            $importo = str_replace(",", ".", $importo);
+            $importo = str_replace('.', '', $importo);
+            $importo = str_replace(',', '.', $importo);
             $importo = trim($importo, "'");
 
             if ($importo < 0) {
-                $tabella = "bilancio_uscite";
+                $tabella = 'bilancio_uscite';
             } else {
-                $tabella = "bilancio_entrate";
+                $tabella = 'bilancio_entrate';
             }
 
-            $SQLdescrizione =
-            "SELECT
-                    *
-            FROM
-                    `bilancio_descrizione2id`
-            WHERE
-                id_utente = ".QuotedValue(CurrentUserID(), DATATYPE_NUMBER)." AND
-                ".QuotedValue($descrizione, DATATYPE_STRING)." LIKE CONCAT('%', descrizione, '%')
-            ORDER BY
-                id_d2id DESC";
-
-            $descrizione_gruppo_metodo = ExecuteRow($SQLdescrizione);
+            $stmt = $conn->prepare(
+                'SELECT * FROM bilancio_descrizione2id WHERE id_utente = ? AND ? LIKE CONCAT("%", descrizione, "%") ORDER BY id_d2id DESC'
+            );
+            $idUtenteSession = $_SESSION['utente_id'];
+            $stmt->bind_param('is', $idUtenteSession, $descrizione);
+            $stmt->execute();
+            $descrizione_gruppo_metodo = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
 
             if ($descrizione_gruppo_metodo) {
               $id_gruppo_transazione    = $descrizione_gruppo_metodo['id_gruppo_transazione'];
               $id_metodo_pagamento      = $descrizione_gruppo_metodo['id_metodo_pagamento'];
               $id_etichetta             = $descrizione_gruppo_metodo['id_etichetta'];
             } else {
-                echo
-                "<div class='alert alert-warning' >Senza gruppo o metodo:<br>".$descrizione."</div>";
+                echo "<div class='alert alert-warning' >Senza gruppo o metodo:<br>" . $descrizione . "</div>";
             }
 
-            $SQL =
-            "INSERT INTO
-              `".$tabella."`
-            (
-              `id_utente`,
-              `id_tipologia`,
-              `id_gruppo_transazione`,
-              `id_metodo_pagamento`,
-              `descrizione_operazione`,
-              `importo`,
-              `data_operazione`)
-            VALUE (
-              ".CurrentUserID().",
-              ".QuotedValue($id_tipologia, DATATYPE_NUMBER).",
-              ".QuotedValue($id_gruppo_transazione, DATATYPE_NUMBER).",
-              ".QuotedValue($id_metodo_pagamento, DATATYPE_NUMBER).",
-              ".QuotedValue($descrizione, DATATYPE_STRING).",
-              ".QuotedValue($importo, DATATYPE_NUMBER).",
-              ".QuotedValue($data_operazione_db, DATATYPE_DATE)." );";
+            if ($tabella === 'bilancio_uscite') {
+                $stmtIns = $stmtInsertUscite;
+            } else {
+                $stmtIns = $stmtInsertEntrate;
+            }
 
-            Execute($SQL);
+            $stmtIns->bind_param(
+                'iiiisds',
+                $idUtenteSession,
+                $id_tipologia,
+                $id_gruppo_transazione,
+                $id_metodo_pagamento,
+                $descrizione,
+                $importo,
+                $data_operazione_db
+            );
+            $stmtIns->execute();
 
-            $conn = GetConnection();
-
-            $id_tabella = $conn->Insert_ID();
+            $id_tabella = $conn->insert_id;
 
             if ($id_tabella > 0) {
                 $inserita++;
@@ -272,17 +227,18 @@ if ($_FILES && is_uploaded_file($_FILES['fileToUpload']['tmp_name'])) {
                     dividi_operazione_per_etichetta($id_etichetta, $tabella, $id_tabella);
                 }
             } else {
-                echo "<div class='alert alert-danger'>Riga non inserita. Errore:<br>".nl2br($SQL)."</div>";
+                echo "<div class='alert alert-danger'>Riga non inserita. Errore:<br>" . $stmtIns->error . "</div>";
             }
 
             $tot_righe++;
         }
 
+        $stmtInsertUscite->close();
+        $stmtInsertEntrate->close();
         fclose($handle);
 
-        echo
-        "<div class='alert alert-success'>Inserite ".$inserita." righe su ".$tot_righe."</div><br>".
-        "<a class='btn btn-primary btn-sm ml-2' href='index.php'>Torna alla lista</a>";
+        echo "<div class='alert alert-success'>Inserite " . $inserita . " righe su " . $tot_righe . "</div><br>" .
+            "<a class='btn btn-primary btn-sm ml-2' href='index.php'>Torna alla lista</a>";
     }
 } else {
 ?>
@@ -299,56 +255,40 @@ if ($_FILES && is_uploaded_file($_FILES['fileToUpload']['tmp_name'])) {
 }
 
 
-function dividi_operazione_per_etichetta($id_etichetta,$tabella,$id_tabella)
+function dividi_operazione_per_etichetta($id_etichetta, $tabella, $id_tabella)
 {
-    $conn = GetConnection();
-    
-    $SQL =
-    "INSERT INTO
-        `bilancio_etichette2operazioni`
-    (
-        `id_etichetta`,
-        `tabella_operazione`,
-        `id_tabella`)
-    VALUE (
-        ".QuotedValue($id_etichetta,DATATYPE_NUMBER).",
-        ".QuotedValue($tabella,DATATYPE_STRING).",
-        ".QuotedValue($id_tabella,DATATYPE_NUMBER).")";
+    global $conn;
 
-		Execute ($SQL);
+    $stmt = $conn->prepare(
+        'INSERT INTO bilancio_etichette2operazioni (id_etichetta, tabella_operazione, id_tabella) VALUES (?, ?, ?)'
+    );
+    $stmt->bind_param('isi', $id_etichetta, $tabella, $id_tabella);
+    $stmt->execute();
+    $id_e2o = $conn->insert_id;
+    $stmt->close();
 
-    $id_e2o = $conn->Insert_ID();
+    $stmt = $conn->prepare(
+        "SELECT utenti_tra_cui_dividere FROM bilancio_etichette WHERE ifnull(utenti_tra_cui_dividere,'')!='' AND id_etichetta = ?"
+    );
+    $stmt->bind_param('i', $id_etichetta);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
 
-    $SQLs =
-    "SELECT
-        `utenti_tra_cui_dividere`
-    FROM
-        `bilancio_etichette`
-    WHERE
-        ifnull(`utenti_tra_cui_dividere`,'')!='' AND
-        `id_etichetta` = ".QuotedValue($id_etichetta,DATATYPE_NUMBER);
+    $utenti_dividere = $row['utenti_tra_cui_dividere'] ?? null;
 
-    $utenti_dividere = ExecuteScalar($SQLs);
-
-    if($utenti_dividere)
-    {
-        $ar_utenti = explode(",",$utenti_dividere);
-
-        foreach($ar_utenti as $id_utente)
-        {
-            $SQL =
-            "INSERT INTO
-                `bilancio_utenti2operazioni_etichettate`
-            (
-                `id_utente`,
-                `id_e2o`)
-            VALUE (
-                ".QuotedValue($id_utente,DATATYPE_NUMBER).",
-                ".QuotedValue($id_e2o,DATATYPE_NUMBER).")";
-
-            Execute($SQL);
+    if ($utenti_dividere) {
+        $ar_utenti = explode(',', $utenti_dividere);
+        $stmtIns = $conn->prepare(
+            'INSERT INTO bilancio_utenti2operazioni_etichettate (id_utente, id_e2o) VALUES (?, ?)'
+        );
+        foreach ($ar_utenti as $id_utente) {
+            $stmtIns->bind_param('ii', $id_utente, $id_e2o);
+            $stmtIns->execute();
         }
+        $stmtIns->close();
     }
 }
 
 include 'includes/footer.php';
+


### PR DESCRIPTION
## Summary
- Refactor `upload_movimenti.php` to use mysqli prepared statements instead of legacy helpers
- Apply prepared statements for Revolut imports and bilancio records
- Update `dividi_operazione_per_etichetta` to insert and select with bound parameters

## Testing
- `php -l upload_movimenti.php`


------
https://chatgpt.com/codex/tasks/task_e_6897652d7d148331a8c6c64dbcfeb10d