### PR TITLE
Add modal for new tagliando

### DIFF
--- a/ajax/add_tagliando.php
+++ b/ajax/add_tagliando.php
@@ -1,0 +1,34 @@
+<?php
+include '../includes/session_check.php';
+include '../includes/db.php';
+header('Content-Type: application/json');
+
+$idUtente = $_SESSION['utente_id'] ?? ($_SESSION['id_utente'] ?? 0);
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+
+$idMezzo = (int)($_POST['id_mezzo'] ?? 0);
+$nome = $_POST['nome_tagliando'] ?? '';
+$mesiImm = (int)($_POST['mesi_da_immatricolazione'] ?? 0);
+$mesiPrec = (int)($_POST['mesi_da_precedente_tagliando'] ?? 0);
+$maxKm = (int)($_POST['massimo_km_tagliando'] ?? 0);
+$freqMesi = (int)($_POST['frequenza_mesi'] ?? 0);
+$freqKm = (int)($_POST['frequenza_km'] ?? 0);
+
+$stmt = $conn->prepare("SELECT id_utente FROM mezzi WHERE id_mezzo=? AND id_famiglia=?");
+$stmt->bind_param('ii', $idMezzo, $idFamiglia);
+$stmt->execute();
+$res = $stmt->get_result();
+$row = $res->fetch_assoc();
+$stmt->close();
+
+if (!$row || (int)$row['id_utente'] !== $idUtente) {
+    echo json_encode(['success' => false, 'error' => 'Operazione non autorizzata']);
+    exit;
+}
+
+$stmt = $conn->prepare("INSERT INTO mezzi_tagliandi (id_mezzo, id_famiglia, id_utente, mesi_da_immatricolazione, mesi_da_precedente_tagliando, massimo_km_tagliando, frequenza_mesi, frequenza_km, nome_tagliando) VALUES (?,?,?,?,?,?,?,?,?)");
+$stmt->bind_param('iiiiiiiis', $idMezzo, $idFamiglia, $idUtente, $mesiImm, $mesiPrec, $maxKm, $freqMesi, $freqKm, $nome);
+$ok = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $ok]);

--- a/js/mezzo_dettaglio.js
+++ b/js/mezzo_dettaglio.js
@@ -32,6 +32,21 @@ document.getElementById('chilometroForm')?.addEventListener('submit', function(e
     .then(res=>{ if(res.success) location.reload(); });
 });
 
+function openTagliandoModal(){
+  const form = document.getElementById('tagliandoForm');
+  form?.reset();
+  new bootstrap.Modal(document.getElementById('tagliandoModal')).show();
+}
+
+document.getElementById('tagliandoForm')?.addEventListener('submit', function(e){
+  e.preventDefault();
+  const fd = new FormData(this);
+  fd.append('id_mezzo', mezzoData.id);
+  fetch('ajax/add_tagliando.php', {method:'POST', body:fd})
+    .then(r=>r.json())
+    .then(res=>{ if(res.success) location.reload(); });
+});
+
 function editChilometro(el){
   openChilometroModal({id:el.dataset.id, data:el.dataset.data, km:el.dataset.km});
 }

--- a/mezzo_dettaglio.php
+++ b/mezzo_dettaglio.php
@@ -103,7 +103,7 @@ if ($id > 0): ?>
   <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
     <h5 class="mb-0">Tagliandi</h5>
     <?php if ($isOwner): ?>
-      <a href="mezzo_dettaglio_tagliando.php?mezzo=<?= (int)$data['id_mezzo'] ?>" class="btn btn-outline-light btn-sm">Aggiungi</a>
+      <button class="btn btn-outline-light btn-sm" onclick="openTagliandoModal()">Aggiungi</button>
     <?php endif; ?>
   </div>
   <div id="tagliandiList">
@@ -180,6 +180,47 @@ if ($id > 0): ?>
         <div class="mb-3">
           <label class="form-label">Chilometri</label>
           <input type="number" name="chilometri" class="form-control bg-secondary text-white" required>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- Modal tagliando -->
+<div class="modal fade" id="tagliandoModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="tagliandoForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Nuovo tagliando</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Nome tagliando</label>
+          <input type="text" name="nome_tagliando" class="form-control bg-secondary text-white" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Mesi da immatricolazione</label>
+          <input type="number" name="mesi_da_immatricolazione" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Mesi da precedente tagliando</label>
+          <input type="number" name="mesi_da_precedente_tagliando" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Massimo km tagliando</label>
+          <input type="number" name="massimo_km_tagliando" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Frequenza mesi</label>
+          <input type="number" name="frequenza_mesi" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Frequenza km</label>
+          <input type="number" name="frequenza_km" class="form-control bg-secondary text-white">
         </div>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
## Summary
- allow adding new tagliando directly from mezzo details via modal
- wire up JS handler and backend endpoint to save tagliandi

## Testing
- `php -l mezzo_dettaglio.php`
- `php -l ajax/add_tagliando.php`


------
https://chatgpt.com/codex/tasks/task_e_689863721e808331a26c5b82ea33469d