### PR TITLE
Add database-driven theme support

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,12 +1,12 @@
 body {
   font-family: 'Segoe UI', sans-serif;
-  background-color: #121212;
-  color: #fff;
+  background-color: var(--bg-color);
+  color: var(--text-color);
   margin: 0;
   padding: 0;
 }
 .list-group-item {
-  background-color: #1f1f1f;
+  background-color: var(--primary-color);
   border: none;
   border-radius: 10px;
   margin-bottom: 12px;
@@ -14,7 +14,7 @@ body {
   transition: background-color 0.2s ease;
 }
 .list-group-item:hover {
-  background-color: #2b2b2b;
+  background-color: var(--secondary-color);
   cursor: pointer;
 }
 .badge-etichetta {
@@ -24,7 +24,7 @@ body {
   display: inline-block;
   padding: 4px 8px;
   border-radius: 6px;
-  color: #fff;
+  color: var(--text-color);
   text-decoration: none;
   cursor: pointer;
 }
@@ -36,7 +36,7 @@ body {
   white-space: nowrap;
   position: sticky;
   top: 0;
-  background-color: #121212;
+  background-color: var(--bg-color);
   z-index: 1000;
 }
 .months-scroll::-webkit-scrollbar {
@@ -48,17 +48,17 @@ body {
   flex: 0 0 auto;
 }
 .months-scroll .btn.active {
-  background-color: #fff;
-  border-color: #fff;
-  color: #000;
+  background-color: var(--text-color);
+  border-color: var(--text-color);
+  color: var(--bg-color);
 }
 .day-header {
   font-size: .85rem;
   text-transform: capitalize;
-  color: #fff;
+  color: var(--text-color);
 }
 .movement {
-  background-color: #1f1f1f;
+  background-color: var(--primary-color);
   border: none;
   border-radius: 10px;
   margin-bottom: 10px;
@@ -72,7 +72,7 @@ body {
   overflow: hidden;
 }
 .movement:hover {
-  background-color: #2b2b2b;
+  background-color: var(--secondary-color);
   cursor: pointer;
 }
 .movement .flex-grow-1 {
@@ -89,18 +89,18 @@ body {
   min-width: 80px;
   text-align: right;
   font-weight: 500;
-  color: #fff;
+  color: var(--text-color);
   white-space: nowrap;
 }
 .movement .text-end {
   flex-shrink: 0;
 }
 #search::placeholder {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(var(--text-color-rgb), 0.5);
 }
 #gruppiModal .category-box {
-  background-color: #2c2f33;
-  border: 1px solid rgba(255,255,255,0.15);
+  background-color: var(--primary-color);
+  border: 1px solid rgba(var(--text-color-rgb),0.15);
   border-radius: .5rem;
   padding: 1rem;
   margin-bottom: 1rem;
@@ -112,7 +112,7 @@ body {
   font-size: 1.05rem;
   font-weight: 600;
   margin-bottom: .75rem;
-  border-bottom: 1px solid rgba(255,255,255,0.1);
+  border-bottom: 1px solid rgba(var(--text-color-rgb),0.1);
   padding-bottom: .25rem;
-  color: #fff;
+  color: var(--text-color);
 }

--- a/cambia_tema.php
+++ b/cambia_tema.php
@@ -1,0 +1,9 @@
+<?php
+session_start();
+if (isset($_POST['id_tema'])) {
+    $_SESSION['theme_id'] = (int)$_POST['id_tema'];
+}
+$referer = $_SERVER['HTTP_REFERER'] ?? 'index.php';
+header('Location: ' . $referer);
+exit;
+?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -7,6 +7,7 @@
   <title>Gestione Famiglia 2.0</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/Gestionale25/includes/theme.php">
   <link rel="stylesheet" href="/Gestionale25/assets/style.css">
   <link rel="icon" href="assets/favicon.ico" type="image/x-icon">
 </head>
@@ -45,6 +46,18 @@
         ?>
           <option value="<?= (int)$fam['id_famiglia'] ?>" <?= (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == $fam['id_famiglia']) ? 'selected' : '' ?>><?= htmlspecialchars($fam['nome_famiglia']) ?></option>
         <?php endwhile; $stmt->close(); ?>
+      </select>
+    </form>
+    <form method="post" action="cambia_tema.php" class="mb-3">
+      <select name="id_tema" class="form-select bg-dark text-white border-secondary" onchange="this.form.submit()">
+        <?php
+        $stmtTheme = $conn->prepare('SELECT id, nome FROM temi');
+        $stmtTheme->execute();
+        $resTheme = $stmtTheme->get_result();
+        while ($t = $resTheme->fetch_assoc()):
+        ?>
+          <option value="<?= (int)$t['id'] ?>" <?= (($_SESSION['theme_id'] ?? 1) == $t['id']) ? 'selected' : '' ?>><?= htmlspecialchars($t['nome']) ?></option>
+        <?php endwhile; $stmtTheme->close(); ?>
       </select>
     </form>
     <?php endif; ?>

--- a/includes/theme.php
+++ b/includes/theme.php
@@ -1,0 +1,51 @@
+<?php
+require_once __DIR__ . '/db.php';
+session_start();
+$themeId = $_SESSION['theme_id'] ?? 1;
+$stmt = $conn->prepare('SELECT background_color, text_color, primary_color, secondary_color FROM temi WHERE id = ?');
+$stmt->bind_param('i', $themeId);
+$stmt->execute();
+$theme = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if (!$theme) {
+    $theme = [
+        'background_color' => '#121212',
+        'text_color' => '#ffffff',
+        'primary_color' => '#1f1f1f',
+        'secondary_color' => '#2b2b2b'
+    ];
+}
+$rgb = sscanf($theme['text_color'], "#%02x%02x%02x");
+$textRgb = implode(',', $rgb);
+header('Content-Type: text/css');
+?>
+:root {
+  --bg-color: <?= htmlspecialchars($theme['background_color']) ?>;
+  --text-color: <?= htmlspecialchars($theme['text_color']) ?>;
+  --primary-color: <?= htmlspecialchars($theme['primary_color']) ?>;
+  --secondary-color: <?= htmlspecialchars($theme['secondary_color']) ?>;
+  --text-color-rgb: <?= $textRgb ?>;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.bg-dark {
+  background-color: var(--bg-color) !important;
+}
+
+.text-white {
+  color: var(--text-color) !important;
+}
+
+.btn-outline-light {
+  color: var(--text-color);
+  border-color: var(--text-color);
+}
+
+.btn-outline-light:hover {
+  background-color: var(--text-color);
+  color: var(--bg-color);
+}

--- a/sql/temi.sql
+++ b/sql/temi.sql
@@ -1,0 +1,12 @@
+CREATE TABLE temi (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  nome VARCHAR(50) NOT NULL,
+  background_color VARCHAR(7) NOT NULL,
+  text_color VARCHAR(7) NOT NULL,
+  primary_color VARCHAR(7) NOT NULL,
+  secondary_color VARCHAR(7) NOT NULL
+);
+
+INSERT INTO temi (id, nome, background_color, text_color, primary_color, secondary_color) VALUES
+  (1, 'Scuro', '#121212', '#ffffff', '#1f1f1f', '#2b2b2b'),
+  (2, 'Chiaro', '#ffffff', '#000000', '#f8f9fa', '#e9ecef');


### PR DESCRIPTION
## Summary
- introduce `temi` SQL table for storing color palettes
- load theme colors dynamically and expose them as CSS variables
- update header and stylesheet to switch themes at runtime

## Testing
- `php -l includes/theme.php`
- `php -l includes/header.php`
- `php -l cambia_tema.php`


------
https://chatgpt.com/codex/tasks/task_e_68986fbce4888331a820d1dac7d51ca3