### PR TITLE
Rendi obbligatorie descrizione e data nei movimenti

### DIFF
--- a/aggiungi_uscita.php
+++ b/aggiungi_uscita.php
@@ -1,28 +1,38 @@
 <?php
 include 'includes/session_check.php';
 include 'includes/db.php';
+
+$error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $descrizione = $_POST['descrizione'] ?? '';
-    $descrizione_extra = $_POST['descrizione_extra'] ?? '';
+    $descrizione = trim($_POST['descrizione'] ?? '');
+    $descrizione_extra = trim($_POST['descrizione_extra'] ?? '');
     $importo = $_POST['importo'] ?? 0;
-    $note = $_POST['note'] ?? '';
-    $data_operazione = $_POST['data_operazione'] ?? date('Y-m-d\TH:i');
-    $data_operazione = date('Y-m-d H:i:s', strtotime($data_operazione));
+    $note = trim($_POST['note'] ?? '');
+    $data_operazione = trim($_POST['data_operazione'] ?? '');
 
-    $stmt = $conn->prepare("INSERT INTO bilancio_uscite (id_utente, mezzo, descrizione_operazione, descrizione_extra, importo, note, data_operazione) VALUES (?, 'contanti', ?, ?, ?, ?, ?)");
-    $stmt->bind_param('issdss', $_SESSION['utente_id'], $descrizione, $descrizione_extra, $importo, $note, $data_operazione);
-    $stmt->execute();
-    $id = $conn->insert_id;
-    $stmt->close();
+    if ($descrizione === '' || $data_operazione === '') {
+        $error = "Descrizione e data operazione sono obbligatorie.";
+    } else {
+        $data_operazione = date('Y-m-d H:i:s', strtotime($data_operazione));
+        $note = $note !== '' ? $note : null;
+        $descrizione_extra = $descrizione_extra !== '' ? $descrizione_extra : null;
 
-    header('Location: dettaglio.php?id=' . $id . '&src=bilancio_uscite');
-    exit;
+        $stmt = $conn->prepare("INSERT INTO bilancio_uscite (id_utente, mezzo, descrizione_operazione, descrizione_extra, importo, note, data_operazione) VALUES (?, 'contanti', ?, ?, ?, ?, ?)");
+        $stmt->bind_param('issdss', $_SESSION['utente_id'], $descrizione, $descrizione_extra, $importo, $note, $data_operazione);
+        $stmt->execute();
+        $id = $conn->insert_id;
+        $stmt->close();
+
+        header('Location: dettaglio.php?id=' . $id . '&src=bilancio_uscite');
+        exit;
+    }
 }
 include 'includes/header.php';
 ?>
 
 <div class="container text-white">
   <h4 class="mb-4">Nuova uscita</h4>
+  <?php if ($error): ?><div class="alert alert-danger"><?= $error ?></div><?php endif; ?>
   <form method="post">
     <div class="mb-3">
       <label class="form-label">Descrizione</label>


### PR DESCRIPTION
## Summary
- Valida lato server la presenza di descrizione e data in `aggiungi_entrata.php` e `aggiungi_uscita.php`, mostrando un messaggio di errore quando mancano

## Testing
- `php -l aggiungi_entrata.php`
- `php -l aggiungi_uscita.php`


------
https://chatgpt.com/codex/tasks/task_e_689871085c188331b4d608a93f97b89e