### PR TITLE
Enhance event detail with invite and food management

### DIFF
--- a/ajax/add_e2c.php
+++ b/ajax/add_e2c.php
@@ -1,0 +1,26 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_evento = (int)($_POST['id_evento'] ?? 0);
+$id_cibo = (int)($_POST['id_cibo'] ?? 0);
+$quantita_input = trim($_POST['quantita'] ?? '');
+$quantita = $quantita_input === '' ? null : (float)$quantita_input;
+
+if(!$id_evento || !$id_cibo){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+if($quantita === null){
+    $stmt = $conn->prepare('INSERT INTO eventi_eventi2cibo (id_evento, id_cibo, quantita) VALUES (?,?,NULL)');
+    $stmt->bind_param('ii', $id_evento, $id_cibo);
+} else {
+    $stmt = $conn->prepare('INSERT INTO eventi_eventi2cibo (id_evento, id_cibo, quantita) VALUES (?,?,?)');
+    $stmt->bind_param('iid', $id_evento, $id_cibo, $quantita);
+}
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/ajax/add_e2i.php
+++ b/ajax/add_e2i.php
@@ -1,0 +1,24 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_evento = (int)($_POST['id_evento'] ?? 0);
+$id_invitato = (int)($_POST['id_invitato'] ?? 0);
+$stato = $_POST['stato'] ?? '';
+$note = trim($_POST['note'] ?? '');
+$partecipa = $stato === 'partecipa' ? 1 : 0;
+$forse = $stato === 'forse' ? 1 : 0;
+$assente = $stato === 'assente' ? 1 : 0;
+
+if(!$id_evento || !$id_invitato){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('INSERT INTO eventi_eventi2invitati (id_evento, id_invitato, partecipa, forse, assente, note) VALUES (?,?,?,?,?,?)');
+$stmt->bind_param('iiiiis', $id_evento, $id_invitato, $partecipa, $forse, $assente, $note);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/ajax/update_e2i.php
+++ b/ajax/update_e2i.php
@@ -1,0 +1,23 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_e2i = (int)($_POST['id_e2i'] ?? 0);
+$stato = $_POST['stato'] ?? '';
+$note = trim($_POST['note'] ?? '');
+$partecipa = $stato === 'partecipa' ? 1 : 0;
+$forse = $stato === 'forse' ? 1 : 0;
+$assente = $stato === 'assente' ? 1 : 0;
+
+if(!$id_e2i){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('UPDATE eventi_eventi2invitati SET partecipa=?, forse=?, assente=?, note=? WHERE id_e2i=?');
+$stmt->bind_param('iiisi', $partecipa, $forse, $assente, $note, $id_e2i);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/eventi_dettaglio.php
+++ b/eventi_dettaglio.php
@@ -20,14 +20,26 @@ if (!$evento) {
     exit;
 }
 
+// Invitati già collegati all'evento con stato e note
 $invitati = [];
-$stmtInv = $conn->prepare("SELECT i.nome, i.cognome FROM eventi_eventi2invitati e2i JOIN eventi_invitati i ON e2i.id_invitato = i.id WHERE e2i.id_evento = ? ORDER BY i.cognome, i.nome");
+$stmtInv = $conn->prepare("SELECT e2i.id_e2i, i.nome, i.cognome, e2i.partecipa, e2i.forse, e2i.assente, e2i.note FROM eventi_eventi2invitati e2i JOIN eventi_invitati i ON e2i.id_invitato = i.id WHERE e2i.id_evento = ? ORDER BY i.cognome, i.nome");
 $stmtInv->bind_param('i', $id);
 $stmtInv->execute();
 $resInv = $stmtInv->get_result();
 while ($row = $resInv->fetch_assoc()) { $invitati[] = $row; }
 $stmtInv->close();
 
+// Invitati disponibili per l'aggiunta (solo attivi e collegati alla famiglia)
+$invitatiDisponibili = [];
+$stmtDisp = $conn->prepare("SELECT i.id, i.nome, i.cognome FROM eventi_invitati i JOIN eventi_invitati2famiglie f ON i.id = f.id_invitato JOIN utenti u ON i.id_utente = u.id WHERE f.id_famiglia = ? AND f.attivo = 1 AND u.attivo = 1 AND i.id NOT IN (SELECT id_invitato FROM eventi_eventi2invitati WHERE id_evento = ?) ORDER BY i.cognome, i.nome");
+$famiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+$stmtDisp->bind_param('ii', $famiglia, $id);
+$stmtDisp->execute();
+$resDisp = $stmtDisp->get_result();
+while ($row = $resDisp->fetch_assoc()) { $invitatiDisponibili[] = $row; }
+$stmtDisp->close();
+
+// Cibo collegato all'evento
 $cibi = [];
 $stmtCibo = $conn->prepare("SELECT c.piatto, c.um, e2c.quantita FROM eventi_eventi2cibo e2c JOIN eventi_cibo c ON e2c.id_cibo = c.id WHERE e2c.id_evento = ? ORDER BY c.piatto");
 $stmtCibo->bind_param('i', $id);
@@ -35,6 +47,15 @@ $stmtCibo->execute();
 $resCibo = $stmtCibo->get_result();
 while ($row = $resCibo->fetch_assoc()) { $cibi[] = $row; }
 $stmtCibo->close();
+
+// Cibo disponibile per l'aggiunta
+$ciboDisponibile = [];
+$stmtCd = $conn->prepare("SELECT id, piatto FROM eventi_cibo WHERE id_famiglia = ? AND attivo = 1 ORDER BY piatto");
+$stmtCd->bind_param('i', $famiglia);
+$stmtCd->execute();
+$resCd = $stmtCd->get_result();
+while ($row = $resCd->fetch_assoc()) { $ciboDisponibile[] = $row; }
+$stmtCd->close();
 
 include 'includes/header.php';
 ?>
@@ -55,11 +76,26 @@ include 'includes/header.php';
         <button id="toggleInvitati" class="btn btn-link p-0">Mostra tutti</button>
       <?php endif; ?>
     </div>
+    <button type="button" class="btn btn-outline-light btn-sm" id="addInvitatoBtn">Aggiungi invitato</button>
   </div>
   <ul class="list-group list-group-flush bg-dark" id="invitatiList">
-    <?php foreach ($invitati as $idx => $row): ?>
-      <li class="list-group-item bg-dark text-white <?= $idx >= 3 ? 'd-none extra-row' : '' ?>">
-        <?= htmlspecialchars($row['nome'] . ' ' . $row['cognome']) ?>
+    <?php foreach ($invitati as $idx => $row):
+      $stato = $row['partecipa'] ? 'partecipa' : ($row['forse'] ? 'forse' : ($row['assente'] ? 'assente' : ''));
+      $icon = 'bi-circle';
+      $color = 'text-secondary';
+      if ($stato === 'partecipa') { $icon = 'bi-check-circle'; $color = 'text-success'; }
+      elseif ($stato === 'forse') { $icon = 'bi-question-circle'; $color = 'text-warning'; }
+      elseif ($stato === 'assente') { $icon = 'bi-x-circle'; $color = 'text-danger'; }
+    ?>
+      <li class="list-group-item bg-dark text-white <?= $idx >= 3 ? 'd-none extra-row' : '' ?> inv-row d-flex align-items-center"
+          data-id="<?= (int)$row['id_e2i'] ?>"
+          data-stato="<?= $stato ?>"
+          data-note="<?= htmlspecialchars($row['note'] ?? '', ENT_QUOTES) ?>">
+        <i class="bi <?= $icon ?> me-2 <?= $color ?>"></i>
+        <span class="flex-grow-1"><?= htmlspecialchars($row['nome'] . ' ' . $row['cognome']) ?></span>
+        <?php if (!empty($row['note'])): ?>
+          <small class="ms-2"><?= htmlspecialchars($row['note']) ?></small>
+        <?php endif; ?>
       </li>
     <?php endforeach; ?>
   </ul>
@@ -71,6 +107,7 @@ include 'includes/header.php';
         <button id="toggleCibo" class="btn btn-link p-0">Mostra tutti</button>
       <?php endif; ?>
     </div>
+    <button type="button" class="btn btn-outline-light btn-sm" id="addCiboBtn">Aggiungi cibo</button>
   </div>
   <ul class="list-group list-group-flush bg-dark" id="ciboList">
     <?php foreach ($cibi as $idx => $row): ?>
@@ -80,14 +117,128 @@ include 'includes/header.php';
     <?php endforeach; ?>
   </ul>
 </div>
-<script>
-document.getElementById('toggleInvitati')?.addEventListener('click', function(){
-  document.querySelectorAll('#invitatiList .extra-row').forEach(el=>el.classList.toggle('d-none'));
-  this.textContent = this.textContent === 'Mostra tutti' ? 'Mostra meno' : 'Mostra tutti';
-});
-document.getElementById('toggleCibo')?.addEventListener('click', function(){
-  document.querySelectorAll('#ciboList .extra-row').forEach(el=>el.classList.toggle('d-none'));
-  this.textContent = this.textContent === 'Mostra tutti' ? 'Mostra meno' : 'Mostra tutti';
-});
-</script>
+
+<!-- Modal modifica invitato -->
+<div class="modal fade" id="invitatoModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="invitatoForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Invitato</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" name="id_e2i" id="id_e2i">
+        <div class="mb-3">
+          <label class="form-label">Stato</label>
+          <div>
+            <div class="form-check form-check-inline">
+              <input class="form-check-input" type="radio" name="stato" id="statoPartecipa" value="partecipa">
+              <label class="form-check-label" for="statoPartecipa"><i class="bi bi-check-circle text-success"></i> Partecipa</label>
+            </div>
+            <div class="form-check form-check-inline">
+              <input class="form-check-input" type="radio" name="stato" id="statoForse" value="forse">
+              <label class="form-check-label" for="statoForse"><i class="bi bi-question-circle text-warning"></i> Forse</label>
+            </div>
+            <div class="form-check form-check-inline">
+              <input class="form-check-input" type="radio" name="stato" id="statoAssente" value="assente">
+              <label class="form-check-label" for="statoAssente"><i class="bi bi-x-circle text-danger"></i> Assente</label>
+            </div>
+          </div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Note</label>
+          <textarea name="note" id="note" class="form-control bg-secondary text-white"></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- Modal aggiungi invitato -->
+<div class="modal fade" id="addInvitatoModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="addInvitatoForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Aggiungi invitato</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" name="id_evento" value="<?= (int)$id ?>">
+        <div class="mb-3">
+          <label class="form-label">Invitato</label>
+          <input type="text" id="invSearch" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
+          <select name="id_invitato" id="invSelect" class="form-select bg-secondary text-white">
+            <?php foreach ($invitatiDisponibili as $inv): ?>
+              <option value="<?= (int)$inv['id'] ?>"><?= htmlspecialchars($inv['nome'] . ' ' . $inv['cognome']) ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Stato</label>
+          <div>
+            <div class="form-check form-check-inline">
+              <input class="form-check-input" type="radio" name="stato" id="addStatoPartecipa" value="partecipa" checked>
+              <label class="form-check-label" for="addStatoPartecipa"><i class="bi bi-check-circle text-success"></i> Partecipa</label>
+            </div>
+            <div class="form-check form-check-inline">
+              <input class="form-check-input" type="radio" name="stato" id="addStatoForse" value="forse">
+              <label class="form-check-label" for="addStatoForse"><i class="bi bi-question-circle text-warning"></i> Forse</label>
+            </div>
+            <div class="form-check form-check-inline">
+              <input class="form-check-input" type="radio" name="stato" id="addStatoAssente" value="assente">
+              <label class="form-check-label" for="addStatoAssente"><i class="bi bi-x-circle text-danger"></i> Assente</label>
+            </div>
+          </div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Note</label>
+          <textarea name="note" class="form-control bg-secondary text-white"></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Aggiungi</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- Modal aggiungi cibo -->
+<div class="modal fade" id="addCiboModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="addCiboForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Aggiungi cibo</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" name="id_evento" value="<?= (int)$id ?>">
+        <div class="mb-3">
+          <label class="form-label">Cibo</label>
+          <select name="id_cibo" class="form-select bg-secondary text-white">
+            <?php foreach ($ciboDisponibile as $c): ?>
+              <option value="<?= (int)$c['id'] ?>"><?= htmlspecialchars($c['piatto']) ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Quantità</label>
+          <input type="number" step="0.01" name="quantita" class="form-control bg-secondary text-white">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Aggiungi</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<style>
+#invitatiList .list-group-item,
+#ciboList .list-group-item { padding: 0.25rem 0.5rem; }
+#invitatiList .inv-row { cursor: pointer; }
+</style>
+<script src="js/eventi_dettaglio.js"></script>
 <?php include 'includes/footer.php'; ?>

--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -1,0 +1,67 @@
+// JavaScript for eventi_dettaglio.php
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('toggleInvitati')?.addEventListener('click', function(){
+    document.querySelectorAll('#invitatiList .extra-row').forEach(el=>el.classList.toggle('d-none'));
+    this.textContent = this.textContent === 'Mostra tutti' ? 'Mostra meno' : 'Mostra tutti';
+  });
+  document.getElementById('toggleCibo')?.addEventListener('click', function(){
+    document.querySelectorAll('#ciboList .extra-row').forEach(el=>el.classList.toggle('d-none'));
+    this.textContent = this.textContent === 'Mostra tutti' ? 'Mostra meno' : 'Mostra tutti';
+  });
+
+  // apertura modal modifica invitato
+  document.querySelectorAll('#invitatiList .inv-row').forEach(li => {
+    li.addEventListener('click', () => {
+      const form = document.getElementById('invitatoForm');
+      form.id_e2i.value = li.dataset.id;
+      form.note.value = li.dataset.note || '';
+      const stato = li.dataset.stato;
+      form.querySelectorAll('input[name="stato"]').forEach(r => r.checked = (r.value === stato));
+      new bootstrap.Modal(document.getElementById('invitatoModal')).show();
+    });
+  });
+
+  document.getElementById('invitatoForm')?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    fetch('ajax/update_e2i.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
+  document.getElementById('addInvitatoBtn')?.addEventListener('click', () => {
+    const form = document.getElementById('addInvitatoForm');
+    form.reset();
+    new bootstrap.Modal(document.getElementById('addInvitatoModal')).show();
+  });
+
+  document.getElementById('invSearch')?.addEventListener('input', function(){
+    const q = this.value.toLowerCase();
+    document.querySelectorAll('#invSelect option').forEach(opt => {
+      opt.style.display = opt.text.toLowerCase().includes(q) ? '' : 'none';
+    });
+  });
+
+  document.getElementById('addInvitatoForm')?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    fetch('ajax/add_e2i.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
+  document.getElementById('addCiboBtn')?.addEventListener('click', () => {
+    const form = document.getElementById('addCiboForm');
+    form.reset();
+    new bootstrap.Modal(document.getElementById('addCiboModal')).show();
+  });
+
+  document.getElementById('addCiboForm')?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    fetch('ajax/add_e2c.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+});


### PR DESCRIPTION
## Summary
- Show invitee status icons and notes in event detail with compact rows
- Enable editing invitee status/notes and adding new invitees or food via modals
- Add backend endpoints and JS handlers for invitee and food management

## Testing
- `php -l eventi_dettaglio.php`
- `php -l ajax/update_e2i.php`
- `php -l ajax/add_e2i.php`
- `php -l ajax/add_e2c.php`


------
https://chatgpt.com/codex/tasks/task_e_689879b68b148331abe85a4227453c74