### PR TITLE
Persist user theme preference

### DIFF
--- a/cambia_tema.php
+++ b/cambia_tema.php
@@ -2,6 +2,13 @@
 session_start();
 if (isset($_POST['id_tema'])) {
     $_SESSION['theme_id'] = (int)$_POST['id_tema'];
+    if (isset($_SESSION['utente_id'])) {
+        require_once 'includes/db.php';
+        $stmt = $conn->prepare('UPDATE utenti SET id_tema = ? WHERE id = ?');
+        $stmt->bind_param('ii', $_SESSION['theme_id'], $_SESSION['utente_id']);
+        $stmt->execute();
+        $stmt->close();
+    }
 }
 $referer = $_SERVER['HTTP_REFERER'] ?? 'index.php';
 header('Location: ' . $referer);

--- a/impersonate.php
+++ b/impersonate.php
@@ -17,7 +17,7 @@ if (($adminRow['admin'] ?? 0) != 1) {
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $targetId = (int)($_POST['id_utente'] ?? 0);
-    $stmt = $conn->prepare('SELECT id, nome, id_famiglia_gestione FROM utenti WHERE id = ? LIMIT 1');
+    $stmt = $conn->prepare('SELECT id, nome, id_famiglia_gestione, id_tema FROM utenti WHERE id = ? LIMIT 1');
     $stmt->bind_param('i', $targetId);
     $stmt->execute();
     if ($user = $stmt->get_result()->fetch_assoc()) {
@@ -25,6 +25,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['utente_id'] = $user['id'];
         $_SESSION['utente_nome'] = $user['nome'];
         $_SESSION['id_famiglia_gestione'] = $user['id_famiglia_gestione'] ?? 0;
+        $_SESSION['theme_id'] = (int)($user['id_tema'] ?? 1);
         
         $lvlStmt = $conn->prepare('SELECT userlevelid FROM utenti2famiglie WHERE id_utente = ? AND id_famiglia = ? LIMIT 1');
         $lvlStmt->bind_param('ii', $_SESSION['utente_id'], $_SESSION['id_famiglia_gestione']);

--- a/includes/foreign_keys.php
+++ b/includes/foreign_keys.php
@@ -30,6 +30,11 @@ return [
         'key'   => 'id_famiglia',
         'label' => 'nome_famiglia'
     ],
+    'id_tema' => [
+        'table' => 'temi',
+        'key'   => 'id',
+        'label' => 'nome'
+    ],
     'userlevelid' => [
         'table' => 'userlevels',
         'key'   => 'userlevelid',

--- a/includes/table_config.php
+++ b/includes/table_config.php
@@ -38,7 +38,7 @@ return [
     ],
     'utenti' => [
         'primary_key' => 'id',
-        'columns' => ['id','username','nome','cognome','soprannome','email','id_famiglia_attuale','id_famiglia_gestione','attivo']
+        'columns' => ['id','username','nome','cognome','soprannome','email','id_famiglia_attuale','id_famiglia_gestione','id_tema','attivo']
     ],
     'utenti2famiglie' => [
         'primary_key' => 'id_u2f',

--- a/login_passcode.php
+++ b/login_passcode.php
@@ -26,7 +26,7 @@ $error = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $pass = $_POST['passcode'] ?? '';
-    $sql = 'SELECT id, nome, passcode, id_famiglia_gestione, attivo, passcode_attempts, passcode_locked_until FROM utenti WHERE id = ? LIMIT 1';
+    $sql = 'SELECT id, nome, passcode, id_famiglia_gestione, attivo, passcode_attempts, passcode_locked_until, id_tema FROM utenti WHERE id = ? LIMIT 1';
     $stmt = $conn->prepare($sql);
     $stmt->bind_param('i', $device['id_utente']);
     $stmt->execute();
@@ -60,6 +60,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_SESSION['utente_id'] = $user['id'];
                 $_SESSION['utente_nome'] = $user['nome'];
                 $_SESSION['id_famiglia_gestione'] = $user['id_famiglia_gestione'] ?? 0;
+                $_SESSION['theme_id'] = (int)($user['id_tema'] ?? 1);
 
                 $lvlStmt = $conn->prepare('SELECT userlevelid FROM utenti2famiglie WHERE id_utente = ? AND id_famiglia = ? LIMIT 1');
                 $lvlStmt->bind_param('ii', $_SESSION['utente_id'], $_SESSION['id_famiglia_gestione']);

--- a/sql/add_id_tema_to_utenti.sql
+++ b/sql/add_id_tema_to_utenti.sql
@@ -1,0 +1,6 @@
+ALTER TABLE utenti
+  ADD COLUMN id_tema INT NOT NULL DEFAULT 1 AFTER id_famiglia_gestione;
+
+ALTER TABLE utenti
+  ADD CONSTRAINT fk_utenti_temi FOREIGN KEY (id_tema) REFERENCES temi(id),
+  ADD INDEX idx_id_tema (id_tema);

--- a/stop_impersonate.php
+++ b/stop_impersonate.php
@@ -6,13 +6,14 @@ if (isset($_SESSION['impersonator_id'])) {
     $originalId = (int)$_SESSION['impersonator_id'];
     unset($_SESSION['impersonator_id']);
 
-    $stmt = $conn->prepare('SELECT id, nome, id_famiglia_gestione FROM utenti WHERE id = ? LIMIT 1');
+    $stmt = $conn->prepare('SELECT id, nome, id_famiglia_gestione, id_tema FROM utenti WHERE id = ? LIMIT 1');
     $stmt->bind_param('i', $originalId);
     $stmt->execute();
     if ($user = $stmt->get_result()->fetch_assoc()) {
         $_SESSION['utente_id'] = $user['id'];
         $_SESSION['utente_nome'] = $user['nome'];
         $_SESSION['id_famiglia_gestione'] = $user['id_famiglia_gestione'] ?? 0;
+        $_SESSION['theme_id'] = (int)($user['id_tema'] ?? 1);
     }
     $stmt->close();
 }

--- a/verifica_2fa.php
+++ b/verifica_2fa.php
@@ -35,6 +35,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $lvlRes = $lvlStmt->get_result();
         $_SESSION['userlevelid'] = ($lvlRes->num_rows === 1) ? intval($lvlRes->fetch_assoc()['userlevelid']) : 0;
 
+        $themeStmt = $conn->prepare('SELECT id_tema FROM utenti WHERE id = ?');
+        $themeStmt->bind_param('i', $_SESSION['utente_id']);
+        $themeStmt->execute();
+        $themeRes = $themeStmt->get_result();
+        $_SESSION['theme_id'] = (int)($themeRes->fetch_assoc()['id_tema'] ?? 1);
+        $themeStmt->close();
+
         unset($_SESSION['2fa_user_id'], $_SESSION['2fa_user_nome'], $_SESSION['2fa_attempts'], $_SESSION['2fa_id_famiglia_gestione']);
         header('Location: setup_passcode.php');
         exit;


### PR DESCRIPTION
## Summary
- save selected theme in user table and update session accordingly on change, login, and impersonation
- expose `id_tema` column/foreign key for user management
- add SQL migration to create `id_tema` field on utenti table

## Testing
- `php -l cambia_tema.php`
- `php -l impersonate.php`
- `php -l includes/foreign_keys.php`
- `php -l includes/table_config.php`
- `php -l login_passcode.php`
- `php -l stop_impersonate.php`
- `php -l verifica_2fa.php`


------
https://chatgpt.com/codex/tasks/task_e_6898ac051a0883319df5504962559b76