### PR TITLE
Add shopping list module with AJAX and permissions

### DIFF
--- a/ajax/add_lista_spesa.php
+++ b/ajax/add_lista_spesa.php
@@ -1,0 +1,18 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:add_lista_spesa', 'insert')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$nome = trim($_POST['nome'] ?? '');
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+if ($nome === '' || !$idFamiglia) { echo json_encode(['success'=>false,'error'=>'Dati non validi']); exit; }
+$stmt = $conn->prepare('INSERT INTO lista_spesa (id_famiglia, nome) VALUES (?, ?)');
+$stmt->bind_param('is', $idFamiglia, $nome);
+$ok = $stmt->execute();
+if ($ok) {
+    echo json_encode(['success'=>true, 'id'=>$conn->insert_id]);
+} else {
+    echo json_encode(['success'=>false,'error'=>'Errore durante l\'inserimento']);
+}
+?>

--- a/ajax/get_lista_spesa.php
+++ b/ajax/get_lista_spesa.php
@@ -1,0 +1,14 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:get_lista_spesa', 'view')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+$stmt = $conn->prepare('SELECT id, nome, checked FROM lista_spesa WHERE id_famiglia = ? ORDER BY checked ASC, created_at DESC');
+$stmt->bind_param('i', $idFamiglia);
+$stmt->execute();
+$res = $stmt->get_result();
+$items = $res->fetch_all(MYSQLI_ASSOC);
+echo json_encode(['success'=>true, 'items'=>$items]);
+?>

--- a/ajax/update_lista_spesa.php
+++ b/ajax/update_lista_spesa.php
@@ -1,0 +1,19 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:update_lista_spesa', 'update')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$id = (int)($_POST['id'] ?? 0);
+$checked = isset($_POST['checked']) && $_POST['checked'] == '1' ? 1 : 0;
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+if (!$id || !$idFamiglia) { echo json_encode(['success'=>false,'error'=>'Dati non validi']); exit; }
+$stmt = $conn->prepare('UPDATE lista_spesa SET checked = ?, updated_at = NOW() WHERE id = ? AND id_famiglia = ?');
+$stmt->bind_param('iii', $checked, $id, $idFamiglia);
+$ok = $stmt->execute();
+if ($ok) {
+    echo json_encode(['success'=>true]);
+} else {
+    echo json_encode(['success'=>false,'error'=>'Errore durante l\'aggiornamento']);
+}
+?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -104,6 +104,7 @@
       <?php
         $showUtility = has_permission($conn, 'page:mezzi.php', 'view') ||
                       has_permission($conn, 'page:eventi.php', 'view') ||
+                      has_permission($conn, 'page:lista_spesa.php', 'view') ||
                       has_permission($conn, 'page:storia.php', 'view');
         if ($showUtility):
       ?>
@@ -118,6 +119,9 @@
             <?php endif; ?>
             <?php if (has_permission($conn, 'page:eventi.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/eventi.php"><i class="bi bi-calendar-event me-2 text-white"></i>Eventi</a></li>
+            <?php endif; ?>
+            <?php if (has_permission($conn, 'page:lista_spesa.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/lista_spesa.php"><i class="bi bi-basket me-2 text-white"></i>Lista spesa</a></li>
             <?php endif; ?>
             <?php if (has_permission($conn, 'page:storia.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/storia.php"><i class="bi bi-clock-history me-2 text-white"></i>Storia</a></li>

--- a/includes/render_lista_spesa.php
+++ b/includes/render_lista_spesa.php
@@ -1,0 +1,12 @@
+<?php
+function render_lista_spesa(array $row): void {
+    $id = (int)($row['id'] ?? 0);
+    $nome = htmlspecialchars($row['nome'] ?? '', ENT_QUOTES);
+    $checked = !empty($row['checked']);
+    $line = $checked ? ' text-decoration-line-through' : '';
+    echo '<div class="d-flex justify-content-between align-items-center py-2 border-bottom" data-id="' . $id . '">';
+    echo '  <span class="flex-grow-1' . $line . '">' . $nome . '</span>';
+    echo '  <input type="checkbox" class="form-check-input ms-2" data-id="' . $id . '"' . ($checked ? ' checked' : '') . '>';
+    echo '</div>';
+}
+?>

--- a/js/lista_spesa.js
+++ b/js/lista_spesa.js
@@ -1,0 +1,74 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const list = document.getElementById('listaSpesaList');
+  const form = document.getElementById('listaForm');
+
+  function render(items) {
+    list.innerHTML = '';
+    items.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'd-flex justify-content-between align-items-center py-2 border-bottom';
+      div.dataset.id = item.id;
+      const span = document.createElement('span');
+      span.className = 'flex-grow-1';
+      if (item.checked == 1) { span.classList.add('text-decoration-line-through'); }
+      span.textContent = item.nome;
+      const chk = document.createElement('input');
+      chk.type = 'checkbox';
+      chk.className = 'form-check-input ms-2';
+      chk.dataset.id = item.id;
+      chk.checked = item.checked == 1;
+      div.appendChild(span);
+      div.appendChild(chk);
+      list.appendChild(div);
+    });
+  }
+
+  function refresh() {
+    fetch('ajax/get_lista_spesa.php')
+      .then(r => r.json())
+      .then(res => { if (res.success) { render(res.items); } });
+  }
+
+  form?.addEventListener('submit', e => {
+    e.preventDefault();
+    const fd = new FormData(form);
+    fetch('ajax/add_lista_spesa.php', { method: 'POST', body: fd })
+      .then(r => r.json())
+      .then(res => {
+        if (res.success) {
+          form.reset();
+          const modalEl = document.getElementById('listaModal');
+          if (modalEl) {
+            bootstrap.Modal.getInstance(modalEl)?.hide();
+          }
+          refresh();
+        } else {
+          alert(res.error || 'Errore');
+        }
+      });
+  });
+
+  list.addEventListener('change', e => {
+    if (e.target.matches('input[type="checkbox"][data-id]')) {
+      const id = e.target.dataset.id;
+      const checked = e.target.checked ? 1 : 0;
+      const fd = new FormData();
+      fd.append('id', id);
+      fd.append('checked', checked);
+      fetch('ajax/update_lista_spesa.php', { method: 'POST', body: fd })
+        .then(r => r.json())
+        .then(res => { if (!res.success) { alert(res.error || 'Errore'); } else { refresh(); } });
+    }
+  });
+
+  refresh();
+  setInterval(refresh, 5000);
+});
+
+function openListaModal(){
+  const form = document.getElementById('listaForm');
+  if(form){
+    form.reset();
+    new bootstrap.Modal(document.getElementById('listaModal')).show();
+  }
+}

--- a/lista_spesa.php
+++ b/lista_spesa.php
@@ -1,0 +1,49 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:lista_spesa.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+require_once 'includes/render_lista_spesa.php';
+include 'includes/header.php';
+
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+$stmt = $conn->prepare("SELECT id, nome, checked FROM lista_spesa WHERE id_famiglia = ? ORDER BY checked ASC, created_at DESC");
+$stmt->bind_param('i', $idFamiglia);
+$stmt->execute();
+$res = $stmt->get_result();
+$canAdd = has_permission($conn, 'ajax:add_lista_spesa', 'insert');
+?>
+<div class="d-flex mb-3 justify-content-between">
+  <h4>Lista spesa</h4>
+  <?php if ($canAdd): ?>
+  <button type="button" class="btn btn-outline-light btn-sm" onclick="openListaModal()">Aggiungi nuovo</button>
+  <?php endif; ?>
+</div>
+<div id="listaSpesaList">
+<?php while ($row = $res->fetch_assoc()): ?>
+  <?php render_lista_spesa($row); ?>
+<?php endwhile; ?>
+</div>
+<?php if ($canAdd): ?>
+<div class="modal fade" id="listaModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="listaForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Nuovo elemento</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Nome</label>
+          <input type="text" name="nome" class="form-control bg-secondary text-white" required>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+<?php endif; ?>
+<script src="js/lista_spesa.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/sql/lista_spesa.sql
+++ b/sql/lista_spesa.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `lista_spesa` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `id_famiglia` INT NOT NULL,
+  `nome` VARCHAR(255) NOT NULL,
+  `checked` TINYINT(1) NOT NULL DEFAULT 0,
+  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_lista_spesa_famiglia` (`id_famiglia`),
+  CONSTRAINT `fk_lista_spesa_famiglie` FOREIGN KEY (`id_famiglia`) REFERENCES `famiglie`(`id_famiglia`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/sql/userlevel_permissions.sql
+++ b/sql/userlevel_permissions.sql
@@ -9,3 +9,15 @@ CREATE TABLE `userlevel_permissions` (
   CONSTRAINT `fk_ulperm_userlevels` FOREIGN KEY (`userlevelid`) REFERENCES `userlevels` (`userlevelid`) ON DELETE CASCADE,
   CONSTRAINT `fk_ulperm_resources` FOREIGN KEY (`resource_id`) REFERENCES `resources` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO resources (name) VALUES
+  ('page:lista_spesa.php'),
+  ('ajax:add_lista_spesa'),
+  ('ajax:update_lista_spesa'),
+  ('ajax:get_lista_spesa');
+
+INSERT INTO userlevel_permissions (userlevelid, resource_id, can_view, can_insert, can_update, can_delete) VALUES
+  (-1, (SELECT id FROM resources WHERE name='page:lista_spesa.php'), 1,1,1,1),
+  (-1, (SELECT id FROM resources WHERE name='ajax:add_lista_spesa'), 1,1,1,1),
+  (-1, (SELECT id FROM resources WHERE name='ajax:update_lista_spesa'), 1,1,1,1),
+  (-1, (SELECT id FROM resources WHERE name='ajax:get_lista_spesa'), 1,1,1,1);


### PR DESCRIPTION
## Summary
- Add `lista_spesa` table and permissions seeds
- Implement shopping list page with rendering helper
- Create AJAX endpoints and client script with auto-refresh
- Link shopping list from navigation menu

## Testing
- `php -l includes/render_lista_spesa.php lista_spesa.php ajax/add_lista_spesa.php ajax/update_lista_spesa.php ajax/get_lista_spesa.php includes/header.php`
- `node --check js/lista_spesa.js`


------
https://chatgpt.com/codex/tasks/task_e_6898b576bf7c83319a5bb40c1de5087b