### PR TITLE
Add render_budget helper and use in budget list

### DIFF
--- a/budget.php
+++ b/budget.php
@@ -1,6 +1,7 @@
 <?php include 'includes/session_check.php'; ?>
 <?php
 include 'includes/db.php';
+require_once 'includes/render_budget.php';
 include 'includes/header.php';
 
 $idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
@@ -22,9 +23,7 @@ $res = $stmt->get_result();
 </div>
 <div id="budgetList" class="list-group">
 <?php while ($row = $res->fetch_assoc()): ?>
-  <div class="list-group-item bg-dark text-white budget-item" data-id="<?= (int)$row['id'] ?>" data-bs-toggle="modal" data-bs-target="#budgetModal">
-    <?= htmlspecialchars($row['descrizione'] ?? '') ?>
-  </div>
+  <?php render_budget($row); ?>
 <?php endwhile; ?>
 </div>
 

--- a/includes/render_budget.php
+++ b/includes/render_budget.php
@@ -1,0 +1,38 @@
+<?php
+function render_budget(array $row): void {
+    $id = (int)($row['id'] ?? ($row['id_budget'] ?? 0));
+    $descrizione = trim($row['descrizione'] ?? '');
+    $tipologia = trim($row['tipologia'] ?? '');
+    $importoNum = isset($row['importo']) ? (float)$row['importo'] : 0;
+    $importoFmt = number_format($importoNum, 2, ',', '.');
+    $dataInizioRaw = $row['data_inizio'] ?? '';
+    $dataFineRaw = $row['data_fine'] ?? ($row['data_scadenza'] ?? '');
+    $dataInizio = $dataInizioRaw ? date('d/m/Y', strtotime($dataInizioRaw)) : '';
+    $dataFine = $dataFineRaw ? date('d/m/Y', strtotime($dataFineRaw)) : '';
+    $search = strtolower(trim($descrizione . ' ' . $tipologia . ' ' . $dataInizio . ' ' . $dataFine . ' ' . $importoFmt));
+    $searchAttr = htmlspecialchars($search, ENT_QUOTES);
+    echo '<div class="list-group-item bg-dark text-white budget-item d-flex flex-column flex-sm-row justify-content-between align-items-start"'
+        . ' data-id="' . $id . '"'
+        . ' data-search="' . $searchAttr . '"'
+        . ' data-descrizione="' . htmlspecialchars($descrizione, ENT_QUOTES) . '"'
+        . ' data-tipologia="' . htmlspecialchars($tipologia, ENT_QUOTES) . '"'
+        . ' data-inizio="' . htmlspecialchars($dataInizioRaw, ENT_QUOTES) . '"'
+        . ' data-fine="' . htmlspecialchars($dataFineRaw, ENT_QUOTES) . '"'
+        . ' data-importo="' . htmlspecialchars((string)$importoNum, ENT_QUOTES) . '">';
+    echo '  <div class="flex-grow-1 me-sm-3">';
+    echo '    <div class="fw-semibold">' . htmlspecialchars($descrizione) . '</div>';
+    if ($tipologia !== '') {
+        echo '    <div class="small">' . htmlspecialchars($tipologia) . '</div>';
+    }
+    if ($dataInizio || $dataFine) {
+        $dates = $dataInizio;
+        if ($dataFine) {
+            $dates .= ' - ' . $dataFine;
+        }
+        echo '    <div class="small text-muted">' . htmlspecialchars($dates) . '</div>';
+    }
+    echo '  </div>';
+    echo '  <div class="text-sm-end mt-2 mt-sm-0">' . $importoFmt . ' &euro;</div>';
+    echo '</div>';
+}
+?>


### PR DESCRIPTION
## Summary
- add `render_budget()` helper to output budget cards with Bootstrap classes and search data attributes
- use `render_budget()` within the `budget.php` listing

## Testing
- `php -l includes/render_budget.php`
- `php -l budget.php`


------
https://chatgpt.com/codex/tasks/task_e_6898b80e9dc08331b77644c1851cd6f3