### PR TITLE
Supporto anno e mese per etichette

### DIFF
--- a/ajax/add_etichetta.php
+++ b/ajax/add_etichetta.php
@@ -7,6 +7,8 @@ $data = json_decode(file_get_contents('php://input'), true);
 $descrizione = trim($data['descrizione'] ?? '');
 $attivo = isset($data['attivo']) && $data['attivo'] == 1 ? 1 : 0;
 $da_dividere = isset($data['da_dividere']) && $data['da_dividere'] == 1 ? 1 : 0;
+$anno = isset($data['anno']) && $data['anno'] !== '' ? (int)$data['anno'] : null;
+$mese = isset($data['mese']) && $data['mese'] !== '' ? (int)$data['mese'] : null;
 $utenti = trim($data['utenti_tra_cui_dividere'] ?? '');
 
 if ($descrizione === '') {
@@ -14,8 +16,8 @@ if ($descrizione === '') {
     exit;
 }
 
-$stmt = $conn->prepare('INSERT INTO bilancio_etichette (descrizione, attivo, da_dividere, utenti_tra_cui_dividere) VALUES (?, ?, ?, ?)');
-$stmt->bind_param('siis', $descrizione, $attivo, $da_dividere, $utenti);
+$stmt = $conn->prepare('INSERT INTO bilancio_etichette (descrizione, attivo, da_dividere, anno, mese, utenti_tra_cui_dividere) VALUES (?, ?, ?, ?, ?, ?)');
+$stmt->bind_param('siiiis', $descrizione, $attivo, $da_dividere, $anno, $mese, $utenti);
 $ok = $stmt->execute();
 
 if ($ok) {

--- a/ajax/update_etichetta.php
+++ b/ajax/update_etichetta.php
@@ -8,6 +8,8 @@ $id = intval($data['id_etichetta'] ?? 0);
 $descrizione = trim($data['descrizione'] ?? '');
 $attivo = isset($data['attivo']) && $data['attivo'] == 1 ? 1 : 0;
 $da_dividere = isset($data['da_dividere']) && $data['da_dividere'] == 1 ? 1 : 0;
+$anno = isset($data['anno']) && $data['anno'] !== '' ? (int)$data['anno'] : null;
+$mese = isset($data['mese']) && $data['mese'] !== '' ? (int)$data['mese'] : null;
 $utenti = trim($data['utenti_tra_cui_dividere'] ?? '');
 
 if (!$id || $descrizione === '') {
@@ -15,8 +17,8 @@ if (!$id || $descrizione === '') {
     exit;
 }
 
-$stmt = $conn->prepare('UPDATE bilancio_etichette SET descrizione = ?, attivo = ?, da_dividere = ?, utenti_tra_cui_dividere = ? WHERE id_etichetta = ?');
-$stmt->bind_param('siisi', $descrizione, $attivo, $da_dividere, $utenti, $id);
+$stmt = $conn->prepare('UPDATE bilancio_etichette SET descrizione = ?, attivo = ?, da_dividere = ?, anno = ?, mese = ?, utenti_tra_cui_dividere = ? WHERE id_etichetta = ?');
+$stmt->bind_param('siiiisi', $descrizione, $attivo, $da_dividere, $anno, $mese, $utenti, $id);
 $ok = $stmt->execute();
 
 if ($ok) {

--- a/etichette_lista.php
+++ b/etichette_lista.php
@@ -3,7 +3,7 @@
 require_once 'includes/db.php';
 include 'includes/header.php';
 
-$sql = "SELECT e.id_etichetta, e.descrizione, e.attivo, e.da_dividere,
+$sql = "SELECT e.id_etichetta, e.descrizione, e.attivo, e.da_dividere, e.anno, e.mese,
                 EXISTS (
                   SELECT 1
                   FROM bilancio_etichette2operazioni eo
@@ -19,6 +19,7 @@ $etichette = $conn->query($sql);
   <div class="d-flex mb-3 justify-content-between"><h4>Etichette</h4><button type="button" class="btn btn-outline-light btn-sm" onclick="openEtichettaModal()">Aggiungi nuova</button></div>
   <div class="d-flex mb-3 align-items-center">
     <input type="text" id="search" class="form-control bg-dark text-white border-secondary me-2" placeholder="Cerca">
+    <button type="button" class="btn btn-outline-light me-2" data-bs-toggle="modal" data-bs-target="#filterModal"><i class="bi bi-funnel"></i></button>
     <div class="form-check form-switch text-nowrap">
       <input class="form-check-input" type="checkbox" id="showInactive">
       <label class="form-check-label" for="showInactive">Mostra non attive</label>
@@ -28,8 +29,15 @@ $etichette = $conn->query($sql);
   <div class="list-group" id="labelList">
     <?php while ($row = $etichette->fetch_assoc()): ?>
       <?php $isActive = (int)($row['attivo'] ?? 0) === 1; ?>
-      <a href="etichetta.php?id_etichetta=<?= urlencode($row['id_etichetta']) ?>" class="list-group-item movement text-white d-flex justify-content-between align-items-center text-decoration-none label-card<?= $isActive ? '' : ' inactive' ?>" data-search="<?= strtolower($row['descrizione']) ?>" style="<?= $isActive ? '' : 'display:none;' ?>">
-        <span><?= htmlspecialchars($row['descrizione']) ?></span>
+      <a href="etichetta.php?id_etichetta=<?= urlencode($row['id_etichetta']) ?>" class="list-group-item movement text-white d-flex justify-content-between align-items-center text-decoration-none label-card<?= $isActive ? '' : ' inactive' ?>" data-search="<?= strtolower(($row['descrizione'] ?? '') . ' ' . ($row['anno'] ?? '') . ' ' . ($row['mese'] ?? '')) ?>" data-year="<?= htmlspecialchars($row['anno'] ?? '') ?>" data-month="<?= htmlspecialchars($row['mese'] ?? '') ?>" style="<?= $isActive ? '' : 'display:none;' ?>">
+        <div class="d-flex flex-column">
+          <span><?= htmlspecialchars($row['descrizione']) ?></span>
+          <?php if (!empty($row['anno']) || !empty($row['mese'])): ?>
+            <small class="text-secondary">
+              <?= htmlspecialchars($row['anno'] ?? '') ?><?= !empty($row['mese']) ? '/' . str_pad((int)$row['mese'], 2, '0', STR_PAD_LEFT) : '' ?>
+            </small>
+          <?php endif; ?>
+        </div>
         <div>
             <?php if (($row['da_dividere'] ?? 0) == 1 && ($row['has_unassigned'] ?? 0) == 1): ?>
           <i class="bi bi-exclamation-circle-fill text-warning ms-1"></i>
@@ -38,7 +46,7 @@ $etichette = $conn->query($sql);
           <i class="bi bi-check-circle-fill text-success"></i>
         <?php else: ?>
           <i class="bi bi-x-circle-fill text-danger"></i>
-        <?php endif; ?>        
+        <?php endif; ?>
         </div>
       </a>
     <?php endwhile; ?>
@@ -66,6 +74,14 @@ $etichette = $conn->query($sql);
           <label class="form-check-label" for="da_dividere">Da dividere</label>
         </div>
         <div class="mb-3">
+          <label for="anno" class="form-label">Anno</label>
+          <input type="number" class="form-control bg-secondary text-white" id="anno">
+        </div>
+        <div class="mb-3">
+          <label for="mese" class="form-label">Mese</label>
+          <input type="number" min="1" max="12" class="form-control bg-secondary text-white" id="mese">
+        </div>
+        <div class="mb-3">
           <label for="utenti_tra_cui_dividere" class="form-label">Utenti tra cui dividere</label>
           <input type="text" class="form-control bg-secondary text-white" id="utenti_tra_cui_dividere">
         </div>
@@ -74,6 +90,31 @@ $etichette = $conn->query($sql);
         <button type="submit" class="btn btn-primary w-100">Salva</button>
       </div>
     </form>
+  </div>
+</div>
+
+<div class="modal fade" id="filterModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content bg-dark text-white">
+      <div class="modal-header">
+        <h5 class="modal-title">Filtra</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="filterAnno" class="form-label">Anno</label>
+          <input type="number" class="form-control bg-secondary text-white" id="filterAnno">
+        </div>
+        <div class="mb-3">
+          <label for="filterMese" class="form-label">Mese</label>
+          <input type="number" min="1" max="12" class="form-control bg-secondary text-white" id="filterMese">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" id="clearFilter">Pulisci</button>
+        <button type="button" class="btn btn-primary" id="applyFilter">Applica</button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/js/etichette.js
+++ b/js/etichette.js
@@ -2,15 +2,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const search = document.getElementById('search');
   const showInactive = document.getElementById('showInactive');
   const cards = Array.from(document.querySelectorAll('.label-card'));
+  const filterAnnoInput = document.getElementById('filterAnno');
+  const filterMeseInput = document.getElementById('filterMese');
+  let filterAnno = '';
+  let filterMese = '';
 
   function filter() {
     const q = search.value.trim().toLowerCase();
     cards.forEach(card => {
       const text = card.dataset.search || '';
       const isInactive = card.classList.contains('inactive');
-      const match = text.includes(q);
-      const visible = match && (!isInactive || showInactive.checked || q !== '');
-      //card.style.display = visible ? '' : 'none';
+      const matchText = text.includes(q);
+      const matchAnno = !filterAnno || card.dataset.year === filterAnno;
+      const matchMese = !filterMese || card.dataset.month === filterMese;
+      const visible = matchText && matchAnno && matchMese && (!isInactive || showInactive.checked || q !== '' || filterAnno || filterMese);
       if (visible) {
         card.style.removeProperty('display');
       } else {
@@ -18,6 +23,22 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  document.getElementById('applyFilter').addEventListener('click', () => {
+    filterAnno = filterAnnoInput.value.trim();
+    filterMese = filterMeseInput.value.trim();
+    filter();
+    bootstrap.Modal.getInstance(document.getElementById('filterModal')).hide();
+  });
+
+  document.getElementById('clearFilter').addEventListener('click', () => {
+    filterAnno = '';
+    filterMese = '';
+    filterAnnoInput.value = '';
+    filterMeseInput.value = '';
+    filter();
+    bootstrap.Modal.getInstance(document.getElementById('filterModal')).hide();
+  });
 
   search.addEventListener('input', filter);
   showInactive.addEventListener('input', filter);
@@ -28,6 +49,8 @@ function openEtichettaModal() {
   document.getElementById('descrizione').value = '';
   document.getElementById('attivo').checked = true;
   document.getElementById('da_dividere').checked = false;
+  document.getElementById('anno').value = '';
+  document.getElementById('mese').value = '';
   document.getElementById('utenti_tra_cui_dividere').value = '';
   new bootstrap.Modal(document.getElementById('editEtichettaModal')).show();
 }
@@ -38,6 +61,8 @@ function saveEtichetta(event) {
     descrizione: document.getElementById('descrizione').value.trim(),
     attivo: document.getElementById('attivo').checked ? 1 : 0,
     da_dividere: document.getElementById('da_dividere').checked ? 1 : 0,
+    anno: document.getElementById('anno').value ? parseInt(document.getElementById('anno').value, 10) : null,
+    mese: document.getElementById('mese').value ? parseInt(document.getElementById('mese').value, 10) : null,
     utenti_tra_cui_dividere: document.getElementById('utenti_tra_cui_dividere').value.trim()
   };
   fetch('ajax/add_etichetta.php', {

--- a/sql/add_anno_mese_to_etichette.sql
+++ b/sql/add_anno_mese_to_etichette.sql
@@ -1,0 +1,3 @@
+ALTER TABLE bilancio_etichette
+  ADD COLUMN anno INT DEFAULT NULL AFTER da_dividere,
+  ADD COLUMN mese TINYINT DEFAULT NULL AFTER anno;


### PR DESCRIPTION
## Summary
- Aggiunti campi `anno` e `mese` alla tabella `bilancio_etichette` con relativa migrazione
- Gestiti i nuovi campi in creazione, modifica e visualizzazione delle etichette
- Introdotta ricerca per anno/mese con icona filtro e modal dedicata

## Testing
- `php -l ajax/add_etichetta.php`
- `php -l ajax/update_etichetta.php`
- `php -l etichette_lista.php`
- `php -l etichetta.php`
- `node --check js/etichette.js`


------
https://chatgpt.com/codex/tasks/task_e_6898bc05c7f88331903b8b3381748ef3