### PR TITLE
feat: add budget type selectors and icons

### DIFF
--- a/budget.php
+++ b/budget.php
@@ -86,6 +86,18 @@ $res = $stmt->get_result();
           <input type="text" name="descrizione" id="budgetDescrizione" class="form-control bg-secondary text-white" required>
         </div>
         <div class="mb-3">
+          <label class="form-label">Tipologia</label>
+          <select name="tipologia" id="budgetTipologia" class="form-select bg-secondary text-white">
+            <option value=""></option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Tipologia spesa</label>
+          <select name="tipologia_spesa" id="budgetTipologiaSpesa" class="form-select bg-secondary text-white">
+            <option value=""></option>
+          </select>
+        </div>
+        <div class="mb-3">
           <label class="form-label">Importo</label>
           <input type="number" step="0.01" name="importo" id="budgetImporto" class="form-control bg-secondary text-white" required>
         </div>

--- a/includes/render_budget.php
+++ b/includes/render_budget.php
@@ -13,6 +13,13 @@ function render_budget(array $row): void {
     $dataFine = $dataFineRaw ? date('d/m/Y', strtotime($dataFineRaw)) : '';
     $search = strtolower(trim($descrizione . ' ' . $tipologia . ' ' . $salvadanaio . ' ' . $tipologiaSpesa . ' ' . $dataInizio . ' ' . $dataFine . ' ' . $importoFmt));
     $searchAttr = htmlspecialchars($search, ENT_QUOTES);
+    $icon = '';
+    $tipologiaLower = strtolower($tipologia);
+    if ($tipologiaLower === 'entrata') {
+        $icon = 'bi-arrow-down-circle text-success';
+    } elseif ($tipologiaLower === 'uscita') {
+        $icon = 'bi-arrow-up-circle text-danger';
+    }
     echo '<div class="list-group-item bg-dark text-white budget-item d-flex flex-column flex-sm-row justify-content-between align-items-start"'
         . ' data-id="' . $id . '"'
         . ' data-search="' . $searchAttr . '"'
@@ -25,9 +32,6 @@ function render_budget(array $row): void {
         . ' data-importo="' . htmlspecialchars((string)$importoNum, ENT_QUOTES) . '">';
     echo '  <div class="flex-grow-1 me-sm-3">';
     echo '    <div class="fw-semibold">' . htmlspecialchars($descrizione) . '</div>';
-    if ($tipologia !== '') {
-        echo '    <div class="small">' . htmlspecialchars($tipologia) . '</div>';
-    }
     if ($dataInizio || $dataFine) {
         $dates = $dataInizio;
         if ($dataFine) {
@@ -36,7 +40,15 @@ function render_budget(array $row): void {
         echo '    <div class="small text-muted">' . htmlspecialchars($dates) . '</div>';
     }
     echo '  </div>';
-    echo '  <div class="text-sm-end mt-2 mt-sm-0">' . $importoFmt . ' &euro;</div>';
+    echo '  <div class="text-sm-end mt-2 mt-sm-0 d-flex flex-column align-items-end">';
+    if ($icon) {
+        echo '    <i class="bi ' . $icon . ' mb-1"></i>';
+    }
+    echo '    <div>' . $importoFmt . ' &euro;</div>';
+    if ($salvadanaio !== '') {
+        echo '    <div class="mt-1"><span class="badge-etichetta">' . htmlspecialchars($salvadanaio) . '</span></div>';
+    }
+    echo '  </div>';
     echo '</div>';
 }
 ?>

--- a/js/budget.js
+++ b/js/budget.js
@@ -14,6 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const budgetForm = document.getElementById('budgetForm');
   const budgetId = document.getElementById('budgetId');
   const budgetDescrizione = document.getElementById('budgetDescrizione');
+  const budgetTipologia = document.getElementById('budgetTipologia');
+  const budgetTipologiaSpesa = document.getElementById('budgetTipologiaSpesa');
   const budgetImporto = document.getElementById('budgetImporto');
   const budgetDataInizio = document.getElementById('budgetDataInizio');
   const budgetDataFine = document.getElementById('budgetDataFine');
@@ -49,6 +51,8 @@ document.addEventListener('DOMContentLoaded', () => {
   populateSelect(filterTipologia, tipologie);
   populateSelect(filterSalvadanaio, salvadanai);
   populateSelect(filterTipologiaSpesa, tipologieSpesa);
+  populateSelect(budgetTipologia, tipologie);
+  populateSelect(budgetTipologiaSpesa, tipologieSpesa);
 
   function applyFilters() {
     const q = (searchInput?.value || '').trim().toLowerCase();
@@ -95,6 +99,8 @@ document.addEventListener('DOMContentLoaded', () => {
   addBudgetBtn?.addEventListener('click', () => {
     budgetForm?.reset();
     if (budgetId) budgetId.value = '';
+    if (budgetTipologia) budgetTipologia.value = '';
+    if (budgetTipologiaSpesa) budgetTipologiaSpesa.value = '';
     if (modalTitle) modalTitle.textContent = 'Nuovo budget';
     deleteBudgetBtn?.classList.add('d-none');
     budgetModal?.show();
@@ -105,6 +111,8 @@ document.addEventListener('DOMContentLoaded', () => {
       budgetForm?.reset();
       if (budgetId) budgetId.value = item.dataset.id || '';
       if (budgetDescrizione) budgetDescrizione.value = item.dataset.descrizione || '';
+      if (budgetTipologia) budgetTipologia.value = item.dataset.tipologia || '';
+      if (budgetTipologiaSpesa) budgetTipologiaSpesa.value = item.dataset.tipologiaSpesa || '';
       if (budgetImporto) budgetImporto.value = item.dataset.importo || '';
       if (budgetDataInizio) budgetDataInizio.value = item.dataset.inizio || '';
       if (budgetDataFine) budgetDataFine.value = item.dataset.fine || '';


### PR DESCRIPTION
## Summary
- add Tipologia and Tipologia spesa dropdowns to budget modal
- show icons for entrata/uscita and label salvadanaio in budget list items
- update budget.js to populate new fields and handle editing

## Testing
- `php -l budget.php`
- `php -l includes/render_budget.php`
- `node --check js/budget.js`


------
https://chatgpt.com/codex/tasks/task_e_6898c3cb90248331b09bffaccff40278