### PR TITLE
Add piggy bank carousel with user preferences

### DIFF
--- a/ajax/salvadanai_prefs.php
+++ b/ajax/salvadanai_prefs.php
@@ -1,0 +1,40 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$idUtente = $_SESSION['utente_id'] ?? 0;
+if (!$idUtente) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$hidden = $data['hidden'] ?? [];
+$preferito = isset($data['preferito']) && $data['preferito'] !== null ? intval($data['preferito']) : null;
+
+$conn->begin_transaction();
+$stmtReset = $conn->prepare('UPDATE utenti2salvadanai SET nascosto = 0, preferito = 0 WHERE id_utente = ?');
+$stmtReset->bind_param('i', $idUtente);
+$stmtReset->execute();
+
+if (!empty($hidden)) {
+    $stmtHide = $conn->prepare('INSERT INTO utenti2salvadanai (id_utente, id_salvadanaio, nascosto, preferito) VALUES (?, ?, 1, 0)
+        ON DUPLICATE KEY UPDATE nascosto = 1, preferito = 0');
+    foreach ($hidden as $h) {
+        $id = intval($h);
+        $stmtHide->bind_param('ii', $idUtente, $id);
+        $stmtHide->execute();
+    }
+}
+
+if ($preferito) {
+    $stmtFav = $conn->prepare('INSERT INTO utenti2salvadanai (id_utente, id_salvadanaio, nascosto, preferito) VALUES (?, ?, 0, 1)
+        ON DUPLICATE KEY UPDATE preferito = 1, nascosto = 0');
+    $stmtFav->bind_param('ii', $idUtente, $preferito);
+    $stmtFav->execute();
+}
+
+$conn->commit();
+
+echo json_encode(['success' => true]);

--- a/js/index.js
+++ b/js/index.js
@@ -33,4 +33,23 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     
     bindMovimenti();
+
+    const saveBtn = document.getElementById('saveSalvadanai');
+    if (saveBtn) {
+        saveBtn.addEventListener('click', () => {
+            const form = document.getElementById('salvadanaiForm');
+            const hidden = [...form.querySelectorAll('input[name="hidden[]"]:checked')].map(el => el.value);
+            const prefInput = form.querySelector('input[name="preferito"]:checked');
+            const preferito = prefInput ? prefInput.value : null;
+            fetch('ajax/salvadanai_prefs.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ hidden: hidden, preferito: preferito })
+            }).then(r => r.json()).then(data => {
+                if (data.success) {
+                    location.reload();
+                }
+            });
+        });
+    }
 });

--- a/sql/add_importo_attuale_to_salvadanai.sql
+++ b/sql/add_importo_attuale_to_salvadanai.sql
@@ -1,0 +1,1 @@
+ALTER TABLE salvadanai ADD COLUMN importo_attuale DECIMAL(10,2) NOT NULL DEFAULT 0 AFTER nome_salvadanaio;

--- a/sql/add_utenti2salvadanai.sql
+++ b/sql/add_utenti2salvadanai.sql
@@ -1,0 +1,11 @@
+CREATE TABLE utenti2salvadanai (
+  id_u2s INT(11) NOT NULL AUTO_INCREMENT,
+  id_utente INT(11) NOT NULL,
+  id_salvadanaio INT(11) NOT NULL,
+  nascosto TINYINT(1) NOT NULL DEFAULT 0,
+  preferito TINYINT(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (id_u2s),
+  UNIQUE KEY uq_u2s (id_utente, id_salvadanaio),
+  CONSTRAINT fk_u2s_utente FOREIGN KEY (id_utente) REFERENCES utenti(id) ON DELETE CASCADE,
+  CONSTRAINT fk_u2s_salvadanaio FOREIGN KEY (id_salvadanaio) REFERENCES salvadanai(id_salvadanaio) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -868,7 +868,8 @@ CREATE TABLE `resources` (
 
 CREATE TABLE `salvadanai` (
   `id_salvadanaio` int(11) NOT NULL,
-  `nome_salvadanaio` varchar(250) DEFAULT NULL
+  `nome_salvadanaio` varchar(250) DEFAULT NULL,
+  `importo_attuale` decimal(10,2) NOT NULL DEFAULT '0.00'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
@@ -1039,6 +1040,20 @@ CREATE TABLE `utenti2menu_smartadmin` (
   `id_collut2me` int(11) NOT NULL,
   `id_utenti` int(11) NOT NULL DEFAULT '0',
   `id_menu` int(11) NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+
+--
+-- Struttura della tabella `utenti2salvadanai`
+--
+
+CREATE TABLE `utenti2salvadanai` (
+  `id_u2s` int(11) NOT NULL,
+  `id_utente` int(11) NOT NULL,
+  `id_salvadanaio` int(11) NOT NULL,
+  `nascosto` tinyint(1) NOT NULL DEFAULT '0',
+  `preferito` tinyint(1) NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 --
@@ -1511,6 +1526,13 @@ ALTER TABLE `utenti2menu_smartadmin`
   ADD KEY `id_utenti` (`id_utenti`,`id_menu`);
 
 --
+-- Indici per le tabelle `utenti2salvadanai`
+--
+ALTER TABLE `utenti2salvadanai`
+  ADD PRIMARY KEY (`id_u2s`),
+  ADD UNIQUE KEY `uq_u2s` (`id_utente`,`id_salvadanaio`);
+
+--
 -- AUTO_INCREMENT per le tabelle scaricate
 --
 
@@ -1887,6 +1909,12 @@ ALTER TABLE `utenti2menu_smartadmin`
   MODIFY `id_collut2me` int(11) NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT per la tabella `utenti2salvadanai`
+--
+ALTER TABLE `utenti2salvadanai`
+  MODIFY `id_u2s` int(11) NOT NULL AUTO_INCREMENT;
+
+--
 -- Limiti per le tabelle scaricate
 --
 
@@ -1997,6 +2025,13 @@ ALTER TABLE `movimenti_revolut`
   ADD CONSTRAINT `fk_revolut_etichetta` FOREIGN KEY (`id_etichetta`) REFERENCES `bilancio_etichette` (`id_etichetta`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_revolut_gruppo` FOREIGN KEY (`id_gruppo_transazione`) REFERENCES `bilancio_gruppi_transazione` (`id_gruppo_transazione`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_revolut_salvadanaio` FOREIGN KEY (`id_salvadanaio`) REFERENCES `salvadanai` (`id_salvadanaio`) ON DELETE SET NULL;
+
+--
+-- Limiti per la tabella `utenti2salvadanai`
+--
+ALTER TABLE `utenti2salvadanai`
+  ADD CONSTRAINT `fk_u2s_utente` FOREIGN KEY (`id_utente`) REFERENCES `utenti` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_u2s_salvadanaio` FOREIGN KEY (`id_salvadanaio`) REFERENCES `salvadanai` (`id_salvadanaio`) ON DELETE CASCADE;
 
 --
 -- Limiti per la tabella `userlevel_permissions`


### PR DESCRIPTION
## Summary
- show a Bootstrap carousel of upcoming piggy bank budgets on the index with goal and current amounts
- allow users to hide or mark a favourite piggy bank via modal dialog and save preferences
- store user piggy bank settings in new utenti2salvadanai table and support importo_attuale column

## Testing
- `php -l index.php`
- `php -l ajax/salvadanai_prefs.php`


------
https://chatgpt.com/codex/tasks/task_e_6899e7fe72c083319301717c46b2a9df