### PR TITLE
Add Budget submenu with year and dashboard pages

### DIFF
--- a/budget_dashboard.php
+++ b/budget_dashboard.php
@@ -1,0 +1,9 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+include 'includes/header.php';
+?>
+<div class="d-flex mb-3 justify-content-between">
+  <h4>Dashboard budget</h4>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -94,11 +94,29 @@
         </a>
       </li>
       <?php endif; ?>
-      <?php if (has_permission($conn, 'page:budget.php', 'view')): ?>
+      <?php
+        $showBudget = has_permission($conn, 'page:budget.php', 'view') ||
+                      has_permission($conn, 'page:budget_anno.php', 'view') ||
+                      has_permission($conn, 'page:budget_dashboard.php', 'view');
+        if ($showBudget):
+      ?>
       <li class="mb-3">
-        <a href="/Gestionale25/budget.php" class="btn btn-outline-light w-100 text-start">
-          <i class="bi bi-wallet me-2 text-white"></i> Budget
-        </a>
+        <div class="dropdown w-100">
+          <button class="btn btn-outline-light w-100 text-start dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+            <i class="bi bi-wallet me-2 text-white"></i> Budget
+          </button>
+          <ul class="dropdown-menu dropdown-menu-dark w-100">
+            <?php if (has_permission($conn, 'page:budget.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/budget.php">Budget</a></li>
+            <?php endif; ?>
+            <?php if (has_permission($conn, 'page:budget_anno.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/budget_anno.php">Budget per anno</a></li>
+            <?php endif; ?>
+            <?php if (has_permission($conn, 'page:budget_dashboard.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/budget_dashboard.php">Dashboard budget</a></li>
+            <?php endif; ?>
+          </ul>
+        </div>
       </li>
       <?php endif; ?>
       <?php if (has_permission($conn, 'page:password.php', 'view')): ?>


### PR DESCRIPTION
## Summary
- Convert Budget link to dropdown submenu linking to annual and dashboard views
- Add basic budget_dashboard page placeholder

## Testing
- `php -l includes/header.php`
- `php -l budget_dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_6899eb43282c8331a0262bf67beb5785