### PR TITLE
Aggiorna importo salvadanai su import Revolut

### DIFF
--- a/sql/add_data_aggiornamento_manuale_to_salvadanai.sql
+++ b/sql/add_data_aggiornamento_manuale_to_salvadanai.sql
@@ -1,0 +1,1 @@
+ALTER TABLE salvadanai ADD COLUMN data_aggiornamento_manuale DATETIME DEFAULT NULL AFTER importo_attuale;

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -869,7 +869,8 @@ CREATE TABLE `resources` (
 CREATE TABLE `salvadanai` (
   `id_salvadanaio` int(11) NOT NULL,
   `nome_salvadanaio` varchar(250) DEFAULT NULL,
-  `importo_attuale` decimal(10,2) NOT NULL DEFAULT '0.00'
+  `importo_attuale` decimal(10,2) NOT NULL DEFAULT '0.00',
+  `data_aggiornamento_manuale` datetime DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
## Summary
- Aggiorna il saldo dei salvadanai durante l'importazione dei movimenti Revolut, evitando l'aggiornamento se ci sono modifiche manuali successive
- Aggiunge la colonna `data_aggiornamento_manuale` alla tabella `salvadanai`
- Fornisce script SQL di migrazione e aggiorna la struttura del database

## Testing
- `php -l upload_movimenti.php`


------
https://chatgpt.com/codex/tasks/task_e_6899f0562c748331a5f5cdd5d48e6d33