### PR TITLE
Fix malformed span attribute in budget render

### DIFF
--- a/includes/render_budget.php
+++ b/includes/render_budget.php
@@ -47,7 +47,7 @@ function render_budget(array $row): void {
     }
    
     if ($salvadanaio !== '') {
-        echo '    <div class="mt-1"><span class="badge-etichetta" style=">' . htmlspecialchars($salvadanaio) . '</span></div>';
+        echo '    <div class="mt-1"><span class="badge-etichetta">' . htmlspecialchars($salvadanaio) . '</span></div>';
     }
     echo '  </div>';
     echo '</div>';


### PR DESCRIPTION
## Summary
- remove invalid style attribute from budget tag rendering to keep HTML structure valid

## Testing
- `php -l includes/render_budget.php`
- `php -l budget.php`


------
https://chatgpt.com/codex/tasks/task_e_6899f1bebf688331b64c59acf4709d73