### PR TITLE
Enable budget row duplication via modal

### DIFF
--- a/ajax/budget_manage.php
+++ b/ajax/budget_manage.php
@@ -21,6 +21,8 @@ if ($action === 'save') {
     $da13 = isset($_POST['da_13esima']) ? (float)$_POST['da_13esima'] : 0;
     $da14 = isset($_POST['da_14esima']) ? (float)$_POST['da_14esima'] : 0;
     $importo = isset($_POST['importo']) ? (float)$_POST['importo'] : 0;
+    $tipologia = $_POST['tipologia'] ?? 'uscita';
+    $tipologia_spesa = $_POST['tipologia_spesa'] ?? 'fissa';
 
     if ($id > 0) {
         $stmt = $conn->prepare('UPDATE budget SET id_salvadanaio=?, descrizione=?, data_inizio=?, data_scadenza=?, da_13esima=?, da_14esima=?, importo=? WHERE id_budget=? AND id_famiglia=?');
@@ -30,8 +32,8 @@ if ($action === 'save') {
         echo json_encode(['success' => $ok]);
         exit;
     } else {
-        $stmt = $conn->prepare('INSERT INTO budget (id_salvadanaio, descrizione, data_inizio, data_scadenza, da_13esima, da_14esima, importo, id_famiglia, id_utente) VALUES (?,?,?,?,?,?,?,?,?)');
-        $stmt->bind_param('isssdddii', $id_salvadanaio, $descrizione, $data_inizio, $data_scadenza, $da13, $da14, $importo, $idFamiglia, $idUtente);
+        $stmt = $conn->prepare('INSERT INTO budget (tipologia, tipologia_spesa, id_salvadanaio, descrizione, data_inizio, data_scadenza, da_13esima, da_14esima, importo, id_famiglia, id_utente) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+        $stmt->bind_param('ssisssdddii', $tipologia, $tipologia_spesa, $id_salvadanaio, $descrizione, $data_inizio, $data_scadenza, $da13, $da14, $importo, $idFamiglia, $idUtente);
         $ok = $stmt->execute();
         $stmt->close();
         echo json_encode(['success' => $ok]);
@@ -53,19 +55,5 @@ if ($action === 'delete') {
     exit;
 }
 
-if ($action === 'duplicate') {
-    $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
-    if ($id > 0) {
-        $stmt = $conn->prepare('INSERT INTO budget (tipologia, importo, id_salvadanaio, descrizione, data_inizio, data_scadenza, tipologia_spesa, da_13esima, da_14esima, id_utente, id_famiglia)
-            SELECT tipologia, importo, id_salvadanaio, descrizione, data_inizio, data_scadenza, tipologia_spesa, da_13esima, da_14esima, ?, id_famiglia FROM budget WHERE id_budget=? AND id_famiglia=?');
-        $stmt->bind_param('iii', $idUtente, $id, $idFamiglia);
-        $ok = $stmt->execute();
-        $stmt->close();
-        echo json_encode(['success' => $ok]);
-        exit;
-    }
-    echo json_encode(['success' => false]);
-    exit;
-}
 
 echo json_encode(['success' => false, 'error' => 'Azione non valida']);

--- a/budget_anno.php
+++ b/budget_anno.php
@@ -217,7 +217,7 @@ $salStmt->close();
   </thead>
   <tbody>
     <?php foreach ($rows as $r): ?>
-    <tr data-id="<?= (int)$r['id_budget'] ?>" data-salvadanaio="<?= htmlspecialchars((string)$r['id_salvadanaio']) ?>" data-descrizione="<?= htmlspecialchars($r['descrizione'], ENT_QUOTES) ?>" data-inizio="<?= htmlspecialchars($r['data_inizio']) ?>" data-scadenza="<?= htmlspecialchars($r['data_scadenza']) ?>" data-da13="<?= number_format($r['da_13esima'],2,'.','') ?>" data-da14="<?= number_format($r['da_14esima'],2,'.','') ?>" data-importo="<?= number_format($r['importo'],2,'.','') ?>">
+    <tr data-id="<?= (int)$r['id_budget'] ?>" data-salvadanaio="<?= htmlspecialchars((string)$r['id_salvadanaio']) ?>" data-descrizione="<?= htmlspecialchars($r['descrizione'], ENT_QUOTES) ?>" data-inizio="<?= htmlspecialchars($r['data_inizio']) ?>" data-scadenza="<?= htmlspecialchars($r['data_scadenza']) ?>" data-da13="<?= number_format($r['da_13esima'],2,'.','') ?>" data-da14="<?= number_format($r['da_14esima'],2,'.','') ?>" data-importo="<?= number_format($r['importo'],2,'.','') ?>" data-tipologia="<?= htmlspecialchars($r['tipologia']) ?>" data-tipologia-spesa="<?= htmlspecialchars($r['tipologia_spesa']) ?>">
       <td class="text-center">
         <?php if (strtolower($r['tipologia']) === 'entrata'): ?>
           <i class="bi bi-arrow-down-circle text-success"></i>
@@ -273,6 +273,8 @@ $salStmt->close();
       </div>
       <div class="modal-body">
         <input type="hidden" name="id" id="editBudgetId">
+        <input type="hidden" name="tipologia" id="editTipologia">
+        <input type="hidden" name="tipologia_spesa" id="editTipologiaSpesa">
         <div class="mb-3">
           <label class="form-label">Salvadanaio</label>
           <select name="id_salvadanaio" id="editSalvadanaio" class="form-select bg-secondary text-white">
@@ -360,6 +362,8 @@ document.addEventListener('DOMContentLoaded', function(){
   const editModal = editModalEl ? new bootstrap.Modal(editModalEl) : null;
   const fields = {
     id: document.getElementById('editBudgetId'),
+    tipologia: document.getElementById('editTipologia'),
+    tipologiaSpesa: document.getElementById('editTipologiaSpesa'),
     salvadanaio: document.getElementById('editSalvadanaio'),
     descrizione: document.getElementById('editDescrizione'),
     inizio: document.getElementById('editDataInizio'),
@@ -378,6 +382,8 @@ document.addEventListener('DOMContentLoaded', function(){
     btn.addEventListener('click', () => {
       const tr = btn.closest('tr');
       fields.id.value = tr.dataset.id;
+      fields.tipologia.value = tr.dataset.tipologia;
+      fields.tipologiaSpesa.value = tr.dataset.tipologiaSpesa;
       fields.salvadanaio.value = tr.dataset.salvadanaio;
       fields.descrizione.value = tr.dataset.descrizione;
       fields.inizio.value = tr.dataset.inizio;
@@ -392,13 +398,28 @@ document.addEventListener('DOMContentLoaded', function(){
   document.querySelectorAll('.duplicate-btn').forEach(btn => {
     btn.addEventListener('click', () => {
       const tr = btn.closest('tr');
-      const fd = new FormData();
-      fd.append('action','duplicate');
-      fd.append('id', tr.dataset.id);
-      fetch('ajax/budget_manage.php', {method:'POST', body:fd})
-        .then(r=>r.json())
-        .then(res => { if(res.success){ location.reload(); } else { alert(res.error || 'Errore'); }});
+      fields.id.value = '';
+      fields.tipologia.value = tr.dataset.tipologia;
+      fields.tipologiaSpesa.value = tr.dataset.tipologiaSpesa;
+      fields.salvadanaio.value = tr.dataset.salvadanaio;
+      fields.descrizione.value = tr.dataset.descrizione;
+      fields.inizio.value = tr.dataset.inizio;
+      fields.scadenza.value = tr.dataset.scadenza;
+      fields.da13.value = tr.dataset.da13;
+      fields.da14.value = tr.dataset.da14;
+      fields.importo.value = tr.dataset.importo;
+      if(editModalEl.querySelector('.modal-title')){
+        editModalEl.querySelector('.modal-title').textContent = 'Duplica budget';
+      }
+      editModal?.show();
     });
+  });
+
+  editModalEl?.addEventListener('hidden.bs.modal', () => {
+    fields.id.value = '';
+    if(editModalEl.querySelector('.modal-title')){
+      editModalEl.querySelector('.modal-title').textContent = 'Modifica budget';
+    }
   });
 
   document.querySelectorAll('.delete-btn').forEach(btn => {


### PR DESCRIPTION
## Summary
- Populate budget rows with type metadata and expose hidden fields in edit form
- Reuse edit modal for duplicating entries and reset fields client-side
- Insert new records with preserved `tipologia` and `tipologia_spesa`

## Testing
- `php -l budget_anno.php`
- `php -l ajax/budget_manage.php`


------
https://chatgpt.com/codex/tasks/task_e_6899f6328b708331a539968cb710a949