### PR TITLE
Gestione salvadanai con controllo manuale e preferiti

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -36,11 +36,49 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const saveBtn = document.getElementById('saveSalvadanai');
     if (saveBtn) {
+        document.querySelectorAll('.salvadanaio-item').forEach(item => {
+            const favIcon = item.querySelector('.toggle-preferito');
+            const hideIcon = item.querySelector('.toggle-nascosto');
+
+            favIcon.addEventListener('click', () => {
+                document.querySelectorAll('.salvadanaio-item').forEach(it => {
+                    it.dataset.preferito = '0';
+                    const ic = it.querySelector('.toggle-preferito');
+                    ic.classList.remove('bi-star-fill', 'text-warning');
+                    ic.classList.add('bi-star');
+                });
+                item.dataset.preferito = '1';
+                favIcon.classList.remove('bi-star');
+                favIcon.classList.add('bi-star-fill', 'text-warning');
+            });
+
+            hideIcon.addEventListener('click', () => {
+                if (item.dataset.nascosto === '1') {
+                    item.dataset.nascosto = '0';
+                    hideIcon.classList.remove('bi-eye-slash');
+                    hideIcon.classList.add('bi-eye');
+                } else {
+                    item.dataset.nascosto = '1';
+                    hideIcon.classList.remove('bi-eye');
+                    hideIcon.classList.add('bi-eye-slash');
+                    if (item.dataset.preferito === '1') {
+                        item.dataset.preferito = '0';
+                        const ic = item.querySelector('.toggle-preferito');
+                        ic.classList.remove('bi-star-fill', 'text-warning');
+                        ic.classList.add('bi-star');
+                    }
+                }
+            });
+        });
+
         saveBtn.addEventListener('click', () => {
-            const form = document.getElementById('salvadanaiForm');
-            const hidden = [...form.querySelectorAll('input[name="hidden[]"]:checked')].map(el => el.value);
-            const prefInput = form.querySelector('input[name="preferito"]:checked');
-            const preferito = prefInput ? prefInput.value : null;
+            const items = document.querySelectorAll('.salvadanaio-item');
+            const hidden = [];
+            let preferito = null;
+            items.forEach(it => {
+                if (it.dataset.nascosto === '1') hidden.push(it.dataset.id);
+                if (it.dataset.preferito === '1') preferito = it.dataset.id;
+            });
             fetch('ajax/salvadanai_prefs.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Evitato lo scorrimento automatico del carousel e aggiunti indicatori dei salvadanai presenti
- Modal rivista con icone stella/occhio per selezionare preferito e nascondere i salvadanai
- Salvataggio delle preferenze corretto e ordinamento con il preferito in testa

## Testing
- `php -l index.php`
- `php -l ajax/salvadanai_prefs.php`


------
https://chatgpt.com/codex/tasks/task_e_6899faeb1a0483319382a706dfcc78b1