### PR TITLE
Add mensile budget type and hide from annual view

### DIFF
--- a/budget_anno.php
+++ b/budget_anno.php
@@ -21,7 +21,10 @@ $scadenzaA = $_GET['scadenza_a'] ?? '';
 $search = trim($_GET['q'] ?? '');
 $export = isset($_GET['export']);
 
-$conditions = ['b.id_famiglia = ?'];
+$conditions = [
+    'b.id_famiglia = ?',
+    "b.tipologia_spesa <> 'mensile'",
+];
 $params = [$idFamiglia];
 $types  = 'i';
 

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -278,7 +278,7 @@ CREATE TABLE `budget` (
   `descrizione` varchar(255) DEFAULT NULL,
   `data_inizio` date NOT NULL,
   `data_scadenza` date DEFAULT NULL,
-  `tipologia_spesa` enum('fissa','una_tantum') NOT NULL
+  `tipologia_spesa` enum('fissa','una_tantum','mensile') NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `mensile` to `tipologia_spesa` enum in budget table schema
- exclude `mensile` budget entries from `budget_anno.php`

## Testing
- `php -l budget_anno.php`

------
https://chatgpt.com/codex/tasks/task_e_689a0761d0008331b81184a641701669