### PR TITLE
Fix budget modal insertion

### DIFF
--- a/budget.php
+++ b/budget.php
@@ -133,7 +133,7 @@ $res = $stmt->get_result();
         </div>
         <div class="mb-3">
           <label class="form-label">Data fine</label>
-          <input type="date" name="data_fine" id="budgetDataFine" class="form-control bg-secondary text-white">
+          <input type="date" name="data_scadenza" id="budgetDataFine" class="form-control bg-secondary text-white">
         </div>
       </div>
       <div class="modal-footer d-flex justify-content-between">

--- a/js/budget.js
+++ b/js/budget.js
@@ -120,13 +120,29 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
+  budgetForm?.addEventListener('submit', e => {
+    e.preventDefault();
+    const fd = new FormData(budgetForm);
+    fd.append('action', 'save');
+    fetch('ajax/budget_manage.php', { method: 'POST', body: fd })
+      .then(r => r.json())
+      .then(res => {
+        if (res.success) {
+          location.reload();
+        } else {
+          alert(res.error || 'Errore');
+        }
+      });
+  });
+
   deleteBudgetBtn?.addEventListener('click', () => {
     const id = budgetId?.value;
     if (!id) return;
     if (!confirm('Eliminare questo budget?')) return;
     const fd = new FormData();
     fd.append('id', id);
-    fetch('ajax/delete_budget.php', { method: 'POST', body: fd })
+    fd.append('action', 'delete');
+    fetch('ajax/budget_manage.php', { method: 'POST', body: fd })
       .then(r => r.json())
       .then(res => {
         if (res.success) {


### PR DESCRIPTION
## Summary
- Enable budget modal to save new entries using ajax/budget_manage.php
- Correct budget deletion to target ajax/budget_manage.php with action flag
- Align budget form field name with backend expectation for data_scadenza

## Testing
- `php -l budget.php`
- `node --check js/budget.js`

------
https://chatgpt.com/codex/tasks/task_e_689b02dc9ee483318b262bf0f984c178