### PR TITLE
Enable selecting salvadanaio in budget form

### DIFF
--- a/ajax/budget_manage.php
+++ b/ajax/budget_manage.php
@@ -29,7 +29,14 @@ if ($action === 'save') {
 
     if ($id > 0) {
         $stmt = $conn->prepare('UPDATE budget SET id_salvadanaio=?, descrizione=?, data_inizio=?, data_scadenza=?, da_13esima=?, da_14esima=?, importo=? WHERE id_budget=? AND id_famiglia=?');
-        $stmt->bind_param('isssdddii', $id_salvadanaio, $descrizione, $data_inizio, $data_scadenza, $da13, $da14, $importo, $id, $idFamiglia);
+        if (!$stmt) {
+            die("Errore nella prepare: " . $conn->error);
+        }
+
+        if (!$stmt->bind_param('isssdddii', $id_salvadanaio, $descrizione, $data_inizio, $data_scadenza, $da13, $da14, $importo, $id, $idFamiglia)) {
+            die("Errore nella bind_param: " . $stmt->error);
+        }
+
         $ok = $stmt->execute();
         $stmt->close();
         echo json_encode(['success' => $ok]);

--- a/budget.php
+++ b/budget.php
@@ -20,6 +20,15 @@ function getEnumValues(mysqli $conn, string $table, string $field): array {
 $tipologie = getEnumValues($conn, 'budget', 'tipologia');
 $tipologieSpesa = getEnumValues($conn, 'budget', 'tipologia_spesa');
 
+$salvadanai = [];
+$stmtSalv = $conn->prepare('SELECT id_salvadanaio, nome_salvadanaio FROM salvadanai ORDER BY nome_salvadanaio');
+$stmtSalv->execute();
+$resSalv = $stmtSalv->get_result();
+while ($rowSalv = $resSalv->fetch_assoc()) {
+    $salvadanai[] = $rowSalv;
+}
+$stmtSalv->close();
+
 $stmt = $conn->prepare('SELECT b.*, s.nome_salvadanaio FROM budget b LEFT JOIN salvadanai s ON b.id_salvadanaio = s.id_salvadanaio WHERE b.id_famiglia = ? ORDER BY b.data_inizio');
 $stmt->bind_param('i', $idFamiglia);
 $stmt->execute();
@@ -120,6 +129,15 @@ $res = $stmt->get_result();
             <option value=""></option>
             <?php foreach ($tipologieSpesa as $ts): ?>
               <option value="<?= htmlspecialchars($ts) ?>"><?= ucfirst(str_replace('_',' ', $ts)) ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Salvadanaio</label>
+          <select name="id_salvadanaio" id="budgetSalvadanaio" class="form-select bg-secondary text-white">
+            <option value=""></option>
+            <?php foreach ($salvadanai as $s): ?>
+              <option value="<?= (int)$s['id_salvadanaio'] ?>"><?= htmlspecialchars($s['nome_salvadanaio']) ?></option>
             <?php endforeach; ?>
           </select>
         </div>

--- a/includes/render_budget.php
+++ b/includes/render_budget.php
@@ -4,6 +4,7 @@ function render_budget(array $row): void {
     $descrizione = trim($row['descrizione'] ?? '');
     $tipologia = trim($row['tipologia'] ?? '');
     $salvadanaio = trim($row['nome_salvadanaio'] ?? '');
+    $idSalvadanaio = isset($row['id_salvadanaio']) ? (int)$row['id_salvadanaio'] : '';
     $tipologiaSpesa = trim($row['tipologia_spesa'] ?? '');
     $importoNum = isset($row['importo']) ? (float)$row['importo'] : 0;
     $importoFmt = number_format($importoNum, 2, ',', '.');
@@ -26,6 +27,7 @@ function render_budget(array $row): void {
         . ' data-descrizione="' . htmlspecialchars($descrizione, ENT_QUOTES) . '"'
         . ' data-tipologia="' . htmlspecialchars($tipologia, ENT_QUOTES) . '"'
         . ' data-salvadanaio="' . htmlspecialchars($salvadanaio, ENT_QUOTES) . '"'
+        . ' data-id-salvadanaio="' . htmlspecialchars((string)$idSalvadanaio, ENT_QUOTES) . '"'
         . ' data-tipologia-spesa="' . htmlspecialchars($tipologiaSpesa, ENT_QUOTES) . '"'
         . ' data-inizio="' . htmlspecialchars($dataInizioRaw, ENT_QUOTES) . '"'
         . ' data-fine="' . htmlspecialchars($dataFineRaw, ENT_QUOTES) . '"'

--- a/js/budget.js
+++ b/js/budget.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const budgetDescrizione = document.getElementById('budgetDescrizione');
   const budgetTipologia = document.getElementById('budgetTipologia');
   const budgetTipologiaSpesa = document.getElementById('budgetTipologiaSpesa');
+  const budgetSalvadanaio = document.getElementById('budgetSalvadanaio');
   const budgetImporto = document.getElementById('budgetImporto');
   const budgetDataInizio = document.getElementById('budgetDataInizio');
   const budgetDataFine = document.getElementById('budgetDataFine');
@@ -99,6 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (budgetId) budgetId.value = '';
     if (budgetTipologia) budgetTipologia.value = '';
     if (budgetTipologiaSpesa) budgetTipologiaSpesa.value = '';
+    if (budgetSalvadanaio) budgetSalvadanaio.value = '';
     if (modalTitle) modalTitle.textContent = 'Nuovo budget';
     deleteBudgetBtn?.classList.add('d-none');
     budgetModal?.show();
@@ -111,6 +113,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (budgetDescrizione) budgetDescrizione.value = item.dataset.descrizione || '';
       if (budgetTipologia) budgetTipologia.value = item.dataset.tipologia || '';
       if (budgetTipologiaSpesa) budgetTipologiaSpesa.value = item.dataset.tipologiaSpesa || '';
+      if (budgetSalvadanaio) budgetSalvadanaio.value = item.dataset.idSalvadanaio || '';
       if (budgetImporto) budgetImporto.value = item.dataset.importo || '';
       if (budgetDataInizio) budgetDataInizio.value = item.dataset.inizio || '';
       if (budgetDataFine) budgetDataFine.value = item.dataset.fine || '';


### PR DESCRIPTION
## Summary
- Load piggy banks and expose `id_salvadanaio` in budget modal
- Preserve piggy bank id in rendered budget items for editing
- Handle piggy bank select in budget JavaScript
- Persist selected `id_salvadanaio` in budget AJAX handler

## Testing
- `php -l budget.php`
- `php -l includes/render_budget.php`
- `php -l ajax/budget_manage.php`
- `node --check js/budget.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689b0c5f8fdc8331ae1cee7e2f125771