### PR TITLE
Use dark logo for light theme

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -25,7 +25,7 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
   </button>
   <!--<a href="index.php" class="navbar-brand mb-0 h1">Gestione Famiglia 2.0</a>-->
   <a href="index.php" class="navbar-brand mb-0 h1">
-    <img src="assets/banner.png" alt="Gestione Famiglia" height="40" />
+    <img src="assets/<?= (($_SESSION['theme_id'] ?? 1) == 2) ? 'banner_nero.png' : 'banner.png' ?>" alt="Gestione Famiglia" height="40" />
   </a>
 </nav>
 


### PR DESCRIPTION
## Summary
- Show `banner_nero.png` when the "Chiaro" theme is active so the logo remains visible.

## Testing
- `php -l includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_689b6d2dd2148331820cf6bc5e7a2022