### PR TITLE
Add event editing and autocomplete for guests and food

### DIFF
--- a/ajax/add_e2c.php
+++ b/ajax/add_e2c.php
@@ -4,14 +4,29 @@ include '../includes/session_check.php';
 include '../includes/db.php';
 
 $id_evento = (int)($_POST['id_evento'] ?? 0);
-$id_cibo = (int)($_POST['id_cibo'] ?? 0);
+$cibo = trim($_POST['cibo'] ?? '');
 $quantita_input = trim($_POST['quantita'] ?? '');
 $quantita = $quantita_input === '' ? null : (float)$quantita_input;
 
-if(!$id_evento || !$id_cibo){
+if(!$id_evento || $cibo === ''){
     echo json_encode(['success' => false]);
     exit;
 }
+
+$famiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+
+$stmt = $conn->prepare('SELECT id FROM eventi_cibo WHERE id_famiglia = ? AND piatto = ? AND attivo = 1');
+$stmt->bind_param('is', $famiglia, $cibo);
+$stmt->execute();
+$stmt->bind_result($id_cibo);
+if(!$stmt->fetch()){
+    $stmt->close();
+    $stmt = $conn->prepare("INSERT INTO eventi_cibo (id_famiglia, piatto, um) VALUES (?,?, 'quantita')");
+    $stmt->bind_param('is', $famiglia, $cibo);
+    $stmt->execute();
+    $id_cibo = $stmt->insert_id;
+}
+$stmt->close();
 
 if($quantita === null){
     $stmt = $conn->prepare('INSERT INTO eventi_eventi2cibo (id_evento, id_cibo, quantita) VALUES (?,?,NULL)');

--- a/ajax/add_e2i.php
+++ b/ajax/add_e2i.php
@@ -4,16 +4,40 @@ include '../includes/session_check.php';
 include '../includes/db.php';
 
 $id_evento = (int)($_POST['id_evento'] ?? 0);
-$id_invitato = (int)($_POST['id_invitato'] ?? 0);
+$invitato = trim($_POST['invitato'] ?? '');
 $stato = $_POST['stato'] ?? '';
 $note = trim($_POST['note'] ?? '');
 $partecipa = $stato === 'partecipa' ? 1 : 0;
 $forse = $stato === 'forse' ? 1 : 0;
 $assente = $stato === 'assente' ? 1 : 0;
 
-if(!$id_evento || !$id_invitato){
+if(!$id_evento || $invitato === ''){
     echo json_encode(['success' => false]);
     exit;
+}
+
+$famiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+$parts = explode(' ', $invitato, 2);
+$nome = $parts[0] ?? '';
+$cognome = $parts[1] ?? '';
+
+$stmt = $conn->prepare('SELECT i.id FROM eventi_invitati i JOIN eventi_invitati2famiglie f ON i.id = f.id_invitato WHERE f.id_famiglia = ? AND f.attivo = 1 AND i.nome = ? AND i.cognome = ?');
+$stmt->bind_param('iss', $famiglia, $nome, $cognome);
+$stmt->execute();
+$stmt->bind_result($id_invitato);
+if(!$stmt->fetch()){
+    $stmt->close();
+    $stmt = $conn->prepare('INSERT INTO eventi_invitati (nome, cognome) VALUES (?,?)');
+    $stmt->bind_param('ss', $nome, $cognome);
+    $stmt->execute();
+    $id_invitato = $stmt->insert_id;
+    $stmt->close();
+    $stmt = $conn->prepare('INSERT INTO eventi_invitati2famiglie (id_invitato, id_famiglia, data_inizio) VALUES (?,?,CURDATE())');
+    $stmt->bind_param('ii', $id_invitato, $famiglia);
+    $stmt->execute();
+    $stmt->close();
+} else {
+    $stmt->close();
 }
 
 $stmt = $conn->prepare('INSERT INTO eventi_eventi2invitati (id_evento, id_invitato, partecipa, forse, assente, note) VALUES (?,?,?,?,?,?)');

--- a/ajax/update_evento.php
+++ b/ajax/update_evento.php
@@ -1,0 +1,31 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+include '../includes/permissions.php';
+
+if (!has_permission($conn, 'table:eventi', 'update')) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Accesso negato']);
+    exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+$titolo = trim($_POST['titolo'] ?? '');
+$descrizione = trim($_POST['descrizione'] ?? '');
+$data_evento = $_POST['data_evento'] ?? null;
+$ora_evento = $_POST['ora_evento'] ?? null;
+$id_tipo_evento = (int)($_POST['id_tipo_evento'] ?? 0);
+if ($id_tipo_evento === 0) { $id_tipo_evento = null; }
+
+if (!$id) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('UPDATE eventi SET titolo = ?, descrizione = ?, data_evento = ?, ora_evento = ?, id_tipo_evento = ? WHERE id = ?');
+$stmt->bind_param('ssssii', $titolo, $descrizione, $data_evento, $ora_evento, $id_tipo_evento, $id);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -36,13 +36,6 @@ document.addEventListener('DOMContentLoaded', () => {
     new bootstrap.Modal(document.getElementById('addInvitatoModal')).show();
   });
 
-  document.getElementById('invSearch')?.addEventListener('input', function(){
-    const q = this.value.toLowerCase();
-    document.querySelectorAll('#invSelect option').forEach(opt => {
-      opt.style.display = opt.text.toLowerCase().includes(q) ? '' : 'none';
-    });
-  });
-
   document.getElementById('addInvitatoForm')?.addEventListener('submit', function(e){
     e.preventDefault();
     const fd = new FormData(this);
@@ -61,6 +54,18 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const fd = new FormData(this);
     fetch('ajax/add_e2c.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
+  document.getElementById('editEventoBtn')?.addEventListener('click', () => {
+    new bootstrap.Modal(document.getElementById('eventoModal')).show();
+  });
+
+  document.getElementById('eventoForm')?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    fetch('ajax/update_evento.php', {method:'POST', body:fd})
       .then(r=>r.json())
       .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
   });


### PR DESCRIPTION
## Summary
- allow editing event details from the event page via pencil icon and modal
- support adding guests with autocomplete and auto-creation when not existing
- support adding food items with autocomplete and auto-creation when not existing

## Testing
- `php -l eventi_dettaglio.php`
- `php -l ajax/add_e2c.php`
- `php -l ajax/add_e2i.php`
- `php -l ajax/update_evento.php`
- `node --check js/eventi_dettaglio.js`


------
https://chatgpt.com/codex/tasks/task_e_689b6f81597c8331a75bda69fd453d6d