### PR TITLE
Enhance shopping list with import and clear actions

### DIFF
--- a/ajax/clear_lista_spesa.php
+++ b/ajax/clear_lista_spesa.php
@@ -1,0 +1,13 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:clear_lista_spesa', 'delete')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+if (!$idFamiglia) { echo json_encode(['success'=>false,'error'=>'Dati non validi']); exit; }
+$stmt = $conn->prepare('DELETE FROM lista_spesa WHERE id_famiglia = ?');
+$stmt->bind_param('i', $idFamiglia);
+$ok = $stmt->execute();
+echo json_encode(['success'=>$ok]);
+?>

--- a/ajax/delete_lista_spesa.php
+++ b/ajax/delete_lista_spesa.php
@@ -1,0 +1,14 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:delete_lista_spesa', 'delete')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$id = (int)($_POST['id'] ?? 0);
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+if (!$id || !$idFamiglia) { echo json_encode(['success'=>false,'error'=>'Dati non validi']); exit; }
+$stmt = $conn->prepare('DELETE FROM lista_spesa WHERE id = ? AND id_famiglia = ?');
+$stmt->bind_param('ii', $id, $idFamiglia);
+$ok = $stmt->execute();
+echo json_encode(['success'=>$ok]);
+?>

--- a/ajax/import_lista_spesa.php
+++ b/ajax/import_lista_spesa.php
@@ -1,0 +1,21 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:import_lista_spesa', 'insert')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$itemsRaw = trim($_POST['items'] ?? '');
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+if ($itemsRaw === '' || !$idFamiglia) { echo json_encode(['success'=>false,'error'=>'Dati non validi']); exit; }
+$lines = array_filter(array_map('trim', preg_split("/[\r\n]+/", $itemsRaw)));
+if (empty($lines)) { echo json_encode(['success'=>false,'error'=>'Nessun elemento']); exit; }
+$stmt = $conn->prepare('INSERT INTO lista_spesa (id_famiglia, nome) VALUES (?, ?)');
+$stmt->bind_param('is', $idFamiglia, $nome);
+$ok = true;
+foreach ($lines as $line) {
+    $nome = $line;
+    if ($nome === '') { continue; }
+    if (!$stmt->execute()) { $ok = false; break; }
+}
+echo json_encode(['success'=>$ok]);
+?>

--- a/includes/render_lista_spesa.php
+++ b/includes/render_lista_spesa.php
@@ -6,7 +6,9 @@ function render_lista_spesa(array $row): void {
     $note = htmlspecialchars($row['note'] ?? '', ENT_QUOTES);
     $checked = !empty($row['checked']);
     $line = $checked ? ' text-decoration-line-through' : '';
-    echo '<div class="d-flex justify-content-between align-items-center py-2 border-bottom" data-id="' . $id . '">';
+    echo '<div class="d-flex align-items-center py-2 border-bottom" data-id="' . $id . '">';
+    echo '  <button type="button" class="btn btn-sm btn-outline-light me-2 edit-btn" data-id="' . $id . '" data-nome="' . $nome . '" data-quantita="' . $quantita . '" data-note="' . $note . '"><i class="bi bi-pencil"></i></button>';
+    echo '  <button type="button" class="btn btn-sm btn-outline-light me-2 delete-btn" data-id="' . $id . '"><i class="bi bi-trash"></i></button>';
     echo '  <div class="flex-grow-1' . $line . '">';
     echo        $nome;
     if ($quantita !== '') {
@@ -16,10 +18,7 @@ function render_lista_spesa(array $row): void {
         echo '<br><small class="text-muted">' . $note . '</small>';
     }
     echo '  </div>';
-    echo '  <div class="d-flex align-items-center ms-2">';
-    echo '    <button type="button" class="btn btn-sm btn-outline-light me-2 edit-btn" data-id="' . $id . '" data-nome="' . $nome . '" data-quantita="' . $quantita . '" data-note="' . $note . '"><i class="bi bi-pencil"></i></button>';
-    echo '    <input type="checkbox" class="form-check-input" data-id="' . $id . '"' . ($checked ? ' checked' : '') . '>';
-    echo '  </div>';
+    echo '  <input type="checkbox" class="form-check-input ms-2" data-id="' . $id . '"' . ($checked ? ' checked' : '') . '>';
     echo '</div>';
 }
 ?>

--- a/lista_spesa.php
+++ b/lista_spesa.php
@@ -16,7 +16,11 @@ $canAdd = has_permission($conn, 'ajax:add_lista_spesa', 'insert');
 <div class="d-flex mb-3 justify-content-between">
   <h4>Lista spesa</h4>
   <?php if ($canAdd): ?>
-  <button type="button" class="btn btn-outline-light btn-sm" onclick="openListaModal()">Aggiungi nuovo</button>
+  <div>
+    <button type="button" class="btn btn-outline-light btn-sm me-2" onclick="openImportModal()">Importa</button>
+    <button type="button" class="btn btn-outline-light btn-sm me-2" id="clearListaBtn">Svuota lista</button>
+    <button type="button" class="btn btn-outline-light btn-sm" onclick="openListaModal()">Aggiungi nuovo</button>
+  </div>
   <?php endif; ?>
 </div>
 <div id="listaSpesaList">
@@ -49,6 +53,26 @@ $canAdd = has_permission($conn, 'ajax:add_lista_spesa', 'insert');
       </div>
       <div class="modal-footer">
         <button type="submit" class="btn btn-primary w-100">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="modal fade" id="importModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="importForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Importa elementi</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Elementi (uno per riga)</label>
+          <textarea name="items" class="form-control bg-secondary text-white" rows="5" required></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Importa</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- Move edit icon to the left and add trash icon for each item in the shopping list
- Add buttons to import multiple items or clear the shopping list
- Support item deletion, list clearing and bulk import via new AJAX endpoints

## Testing
- `php -l lista_spesa.php`
- `php -l includes/render_lista_spesa.php`
- `php -l ajax/delete_lista_spesa.php`
- `php -l ajax/clear_lista_spesa.php`
- `php -l ajax/import_lista_spesa.php`
- `node --check js/lista_spesa.js`

------
https://chatgpt.com/codex/tasks/task_e_689b70c1f0148331bec1e3199a5af501