### PR TITLE
Enable cibo editing and add field hints

### DIFF
--- a/ajax/update_e2c.php
+++ b/ajax/update_e2c.php
@@ -1,0 +1,41 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_e2c = (int)($_POST['id_e2c'] ?? 0);
+$cibo = trim($_POST['cibo'] ?? '');
+$quantita_input = trim($_POST['quantita'] ?? '');
+$quantita = $quantita_input === '' ? null : (float)$quantita_input;
+
+if(!$id_e2c || $cibo === ''){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$famiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+
+$stmt = $conn->prepare('SELECT id FROM eventi_cibo WHERE id_famiglia = ? AND piatto = ? AND attivo = 1');
+$stmt->bind_param('is', $famiglia, $cibo);
+$stmt->execute();
+$stmt->bind_result($id_cibo);
+if(!$stmt->fetch()){
+    $stmt->close();
+    $stmt = $conn->prepare("INSERT INTO eventi_cibo (id_famiglia, piatto, um) VALUES (?,?, 'quantita')");
+    $stmt->bind_param('is', $famiglia, $cibo);
+    $stmt->execute();
+    $id_cibo = $stmt->insert_id;
+}
+$stmt->close();
+
+if($quantita === null){
+    $stmt = $conn->prepare('UPDATE eventi_eventi2cibo SET id_cibo=?, quantita=NULL WHERE id_e2c=?');
+    $stmt->bind_param('ii', $id_cibo, $id_e2c);
+} else {
+    $stmt = $conn->prepare('UPDATE eventi_eventi2cibo SET id_cibo=?, quantita=? WHERE id_e2c=?');
+    $stmt->bind_param('idi', $id_cibo, $quantita, $id_e2c);
+}
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/eventi_dettaglio.php
+++ b/eventi_dettaglio.php
@@ -45,7 +45,7 @@ $stmtDisp->close();
 
 // Cibo collegato all'evento
 $cibi = [];
-$stmtCibo = $conn->prepare("SELECT c.piatto, c.um, e2c.quantita FROM eventi_eventi2cibo e2c JOIN eventi_cibo c ON e2c.id_cibo = c.id WHERE e2c.id_evento = ? ORDER BY c.piatto");
+$stmtCibo = $conn->prepare("SELECT e2c.id_e2c, c.piatto, c.um, e2c.quantita FROM eventi_eventi2cibo e2c JOIN eventi_cibo c ON e2c.id_cibo = c.id WHERE e2c.id_evento = ? ORDER BY c.piatto");
 $stmtCibo->bind_param('i', $id);
 $stmtCibo->execute();
 $resCibo = $stmtCibo->get_result();
@@ -119,7 +119,10 @@ include 'includes/header.php';
   </div>
   <ul class="list-group list-group-flush bg-dark" id="ciboList">
     <?php foreach ($cibi as $idx => $row): ?>
-      <li class="list-group-item bg-dark text-white <?= $idx >= 3 ? 'd-none extra-row' : '' ?>">
+      <li class="list-group-item bg-dark text-white <?= $idx >= 3 ? 'd-none extra-row' : '' ?> cibo-row"
+          data-id="<?= (int)$row['id_e2c'] ?>"
+          data-piatto="<?= htmlspecialchars($row['piatto'], ENT_QUOTES) ?>"
+          data-quantita="<?= htmlspecialchars($row['quantita'] ?? '', ENT_QUOTES) ?>">
         <?= htmlspecialchars($row['piatto']) ?><?php if ($row['quantita'] !== null) echo ' - ' . htmlspecialchars($row['quantita']) . ' ' . htmlspecialchars($row['um']); ?>
       </li>
     <?php endforeach; ?>
@@ -232,6 +235,7 @@ include 'includes/header.php';
               <option value="<?= htmlspecialchars($inv['nome'] . ' ' . $inv['cognome']) ?>"></option>
             <?php endforeach; ?>
           </datalist>
+          <div class="form-text text-white-50">Inizia a digitare e seleziona un invitato dai suggerimenti</div>
         </div>
         <div class="mb-3">
           <label class="form-label">Stato</label>
@@ -259,6 +263,38 @@ include 'includes/header.php';
         <button type="submit" class="btn btn-primary w-100">Aggiungi</button>
       </div>
     </form>
+</div>
+</div>
+
+<!-- Modal modifica cibo -->
+<div class="modal fade" id="ciboModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="ciboForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Cibo</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" name="id_e2c" id="id_e2c">
+        <div class="mb-3">
+          <label class="form-label">Cibo</label>
+          <input type="text" name="cibo" id="ciboNome" list="ciboOptionsEdit" class="form-control bg-secondary text-white">
+          <datalist id="ciboOptionsEdit">
+            <?php foreach ($ciboDisponibile as $c): ?>
+              <option value="<?= htmlspecialchars($c['piatto']) ?>"></option>
+            <?php endforeach; ?>
+          </datalist>
+          <div class="form-text text-white-50">Inizia a digitare e seleziona un cibo dai suggerimenti</div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Quantità</label>
+          <input type="number" step="0.01" name="quantita" id="ciboQuantita" class="form-control bg-secondary text-white">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Salva</button>
+      </div>
+    </form>
   </div>
 </div>
 
@@ -280,6 +316,7 @@ include 'includes/header.php';
               <option value="<?= htmlspecialchars($c['piatto']) ?>"></option>
             <?php endforeach; ?>
           </datalist>
+          <div class="form-text text-white-50">Inizia a digitare e seleziona un cibo dai suggerimenti</div>
         </div>
         <div class="mb-3">
           <label class="form-label">Quantità</label>
@@ -297,6 +334,7 @@ include 'includes/header.php';
 #invitatiList .list-group-item,
 #ciboList .list-group-item { padding: 0.25rem 0.5rem; }
 #invitatiList .inv-row { cursor: pointer; }
+#ciboList .cibo-row { cursor: pointer; }
 </style>
 <script src="js/eventi_dettaglio.js"></script>
 <?php include 'includes/footer.php'; ?>

--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -58,6 +58,25 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
   });
 
+  // apertura modal modifica cibo
+  document.querySelectorAll('#ciboList .cibo-row').forEach(li => {
+    li.addEventListener('click', () => {
+      const form = document.getElementById('ciboForm');
+      form.id_e2c.value = li.dataset.id;
+      form.cibo.value = li.dataset.piatto;
+      form.quantita.value = li.dataset.quantita || '';
+      new bootstrap.Modal(document.getElementById('ciboModal')).show();
+    });
+  });
+
+  document.getElementById('ciboForm')?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    fetch('ajax/update_e2c.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
   document.getElementById('editEventoBtn')?.addEventListener('click', () => {
     new bootstrap.Modal(document.getElementById('eventoModal')).show();
   });


### PR DESCRIPTION
## Summary
- Allow editing of event food entries by clicking list items
- Clarify invitato and cibo fields with inline hints
- Provide backend endpoint and JS to update event food quantities

## Testing
- `php -l eventi_dettaglio.php`
- `php -l ajax/update_e2c.php`
- `node --check js/eventi_dettaglio.js`


------
https://chatgpt.com/codex/tasks/task_e_689b7629e10883319fa8176725720347