### PR TITLE
Add shift calendar with database support

### DIFF
--- a/ajax/turni_update.php
+++ b/ajax/turni_update.php
@@ -1,0 +1,30 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+include '../includes/permissions.php';
+if (!has_permission($conn, 'table:turni_calendario', 'update')) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Accesso negato']);
+    exit;
+}
+$data = json_decode(file_get_contents('php://input'), true);
+$date = $data['date'] ?? null;
+$idTipo = isset($data['id_tipo']) ? (int)$data['id_tipo'] : null;
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+if (!$date || !$idFamiglia) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+if ($idTipo) {
+    $stmt = $conn->prepare('INSERT INTO turni_calendario (id_famiglia, data, id_tipo) VALUES (?,?,?) ON DUPLICATE KEY UPDATE id_tipo = VALUES(id_tipo)');
+    $stmt->bind_param('isi', $idFamiglia, $date, $idTipo);
+    $success = $stmt->execute();
+    $stmt->close();
+} else {
+    $stmt = $conn->prepare('DELETE FROM turni_calendario WHERE id_famiglia = ? AND data = ?');
+    $stmt->bind_param('is', $idFamiglia, $date);
+    $success = $stmt->execute();
+    $stmt->close();
+}
+echo json_encode(['success' => $success]);

--- a/includes/header.php
+++ b/includes/header.php
@@ -153,6 +153,9 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
             <?php if (has_permission($conn, 'page:eventi.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/eventi.php"><i class="bi bi-calendar-event me-2 text-white"></i>Eventi</a></li>
             <?php endif; ?>
+            <?php if (has_permission($conn, 'page:turni.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/turni.php"><i class="bi bi-calendar-week me-2 text-white"></i>Turni</a></li>
+            <?php endif; ?>
             <?php if (has_permission($conn, 'page:lista_spesa.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/lista_spesa.php"><i class="bi bi-basket me-2 text-white"></i>Lista spesa</a></li>
             <?php endif; ?>

--- a/js/turni.js
+++ b/js/turni.js
@@ -1,0 +1,101 @@
+document.addEventListener('DOMContentLoaded', () => {
+  let current = new Date();
+  let selectedType = null;
+  const monthLabel = document.getElementById('monthLabel');
+  const calendarContainer = document.getElementById('calendarContainer');
+
+  function loadTurni(year, month){
+    fetch(`ajax/turni_get.php?year=${year}&month=${month+1}`)
+      .then(r=>r.json())
+      .then(data=>renderCalendar(year, month, data));
+  }
+
+  function renderCalendar(year, month, turni){
+    calendarContainer.innerHTML = '';
+    const headers = ['LUN','MAR','MER','GIO','VEN','SAB','DOM'];
+    const headerRow = document.createElement('div');
+    headerRow.className = 'row row-cols-7 g-0 text-center fw-bold';
+    headers.forEach(h=>{
+      const col = document.createElement('div');
+      col.className='col border py-2';
+      col.textContent=h;
+      headerRow.appendChild(col);
+    });
+    calendarContainer.appendChild(headerRow);
+
+    const first = new Date(year, month, 1);
+    const last = new Date(year, month+1, 0);
+    const start = (first.getDay()+6)%7; // monday=0
+    let day=1;
+    let row = document.createElement('div');
+    row.className='row row-cols-7 g-0';
+    for(let i=0;i<start;i++){
+      const col=document.createElement('div');
+      col.className='col border bg-secondary bg-opacity-10';
+      row.appendChild(col);
+    }
+    while(day<=last.getDate()){
+      if(row.children.length===7){
+        calendarContainer.appendChild(row);
+        row=document.createElement('div');
+        row.className='row row-cols-7 g-0';
+      }
+      const col=document.createElement('div');
+      col.className='col border p-2 position-relative day-cell';
+      const dateStr=`${year}-${String(month+1).padStart(2,'0')}-${String(day).padStart(2,'0')}`;
+      col.dataset.date=dateStr;
+      col.innerHTML=`<div class="small text-start">${day}</div>`;
+      const info=turni[dateStr];
+      if(info){
+        col.dataset.idTipo=info.id_tipo;
+        col.insertAdjacentHTML('beforeend', `<div class="text-center">${info.descrizione}</div>`);
+        col.style.background=info.colore_bg;
+        col.style.color=info.colore_testo;
+      }
+      const t=new Date();
+      if(year===t.getFullYear() && month===t.getMonth() && day===t.getDate()){
+        col.classList.add('border-primary');
+      }
+      row.appendChild(col);
+      day++;
+    }
+    while(row.children.length<7){
+      const col=document.createElement('div');
+      col.className='col border bg-secondary bg-opacity-10';
+      row.appendChild(col);
+    }
+    calendarContainer.appendChild(row);
+    monthLabel.textContent = new Intl.DateTimeFormat('it-IT',{month:'long',year:'numeric'}).format(new Date(year,month,1)).toUpperCase();
+  }
+
+  calendarContainer.addEventListener('click', e=>{
+    const cell=e.target.closest('.day-cell');
+    if(!cell || selectedType===null) return;
+    const date=cell.dataset.date;
+    const payload = selectedType==='delete' ? {date} : {date,id_tipo:selectedType};
+    fetch('ajax/turni_update.php',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success){ loadTurni(current.getFullYear(), current.getMonth()); }});
+  });
+
+  function toggleStateB(show){
+    document.getElementById('stateA').classList.toggle('d-none', show);
+    document.getElementById('stateB').classList.toggle('d-none', !show);
+  }
+
+  document.getElementById('btnSingolo').addEventListener('click', ()=>toggleStateB(true));
+  document.getElementById('closeStateB').addEventListener('click', ()=>{selectedType=null;toggleStateB(false);});
+
+  document.getElementById('pillContainer').addEventListener('click', e=>{
+    if(e.target.classList.contains('pill')){
+      document.querySelectorAll('#pillContainer .pill').forEach(p=>p.classList.remove('active'));
+      e.target.classList.add('active');
+      selectedType=e.target.dataset.type;
+    }
+  });
+
+  document.getElementById('prevMonth').addEventListener('click', ()=>{current.setMonth(current.getMonth()-1);loadTurni(current.getFullYear(),current.getMonth());});
+  document.getElementById('nextMonth').addEventListener('click', ()=>{current.setMonth(current.getMonth()+1);loadTurni(current.getFullYear(),current.getMonth());});
+
+  loadTurni(current.getFullYear(), current.getMonth());
+});

--- a/sql/turni.sql
+++ b/sql/turni.sql
@@ -1,0 +1,17 @@
+CREATE TABLE turni_tipi (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    descrizione VARCHAR(100) NOT NULL,
+    colore_bg VARCHAR(7) NOT NULL,
+    colore_testo VARCHAR(7) NOT NULL DEFAULT '#000000',
+    attivo TINYINT(1) NOT NULL DEFAULT 1
+);
+
+CREATE TABLE turni_calendario (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    id_famiglia INT NOT NULL,
+    data DATE NOT NULL,
+    id_tipo INT NOT NULL,
+    UNIQUE KEY uniq_turno (id_famiglia, data),
+    FOREIGN KEY (id_famiglia) REFERENCES famiglie(id_famiglia),
+    FOREIGN KEY (id_tipo) REFERENCES turni_tipi(id)
+);

--- a/turni.php
+++ b/turni.php
@@ -1,0 +1,61 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:turni.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+include 'includes/header.php';
+
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+$tipiRes = $conn->query("SELECT id, descrizione, colore_bg, colore_testo FROM turni_tipi WHERE attivo = 1 ORDER BY descrizione");
+$tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
+?>
+<style>
+  #calendarContainer .col {height: 100px;}
+  #pillContainer .pill.active {outline:2px solid #fff;}
+</style>
+<div id="shifter" class="d-flex flex-column min-vh-100 p-0">
+  <div class="bg-dark text-white p-3 position-sticky top-0">
+    <div class="d-flex justify-content-between align-items-center">
+      <div class="d-flex align-items-center">
+        <span class="fw-bold me-3">Shifter</span>
+        <span class="text-muted">Turni neuro</span>
+      </div>
+      <div class="d-flex align-items-center">
+        <i class="bi bi-chevron-left me-2" id="prevMonth" role="button"></i>
+        <span id="monthLabel" class="mx-2 text-uppercase"></span>
+        <i class="bi bi-chevron-right ms-2" id="nextMonth" role="button"></i>
+      </div>
+    </div>
+    <div class="mt-2 text-center">
+      <span class="me-3">SETTEMBRE</span>
+      <span class="me-3">AGOSTO</span>
+      <span>RIEPILOGO</span>
+    </div>
+  </div>
+  <div class="flex-grow-1 overflow-auto" id="calendarContainer"></div>
+  <div id="bottomBar" class="bg-dark text-white p-2 position-sticky bottom-0">
+    <div id="stateA" class="d-flex justify-content-around">
+      <button class="btn btn-outline-light flex-fill mx-1" id="btnSingolo">SINGOLO</button>
+      <button class="btn btn-outline-light flex-fill mx-1" disabled>MULTIPLA</button>
+      <button class="btn btn-outline-light flex-fill mx-1" disabled>TURNI</button>
+    </div>
+    <div id="stateB" class="d-none">
+      <div class="d-flex align-items-center">
+        <i class="bi bi-chevron-down me-2" id="closeStateB" role="button"></i>
+        <div class="flex-grow-1 overflow-auto">
+          <div class="d-flex flex-nowrap" id="pillContainer">
+            <button class="btn btn-sm btn-outline-light me-2 pill" data-type="delete">Eliminare</button>
+            <?php foreach ($tipi as $t): ?>
+            <button class="btn btn-sm me-2 pill" data-type="<?= (int)$t['id'] ?>" style="background: <?= htmlspecialchars($t['colore_bg']) ?>;color: <?= htmlspecialchars($t['colore_testo']) ?>"><?= htmlspecialchars($t['descrizione']) ?></button>
+            <?php endforeach; ?>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  const turniTipi = <?= json_encode($tipi) ?>;
+</script>
+<script src="js/turni.js"></script>
+<?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add monthly "Turni" planner with selectable shift types and sticky controls
- store shift types and assignments in new `turni` tables
- expose AJAX endpoints and menu link for calendar access

## Testing
- `php -l turni.php`
- `php -l ajax/turni_get.php`
- `php -l ajax/turni_update.php`
- `node --check js/turni.js && echo SyntaxOK`


------
https://chatgpt.com/codex/tasks/task_e_689de5bcc224833199a45433f227d93f