### PR TITLE
Add event guest and food management pages

### DIFF
--- a/ajax/add_invitato_evento.php
+++ b/ajax/add_invitato_evento.php
@@ -1,0 +1,45 @@
+<?php
+include '../includes/session_check.php';
+require_once '../includes/db.php';
+require_once '../includes/permissions.php';
+header('Content-Type: application/json');
+if (!has_permission($conn, 'table:eventi_invitati', 'insert')) {
+    echo json_encode(['success'=>false,'error'=>'Accesso negato']);
+    exit;
+}
+$nome = trim($_POST['nome'] ?? '');
+$cognome = trim($_POST['cognome'] ?? '');
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+if ($nome === '' || $cognome === '' || !$idFamiglia) {
+    echo json_encode(['success'=>false,'error'=>'Dati mancanti']);
+    exit;
+}
+$conn->begin_transaction();
+try {
+    $stmt = $conn->prepare('SELECT i.id FROM eventi_invitati i JOIN eventi_invitati2famiglie f ON i.id=f.id_invitato WHERE f.id_famiglia=? AND f.attivo=1 AND i.nome=? AND i.cognome=?');
+    $stmt->bind_param('iss', $idFamiglia, $nome, $cognome);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($row = $res->fetch_assoc()) {
+        $idInv = (int)$row['id'];
+    } else {
+        $stmt = $conn->prepare('INSERT INTO eventi_invitati (nome,cognome) VALUES (?,?)');
+        $stmt->bind_param('ss', $nome, $cognome);
+        $stmt->execute();
+        $idInv = $stmt->insert_id;
+    }
+    $stmt = $conn->prepare('SELECT id_i2f FROM eventi_invitati2famiglie WHERE id_invitato=? AND id_famiglia=? AND attivo=1');
+    $stmt->bind_param('ii', $idInv, $idFamiglia);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if (!$res->num_rows) {
+        $stmt = $conn->prepare('INSERT INTO eventi_invitati2famiglie (id_invitato,id_famiglia,data_inizio) VALUES (?,?,CURDATE())');
+        $stmt->bind_param('ii', $idInv, $idFamiglia);
+        $stmt->execute();
+    }
+    $conn->commit();
+    echo json_encode(['success'=>true]);
+} catch (Exception $e) {
+    $conn->rollback();
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+}

--- a/ajax/invitati_cibo.php
+++ b/ajax/invitati_cibo.php
@@ -1,0 +1,46 @@
+<?php
+include '../includes/session_check.php';
+require_once '../includes/db.php';
+require_once '../includes/permissions.php';
+header('Content-Type: application/json');
+$action = $_POST['action'] ?? '';
+try {
+    switch ($action) {
+        case 'add':
+            if (!has_permission($conn,'table:eventi_cibo','insert')) throw new Exception('Accesso negato');
+            $idFam = $_SESSION['id_famiglia_gestione'] ?? 0;
+            $piatto = trim($_POST['piatto'] ?? '');
+            $dolce = isset($_POST['dolce']) ? 1 : 0;
+            $bere = isset($_POST['bere']) ? 1 : 0;
+            $um = $_POST['um'] ?? '';
+            $stmt = $conn->prepare('INSERT INTO eventi_cibo (id_famiglia,piatto,dolce,bere,um) VALUES (?,?,?,?,?)');
+            $stmt->bind_param('isiis',$idFam,$piatto,$dolce,$bere,$um);
+            $stmt->execute();
+            echo json_encode(['success'=>true]);
+            break;
+        case 'update':
+            if (!has_permission($conn,'table:eventi_cibo','update')) throw new Exception('Accesso negato');
+            $id = (int)($_POST['id'] ?? 0);
+            $piatto = trim($_POST['piatto'] ?? '');
+            $dolce = isset($_POST['dolce']) ? 1 : 0;
+            $bere = isset($_POST['bere']) ? 1 : 0;
+            $um = $_POST['um'] ?? '';
+            $stmt = $conn->prepare('UPDATE eventi_cibo SET piatto=?, dolce=?, bere=?, um=? WHERE id=?');
+            $stmt->bind_param('siisi',$piatto,$dolce,$bere,$um,$id);
+            $stmt->execute();
+            echo json_encode(['success'=>true]);
+            break;
+        case 'delete':
+            if (!has_permission($conn,'table:eventi_cibo','delete')) throw new Exception('Accesso negato');
+            $id = (int)($_POST['id'] ?? 0);
+            $stmt = $conn->prepare('DELETE FROM eventi_cibo WHERE id=?');
+            $stmt->bind_param('i',$id);
+            $stmt->execute();
+            echo json_encode(['success'=>true]);
+            break;
+        default:
+            throw new Exception('Azione non valida');
+    }
+} catch (Exception $e) {
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+}

--- a/ajax/invitati_eventi_dettaglio.php
+++ b/ajax/invitati_eventi_dettaglio.php
@@ -1,0 +1,56 @@
+<?php
+include '../includes/session_check.php';
+require_once '../includes/db.php';
+require_once '../includes/permissions.php';
+header('Content-Type: application/json');
+$action = $_POST['action'] ?? '';
+try {
+    switch ($action) {
+        case 'update_invitato':
+            if (!has_permission($conn,'table:eventi_invitati','update')) throw new Exception('Accesso negato');
+            $id = (int)($_POST['id'] ?? 0);
+            $nome = trim($_POST['nome'] ?? '');
+            $cognome = trim($_POST['cognome'] ?? '');
+            $stmt = $conn->prepare('UPDATE eventi_invitati SET nome=?, cognome=? WHERE id=?');
+            $stmt->bind_param('ssi',$nome,$cognome,$id);
+            $stmt->execute();
+            echo json_encode(['success'=>true]);
+            break;
+        case 'add_famiglia':
+            if (!has_permission($conn,'table:eventi_invitati2famiglie','insert')) throw new Exception('Accesso negato');
+            $idInv = (int)($_POST['id_invitato'] ?? ($_POST['id'] ?? 0));
+            $idFam = (int)($_POST['id_famiglia'] ?? 0);
+            $inizio = $_POST['data_inizio'] ?? '';
+            $fine = $_POST['data_fine'] ?? '9999-12-31';
+            $attivo = isset($_POST['attivo']) ? 1 : 0;
+            $stmt = $conn->prepare('INSERT INTO eventi_invitati2famiglie (id_invitato,id_famiglia,data_inizio,data_fine,attivo) VALUES (?,?,?,?,?)');
+            $stmt->bind_param('iissi',$idInv,$idFam,$inizio,$fine,$attivo);
+            $stmt->execute();
+            echo json_encode(['success'=>true]);
+            break;
+        case 'update_famiglia':
+            if (!has_permission($conn,'table:eventi_invitati2famiglie','update')) throw new Exception('Accesso negato');
+            $id = (int)($_POST['id'] ?? 0);
+            $idFam = (int)($_POST['id_famiglia'] ?? 0);
+            $inizio = $_POST['data_inizio'] ?? '';
+            $fine = $_POST['data_fine'] ?? '9999-12-31';
+            $attivo = isset($_POST['attivo']) ? 1 : 0;
+            $stmt = $conn->prepare('UPDATE eventi_invitati2famiglie SET id_famiglia=?, data_inizio=?, data_fine=?, attivo=? WHERE id_i2f=?');
+            $stmt->bind_param('issii',$idFam,$inizio,$fine,$attivo,$id);
+            $stmt->execute();
+            echo json_encode(['success'=>true]);
+            break;
+        case 'delete_famiglia':
+            if (!has_permission($conn,'table:eventi_invitati2famiglie','delete')) throw new Exception('Accesso negato');
+            $id = (int)($_POST['id'] ?? 0);
+            $stmt = $conn->prepare('DELETE FROM eventi_invitati2famiglie WHERE id_i2f=?');
+            $stmt->bind_param('i',$id);
+            $stmt->execute();
+            echo json_encode(['success'=>true]);
+            break;
+        default:
+            throw new Exception('Azione non valida');
+    }
+} catch (Exception $e) {
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+}

--- a/includes/header.php
+++ b/includes/header.php
@@ -268,6 +268,16 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
             <?php if (isset($tableLinks['userlevels'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/table_manager.php?table=userlevels">User Levels</a></li>
             <?php endif; ?>
+            <?php if (has_permission($conn, 'page:invitati_eventi.php', 'view') || has_permission($conn, 'page:invitati_cibo.php', 'view')): ?>
+            <li><hr class="dropdown-divider"></li>
+            <li><h6 class="dropdown-header">Eventi</h6></li>
+            <?php if (has_permission($conn, 'page:invitati_eventi.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/invitati_eventi.php">Invitati</a></li>
+            <?php endif; ?>
+            <?php if (has_permission($conn, 'page:invitati_cibo.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/invitati_cibo.php">Cibo</a></li>
+            <?php endif; ?>
+            <?php endif; ?>
             <?php if (has_permission($conn, 'page:temi.php', 'view')): ?>
             <li><hr class="dropdown-divider"></li>
             <li><h6 class="dropdown-header">Aspetto</h6></li>

--- a/includes/render_cibo_evento.php
+++ b/includes/render_cibo_evento.php
@@ -1,0 +1,14 @@
+<?php
+function render_cibo_evento(array $row): void {
+    $search = strtolower($row['piatto'] ?? '');
+    $searchAttr = htmlspecialchars($search, ENT_QUOTES);
+    $id = (int)($row['id'] ?? 0);
+    $piatto = htmlspecialchars($row['piatto'] ?? '', ENT_QUOTES);
+    $dolce = (int)($row['dolce'] ?? 0);
+    $bere = (int)($row['bere'] ?? 0);
+    $um = htmlspecialchars($row['um'] ?? '', ENT_QUOTES);
+    echo '<div class="cibo-card movement d-flex justify-content-between align-items-start text-white text-decoration-none" data-search="' . $searchAttr . '" data-id="' . $id . '" data-piatto="' . $piatto . '" data-dolce="' . $dolce . '" data-bere="' . $bere . '" data-um="' . $um . '" onclick="openCiboEdit(this)">';
+    echo '  <div class="fw-semibold">' . htmlspecialchars($row['piatto']) . '</div>';
+    echo '</div>';
+}
+?>

--- a/includes/render_invitato_evento.php
+++ b/includes/render_invitato_evento.php
@@ -1,0 +1,12 @@
+<?php
+function render_invitato_evento(array $row): void {
+    $search = strtolower(trim(($row['nome'] ?? '') . ' ' . ($row['cognome'] ?? '')));
+    $searchAttr = htmlspecialchars($search, ENT_QUOTES);
+    $url = 'invitati_eventi_dettaglio.php?id=' . (int)($row['id'] ?? 0);
+    echo '<div class="invitato-card movement d-flex justify-content-between align-items-start text-white text-decoration-none" data-search="' . $searchAttr . '" onclick="window.location.href=\'' . $url . '\'">';
+    echo '  <div class="flex-grow-1">';
+    echo '    <div class="fw-semibold">' . htmlspecialchars(($row['nome'] ?? '') . ' ' . ($row['cognome'] ?? '')) . '</div>';
+    echo '  </div>';
+    echo '</div>';
+}
+?>

--- a/invitati_cibo.php
+++ b/invitati_cibo.php
@@ -1,0 +1,72 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:invitati_cibo.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+require_once 'includes/render_cibo_evento.php';
+include 'includes/header.php';
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+$stmt = $conn->prepare('SELECT * FROM eventi_cibo WHERE id_famiglia=? AND attivo=1 ORDER BY piatto');
+$stmt->bind_param("i", $idFamiglia);
+$stmt->execute();
+$res = $stmt->get_result();
+$canInsert = has_permission($conn, 'table:eventi_cibo', 'insert');
+$canUpdate = has_permission($conn, 'table:eventi_cibo', 'update');
+$canDelete = has_permission($conn, 'table:eventi_cibo', 'delete');
+?>
+<div class="d-flex mb-3 justify-content-between">
+  <h4>Cibo eventi</h4>
+  <?php if ($canInsert): ?>
+  <button type="button" class="btn btn-outline-light btn-sm" onclick="openCiboModal()">Aggiungi nuovo</button>
+  <?php endif; ?>
+</div>
+<div class="d-flex mb-3 align-items-center">
+  <input type="text" id="search" class="form-control bg-dark text-white border-secondary" placeholder="Cerca">
+</div>
+<div id="ciboList">
+<?php while ($row = $res->fetch_assoc()): ?>
+  <?php render_cibo_evento($row); ?>
+<?php endwhile; ?>
+</div>
+<?php if ($canInsert || $canUpdate): ?>
+<div class="modal fade" id="ciboModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="ciboForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Cibo</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Piatto</label>
+          <input type="text" name="piatto" class="form-control bg-secondary text-white" required>
+        </div>
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="checkbox" name="dolce" id="dolce">
+          <label class="form-check-label" for="dolce">Dolce</label>
+        </div>
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="checkbox" name="bere" id="bere">
+          <label class="form-check-label" for="bere">Bere</label>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Unità di misura</label>
+          <select name="um" class="form-select bg-secondary text-white">
+            <option value="etti">etti</option>
+            <option value="quantita">quantità</option>
+            <option value="porzioni">porzioni</option>
+            <option value="litri">litri</option>
+          </select>
+        </div>
+        <input type="hidden" name="id" id="cibo_id">
+      </div>
+      <div class="modal-footer d-flex justify-content-between">
+        <button type="button" class="btn btn-danger me-auto d-none" id="deleteCibo">Elimina</button>
+        <button type="submit" class="btn btn-primary">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+<?php endif; ?>
+<script src="js/invitati_cibo.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/invitati_eventi.php
+++ b/invitati_eventi.php
@@ -1,0 +1,55 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:invitati_eventi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+require_once 'includes/render_invitato_evento.php';
+include 'includes/header.php';
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+$stmt = $conn->prepare('SELECT i.id, IFNULL(u.nome,i.nome) AS nome, IFNULL(u.cognome,i.cognome) AS cognome FROM eventi_invitati i JOIN eventi_invitati2famiglie f ON i.id=f.id_invitato LEFT JOIN utenti u ON i.id_utente=u.id AND u.attivo=1 WHERE f.id_famiglia=? AND f.attivo=1 ORDER BY cognome,nome');
+$stmt->bind_param('i', $idFamiglia);
+$stmt->execute();
+$res = $stmt->get_result();
+$canInsert = has_permission($conn, 'table:eventi_invitati', 'insert');
+?>
+<div class="d-flex mb-3 justify-content-between">
+  <h4>Invitati</h4>
+  <?php if ($canInsert): ?>
+  <button type="button" class="btn btn-outline-light btn-sm" onclick="openInvitatoModal()">Aggiungi nuovo</button>
+  <?php endif; ?>
+</div>
+<div class="d-flex mb-3 align-items-center">
+  <input type="text" id="search" class="form-control bg-dark text-white border-secondary" placeholder="Cerca">
+</div>
+<div id="invitatiList">
+<?php while ($row = $res->fetch_assoc()): ?>
+  <?php render_invitato_evento($row); ?>
+<?php endwhile; ?>
+</div>
+<?php if ($canInsert): ?>
+<div class="modal fade" id="invitatoModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="invitatoForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Nuovo invitato</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Nome</label>
+          <input type="text" name="nome" class="form-control bg-secondary text-white" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Cognome</label>
+          <input type="text" name="cognome" class="form-control bg-secondary text-white" required>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+<?php endif; ?>
+<script src="js/invitati_eventi.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/invitati_eventi_dettaglio.php
+++ b/invitati_eventi_dettaglio.php
@@ -1,0 +1,101 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:invitati_eventi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+include 'includes/header.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $conn->prepare('SELECT id, nome, cognome FROM eventi_invitati WHERE id=?');
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$inv = $stmt->get_result()->fetch_assoc();
+if (!$inv) { echo '<p class="text-danger">Invitato non trovato.</p>'; include 'includes/footer.php'; exit; }
+$famStmt = $conn->prepare('SELECT f.id_i2f, f.id_famiglia, fam.nome_famiglia, f.data_inizio, f.data_fine, f.attivo FROM eventi_invitati2famiglie f JOIN famiglie fam ON f.id_famiglia=fam.id_famiglia WHERE f.id_invitato=? ORDER BY f.data_inizio DESC');
+$famStmt->bind_param('i', $id);
+$famStmt->execute();
+$famRes = $famStmt->get_result();
+$families = $famRes->fetch_all(MYSQLI_ASSOC);
+$allFamRes = $conn->query('SELECT id_famiglia, nome_famiglia FROM famiglie ORDER BY nome_famiglia');
+$allFamilies = $allFamRes ? $allFamRes->fetch_all(MYSQLI_ASSOC) : [];
+?>
+<div class="d-flex mb-3 align-items-center">
+  <h4 class="mb-0 me-2"><?= htmlspecialchars($inv['nome'] . ' ' . $inv['cognome']) ?></h4>
+  <button class="btn btn-outline-light btn-sm" onclick="openInvitatoEditModal()"><i class="bi bi-pencil"></i></button>
+</div>
+<div class="d-flex mb-3 justify-content-between">
+  <h5>Famiglie</h5>
+  <button type="button" class="btn btn-outline-light btn-sm" onclick="openFamigliaModal()">Aggiungi</button>
+</div>
+<div id="famiglieList" class="list-group list-group-flush bg-dark">
+<?php foreach ($families as $row): ?>
+  <div class="list-group-item bg-dark text-white fam-row" data-id="<?= (int)$row['id_i2f'] ?>" data-famiglia="<?= (int)$row['id_famiglia'] ?>" data-inizio="<?= htmlspecialchars($row['data_inizio']) ?>" data-fine="<?= htmlspecialchars($row['data_fine']) ?>" data-attivo="<?= (int)$row['attivo'] ?>" onclick="openFamigliaEdit(this)">
+    <div class="fw-semibold"><?= htmlspecialchars($row['nome_famiglia']) ?></div>
+    <div class="small">Dal <?= htmlspecialchars($row['data_inizio']) ?> al <?= htmlspecialchars($row['data_fine']) ?></div>
+    <?php if (!(int)$row['attivo']): ?><div class="small text-danger">Non attivo</div><?php endif; ?>
+  </div>
+<?php endforeach; ?>
+</div>
+<div class="modal fade" id="invitatoEditModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="invitatoEditForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Modifica invitato</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Nome</label>
+          <input type="text" name="nome" class="form-control bg-secondary text-white" required value="<?= htmlspecialchars($inv['nome']) ?>">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Cognome</label>
+          <input type="text" name="cognome" class="form-control bg-secondary text-white" required value="<?= htmlspecialchars($inv['cognome']) ?>">
+        </div>
+        <input type="hidden" name="id" value="<?= (int)$inv['id'] ?>">
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary w-100">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+<div class="modal fade" id="famigliaModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content bg-dark text-white" id="famigliaForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Famiglia</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Famiglia</label>
+          <select name="id_famiglia" class="form-select bg-secondary text-white">
+            <?php foreach ($allFamilies as $f): ?>
+              <option value="<?= (int)$f['id_famiglia'] ?>"><?= htmlspecialchars($f['nome_famiglia']) ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Data inizio</label>
+          <input type="date" name="data_inizio" class="form-control bg-secondary text-white" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Data fine</label>
+          <input type="date" name="data_fine" class="form-control bg-secondary text-white" value="9999-12-31">
+        </div>
+        <div class="form-check form-switch mb-3">
+          <input class="form-check-input" type="checkbox" name="attivo" id="attivo" checked>
+          <label class="form-check-label" for="attivo">Attivo</label>
+        </div>
+        <input type="hidden" name="id_invitato" value="<?= (int)$inv['id'] ?>">
+        <input type="hidden" name="id" id="id_i2f">
+      </div>
+      <div class="modal-footer d-flex justify-content-between">
+        <button type="button" class="btn btn-danger me-auto d-none" id="deleteFam">Elimina</button>
+        <button type="submit" class="btn btn-primary">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+<script src="js/invitati_eventi_dettaglio.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/js/invitati_cibo.js
+++ b/js/invitati_cibo.js
@@ -1,0 +1,48 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const search = document.getElementById('search');
+  const cards = Array.from(document.querySelectorAll('.cibo-card'));
+  function filter(){
+    const q = search.value.trim().toLowerCase();
+    cards.forEach(card=>{
+      const text = card.dataset.search || '';
+      if(text.includes(q)) card.style.removeProperty('display');
+      else card.style.setProperty('display','none','important');
+    });
+  }
+  search.addEventListener('input', filter);
+  filter();
+  const form = document.getElementById('ciboForm');
+  form?.addEventListener('submit', e=>{
+    e.preventDefault();
+    const fd = new FormData(form);
+    const id = fd.get('id');
+    fd.append('action', id ? 'update' : 'add');
+    fetch('ajax/invitati_cibo.php',{method:'POST',body:fd})
+      .then(r=>r.json()).then(res=>{ if(res.success){ location.reload(); } else { alert(res.error||'Errore'); }});
+  });
+  document.getElementById('deleteCibo')?.addEventListener('click', ()=>{
+    const id = document.getElementById('cibo_id').value;
+    if(!id) return;
+    const fd = new FormData();
+    fd.append('action','delete');
+    fd.append('id',id);
+    fetch('ajax/invitati_cibo.php',{method:'POST',body:fd})
+      .then(r=>r.json()).then(res=>{ if(res.success){ location.reload(); } else { alert(res.error||'Errore'); }});
+  });
+});
+function openCiboModal(){
+  const form = document.getElementById('ciboForm');
+  if(form){ form.reset(); document.getElementById('cibo_id').value=''; document.getElementById('deleteCibo').classList.add('d-none'); new bootstrap.Modal(document.getElementById('ciboModal')).show(); }
+}
+function openCiboEdit(el){
+  const form = document.getElementById('ciboForm');
+  if(!form) return;
+  form.reset();
+  form.piatto.value = el.dataset.piatto;
+  form.dolce.checked = el.dataset.dolce === '1';
+  form.bere.checked = el.dataset.bere === '1';
+  form.um.value = el.dataset.um;
+  document.getElementById('cibo_id').value = el.dataset.id;
+  document.getElementById('deleteCibo').classList.remove('d-none');
+  new bootstrap.Modal(document.getElementById('ciboModal')).show();
+}

--- a/js/invitati_eventi.js
+++ b/js/invitati_eventi.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const search = document.getElementById('search');
+  const cards = Array.from(document.querySelectorAll('.invitato-card'));
+  function filter(){
+    const q = search.value.trim().toLowerCase();
+    cards.forEach(card => {
+      const text = card.dataset.search || '';
+      if(text.includes(q)){
+        card.style.removeProperty('display');
+      } else {
+        card.style.setProperty('display','none','important');
+      }
+    });
+  }
+  search.addEventListener('input', filter);
+  filter();
+  const form = document.getElementById('invitatoForm');
+  form?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const formData = new FormData(form);
+    fetch('ajax/add_invitato_evento.php', {method:'POST', body:formData})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success){ location.reload(); } else { alert(res.error||'Errore'); }});
+  });
+});
+function openInvitatoModal(){
+  const form = document.getElementById('invitatoForm');
+  if(form){ form.reset(); new bootstrap.Modal(document.getElementById('invitatoModal')).show(); }
+}

--- a/js/invitati_eventi_dettaglio.js
+++ b/js/invitati_eventi_dettaglio.js
@@ -1,0 +1,52 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const invitatoForm = document.getElementById('invitatoEditForm');
+  invitatoForm?.addEventListener('submit', e => {
+    e.preventDefault();
+    const formData = new FormData(invitatoForm);
+    formData.append('action','update_invitato');
+    fetch('ajax/invitati_eventi_dettaglio.php',{method:'POST',body:formData})
+      .then(r=>r.json()).then(res=>{ if(res.success){ location.reload(); } else { alert(res.error||'Errore'); }});
+  });
+  const famigliaForm = document.getElementById('famigliaForm');
+  famigliaForm?.addEventListener('submit', e => {
+    e.preventDefault();
+    const formData = new FormData(famigliaForm);
+    const id = formData.get('id');
+    formData.append('action', id ? 'update_famiglia' : 'add_famiglia');
+    fetch('ajax/invitati_eventi_dettaglio.php',{method:'POST',body:formData})
+      .then(r=>r.json()).then(res=>{ if(res.success){ location.reload(); } else { alert(res.error||'Errore'); }});
+  });
+  document.getElementById('deleteFam')?.addEventListener('click', () => {
+    const id = document.getElementById('id_i2f').value;
+    if(!id) return;
+    const fd = new FormData();
+    fd.append('action','delete_famiglia');
+    fd.append('id',id);
+    fetch('ajax/invitati_eventi_dettaglio.php',{method:'POST',body:fd})
+      .then(r=>r.json()).then(res=>{ if(res.success){ location.reload(); } else { alert(res.error||'Errore'); }});
+  });
+});
+function openInvitatoEditModal(){
+  new bootstrap.Modal(document.getElementById('invitatoEditModal')).show();
+}
+function openFamigliaModal(){
+  const form = document.getElementById('famigliaForm');
+  if(form){
+    form.reset();
+    document.getElementById('id_i2f').value='';
+    document.getElementById('deleteFam').classList.add('d-none');
+    new bootstrap.Modal(document.getElementById('famigliaModal')).show();
+  }
+}
+function openFamigliaEdit(el){
+  const form = document.getElementById('famigliaForm');
+  if(!form) return;
+  form.reset();
+  form.id_famiglia.value = el.dataset.famiglia;
+  form.data_inizio.value = el.dataset.inizio;
+  form.data_fine.value = el.dataset.fine;
+  form.attivo.checked = el.dataset.attivo === '1';
+  document.getElementById('id_i2f').value = el.dataset.id;
+  document.getElementById('deleteFam').classList.remove('d-none');
+  new bootstrap.Modal(document.getElementById('famigliaModal')).show();
+}


### PR DESCRIPTION
## Summary
- Add "Eventi" section in tables menu linking to guest and food management pages
- Implement invitati_eventi with modal insertion, search, and detail page with family associations
- Implement invitati_cibo with modal-based add/edit for event food items

## Testing
- `php -l includes/render_invitato_evento.php`
- `php -l ajax/add_invitato_evento.php`
- `php -l invitati_eventi.php`
- `php -l invitati_eventi_dettaglio.php`
- `php -l ajax/invitati_eventi_dettaglio.php`
- `php -l includes/render_cibo_evento.php`
- `php -l ajax/invitati_cibo.php`
- `php -l invitati_cibo.php`
- `php -l includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_689de77f68008331943f243190c58c8a