### PR TITLE
Mostra eventi nel calendario dei turni e aggiunge selezione multipla

### DIFF
--- a/ajax/turni_get.php
+++ b/ajax/turni_get.php
@@ -21,9 +21,20 @@ $stmt = $conn->prepare('SELECT t.data, t.id_tipo, tp.descrizione, tp.colore_bg, 
 $stmt->bind_param('iss', $idFamiglia, $start, $end);
 $stmt->execute();
 $res = $stmt->get_result();
-$out = [];
+$turni = [];
 while ($row = $res->fetch_assoc()) {
-    $out[$row['data']] = $row;
+    $turni[$row['data']] = $row;
 }
 $stmt->close();
-echo json_encode($out);
+
+$evStmt = $conn->prepare('SELECT e.id, e.titolo, e.data_evento FROM eventi e JOIN eventi_eventi2famiglie f ON e.id = f.id_evento WHERE f.id_famiglia = ? AND e.data_evento BETWEEN ? AND ? ORDER BY e.data_evento');
+$evStmt->bind_param('iss', $idFamiglia, $start, $end);
+$evStmt->execute();
+$evRes = $evStmt->get_result();
+$eventi = [];
+while ($row = $evRes->fetch_assoc()) {
+    $eventi[$row['data_evento']][] = ['id' => (int)$row['id'], 'titolo' => $row['titolo']];
+}
+$evStmt->close();
+
+echo json_encode(['turni' => $turni, 'eventi' => $eventi]);

--- a/turni.php
+++ b/turni.php
@@ -12,6 +12,8 @@ $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
 <style>
   #calendarContainer .col {height: 100px;}
   #pillContainer .pill.active {outline:2px solid #fff;}
+  #calendarContainer .event-link {font-size: .8rem;}
+  #calendarContainer .day-cell.multi-selected {outline:2px solid #0d6efd;}
 </style>
 <div id="shifter" class="d-flex flex-column min-vh-100 p-0">
   <div class="bg-dark text-white p-3 position-sticky top-0">
@@ -35,8 +37,8 @@ $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
   <div class="flex-grow-1 overflow-auto" id="calendarContainer"></div>
   <div id="bottomBar" class="bg-dark text-white p-2 position-sticky bottom-0">
     <div id="stateA" class="d-flex justify-content-around">
-      <button class="btn btn-outline-light flex-fill mx-1" id="btnSingolo">SINGOLO</button>
-      <button class="btn btn-outline-light flex-fill mx-1" disabled>MULTIPLA</button>
+      <button class="btn btn-outline-light flex-fill mx-1" id="btnSingolo">SINGOLA</button>
+      <button class="btn btn-outline-light flex-fill mx-1" id="btnMultipla">MULTIPLA</button>
       <button class="btn btn-outline-light flex-fill mx-1" disabled>TURNI</button>
     </div>
     <div id="stateB" class="d-none">


### PR DESCRIPTION
## Summary
- Visualizza anche gli eventi nel calendario dei turni con link al dettaglio.
- Aggiunge un pulsante "Multipla" che abilita la selezione di più giorni tramite trascinamento.
- Restituisce dati di eventi dal backend insieme ai turni.

## Testing
- `php -l turni.php`
- `php -l ajax/turni_get.php`
- `node --check js/turni.js`


------
https://chatgpt.com/codex/tasks/task_e_689dec219500833183327aa8e9ea2b63