### PR TITLE
Add navigation and deletion to event invite detail

### DIFF
--- a/ajax/invitati_eventi_dettaglio.php
+++ b/ajax/invitati_eventi_dettaglio.php
@@ -48,6 +48,17 @@ try {
             $stmt->execute();
             echo json_encode(['success'=>true]);
             break;
+        case 'delete_invitato':
+            if (!has_permission($conn,'table:eventi_invitati','delete')) throw new Exception('Accesso negato');
+            $id = (int)($_POST['id'] ?? 0);
+            $stmt = $conn->prepare('DELETE FROM eventi_invitati2famiglie WHERE id_invitato=?');
+            $stmt->bind_param('i',$id);
+            $stmt->execute();
+            $stmt = $conn->prepare('DELETE FROM eventi_invitati WHERE id=?');
+            $stmt->bind_param('i',$id);
+            $stmt->execute();
+            echo json_encode(['success'=>true]);
+            break;
         default:
             throw new Exception('Azione non valida');
     }

--- a/invitati_eventi_dettaglio.php
+++ b/invitati_eventi_dettaglio.php
@@ -17,7 +17,9 @@ $famRes = $famStmt->get_result();
 $families = $famRes->fetch_all(MYSQLI_ASSOC);
 $allFamRes = $conn->query('SELECT id_famiglia, nome_famiglia FROM famiglie ORDER BY nome_famiglia');
 $allFamilies = $allFamRes ? $allFamRes->fetch_all(MYSQLI_ASSOC) : [];
+$canDelete = has_permission($conn, 'table:eventi_invitati', 'delete');
 ?>
+<a href="javascript:history.back()" class="btn btn-outline-light mb-3">&larr; Indietro</a>
 <div class="d-flex mb-3 align-items-center">
   <h4 class="mb-0 me-2"><?= htmlspecialchars($inv['nome'] . ' ' . $inv['cognome']) ?></h4>
   <button class="btn btn-outline-light btn-sm" onclick="openInvitatoEditModal()"><i class="bi bi-pencil"></i></button>
@@ -35,6 +37,9 @@ $allFamilies = $allFamRes ? $allFamRes->fetch_all(MYSQLI_ASSOC) : [];
   </div>
 <?php endforeach; ?>
 </div>
+<?php if ($canDelete): ?>
+  <button type="button" class="btn btn-danger w-100 mt-3" id="deleteInvitato" data-id="<?= (int)$inv['id'] ?>">Elimina</button>
+<?php endif; ?>
 <div class="modal fade" id="invitatoEditModal" tabindex="-1">
   <div class="modal-dialog">
     <form class="modal-content bg-dark text-white" id="invitatoEditForm">

--- a/js/invitati_eventi_dettaglio.js
+++ b/js/invitati_eventi_dettaglio.js
@@ -25,6 +25,16 @@ document.addEventListener('DOMContentLoaded', () => {
     fetch('ajax/invitati_eventi_dettaglio.php',{method:'POST',body:fd})
       .then(r=>r.json()).then(res=>{ if(res.success){ location.reload(); } else { alert(res.error||'Errore'); }});
   });
+  document.getElementById('deleteInvitato')?.addEventListener('click', e => {
+    const id = e.currentTarget.dataset.id;
+    if(!id) return;
+    if(!confirm('Sei sicuro di voler eliminare questo invitato?')) return;
+    const fd = new FormData();
+    fd.append('action','delete_invitato');
+    fd.append('id', id);
+    fetch('ajax/invitati_eventi_dettaglio.php',{method:'POST',body:fd})
+      .then(r=>r.json()).then(res=>{ if(res.success){ history.back(); } else { alert(res.error||'Errore'); }});
+  });
 });
 function openInvitatoEditModal(){
   new bootstrap.Modal(document.getElementById('invitatoEditModal')).show();


### PR DESCRIPTION
## Summary
- Add back navigation button to event invite detail page
- Allow deleting an invitee with a new red button and backend handling

## Testing
- `php -l invitati_eventi_dettaglio.php`
- `php -l ajax/invitati_eventi_dettaglio.php`
- `node --check js/invitati_eventi_dettaglio.js`

------
https://chatgpt.com/codex/tasks/task_e_689ded28b5188331afd75ce2be9c1587