### PR TITLE
Fix empty userlevel dropdown in family assignment modal

### DIFF
--- a/gestione_utenti.php
+++ b/gestione_utenti.php
@@ -33,6 +33,12 @@ foreach ($displayColumns as $col) {
         }
     }
 }
+$sql = "SELECT userlevelid AS id, userlevelname AS label FROM userlevels ORDER BY userlevelname";
+if ($res = $conn->query($sql)) {
+    while ($row = $res->fetch_assoc()) {
+        $lookups['userlevelid'][$row['id']] = trim((string)$row['label']);
+    }
+}
 $canInsert = has_permission($conn, 'table:utenti', 'insert');
 $canUpdate = has_permission($conn, 'table:utenti', 'update');
 $canManageFamilies = has_permission($conn, 'table:utenti2famiglie', 'update');


### PR DESCRIPTION
## Summary
- populate userlevel lookup list so the Assegna famiglie modal shows all levels

## Testing
- `php -l gestione_utenti.php`


------
https://chatgpt.com/codex/tasks/task_e_689df0c065188331b536aadbcc40d1a6