### PR TITLE
Gestione famiglie per eventi

### DIFF
--- a/ajax/add_evento.php
+++ b/ajax/add_evento.php
@@ -8,6 +8,8 @@ $descrizione = trim($_POST['descrizione'] ?? '');
 $data_evento = $_POST['data_evento'] ?? null;
 $ora_evento = $_POST['ora_evento'] ?? null;
 $id_tipo_evento = (int)($_POST['id_tipo_evento'] ?? 0);
+$famiglie = $_POST['famiglie'] ?? [];
+if (!is_array($famiglie)) { $famiglie = []; }
 
 if ($titolo === '') {
     echo json_encode(['success' => false, 'error' => 'Titolo mancante']);
@@ -17,9 +19,23 @@ if ($titolo === '') {
 $stmt = $conn->prepare('INSERT INTO eventi (titolo, descrizione, data_evento, ora_evento, id_tipo_evento) VALUES (?,?,?,?,?)');
 $stmt->bind_param('ssssi', $titolo, $descrizione, $data_evento, $ora_evento, $id_tipo_evento);
 $ok = $stmt->execute();
+$eventoId = $conn->insert_id;
+$stmt->close();
+
+if ($ok && $famiglie) {
+    $stmtFam = $conn->prepare('INSERT INTO eventi_eventi2famiglie (id_evento, id_famiglia) VALUES (?,?)');
+    foreach ($famiglie as $fid) {
+        $fid = (int)$fid;
+        if ($fid > 0) {
+            $stmtFam->bind_param('ii', $eventoId, $fid);
+            $stmtFam->execute();
+        }
+    }
+    $stmtFam->close();
+}
 
 if ($ok) {
-    echo json_encode(['success' => true, 'id' => $conn->insert_id]);
+    echo json_encode(['success' => true, 'id' => $eventoId]);
 } else {
     echo json_encode(['success' => false, 'error' => 'Errore durante l\'inserimento']);
 }

--- a/ajax/update_evento.php
+++ b/ajax/update_evento.php
@@ -17,6 +17,8 @@ $data_evento = $_POST['data_evento'] ?? null;
 $ora_evento = $_POST['ora_evento'] ?? null;
 $id_tipo_evento = (int)($_POST['id_tipo_evento'] ?? 0);
 if ($id_tipo_evento === 0) { $id_tipo_evento = null; }
+$famiglie = $_POST['famiglie'] ?? [];
+if (!is_array($famiglie)) { $famiglie = []; }
 
 if (!$id) {
     echo json_encode(['success' => false]);
@@ -27,5 +29,24 @@ $stmt = $conn->prepare('UPDATE eventi SET titolo = ?, descrizione = ?, data_even
 $stmt->bind_param('ssssii', $titolo, $descrizione, $data_evento, $ora_evento, $id_tipo_evento, $id);
 $success = $stmt->execute();
 $stmt->close();
+
+if ($success) {
+    $stmtDel = $conn->prepare('DELETE FROM eventi_eventi2famiglie WHERE id_evento = ?');
+    $stmtDel->bind_param('i', $id);
+    $stmtDel->execute();
+    $stmtDel->close();
+
+    if ($famiglie) {
+        $stmtIns = $conn->prepare('INSERT INTO eventi_eventi2famiglie (id_evento, id_famiglia) VALUES (?,?)');
+        foreach ($famiglie as $fid) {
+            $fid = (int)$fid;
+            if ($fid > 0) {
+                $stmtIns->bind_param('ii', $id, $fid);
+                $stmtIns->execute();
+            }
+        }
+        $stmtIns->close();
+    }
+}
 
 echo json_encode(['success' => $success]);

--- a/eventi.php
+++ b/eventi.php
@@ -12,6 +12,9 @@ $res = $stmt->get_result();
 $canInsert = has_permission($conn, 'table:eventi', 'insert');
 $tipiRes = $conn->query('SELECT id, tipo_evento FROM eventi_tipi_eventi ORDER BY tipo_evento');
 $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
+$famRes = $conn->query('SELECT id_famiglia, nome_famiglia FROM famiglie ORDER BY nome_famiglia');
+$famiglie = $famRes ? $famRes->fetch_all(MYSQLI_ASSOC) : [];
+$famigliaDefault = $_SESSION['id_famiglia_gestione'] ?? 0;
 ?>
 <div class="d-flex mb-3 justify-content-between">
   <h4>Eventi</h4>
@@ -60,6 +63,15 @@ $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
               <option value="<?= (int)$tipo['id'] ?>"><?= htmlspecialchars($tipo['tipo_evento']) ?></option>
             <?php endforeach; ?>
           </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Famiglie</label>
+          <?php foreach ($famiglie as $fam): ?>
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" name="famiglie[]" id="fam<?= (int)$fam['id_famiglia'] ?>" value="<?= (int)$fam['id_famiglia'] ?>" <?= $fam['id_famiglia'] == $famigliaDefault ? 'checked' : '' ?>>
+              <label class="form-check-label" for="fam<?= (int)$fam['id_famiglia'] ?>"><?= htmlspecialchars($fam['nome_famiglia']) ?></label>
+            </div>
+          <?php endforeach; ?>
         </div>
       </div>
       <div class="modal-footer">

--- a/eventi_dettaglio.php
+++ b/eventi_dettaglio.php
@@ -24,6 +24,16 @@ $canUpdate = has_permission($conn, 'table:eventi', 'update');
 $tipiRes = $conn->query('SELECT id, tipo_evento FROM eventi_tipi_eventi ORDER BY tipo_evento');
 $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
 
+$famiglieEvento = [];
+$stmtFam = $conn->prepare('SELECT id_famiglia FROM eventi_eventi2famiglie WHERE id_evento = ?');
+$stmtFam->bind_param('i', $id);
+$stmtFam->execute();
+$resFam = $stmtFam->get_result();
+while ($row = $resFam->fetch_assoc()) { $famiglieEvento[] = (int)$row['id_famiglia']; }
+$stmtFam->close();
+$allFamRes = $conn->query('SELECT id_famiglia, nome_famiglia FROM famiglie ORDER BY nome_famiglia');
+$allFamiglie = $allFamRes ? $allFamRes->fetch_all(MYSQLI_ASSOC) : [];
+
 // Invitati già collegati all'evento con stato e note
 $invitati = [];
 $stmtInv = $conn->prepare("SELECT e2i.id_e2i, i.nome, i.cognome, e2i.partecipa, e2i.forse, e2i.assente, e2i.note FROM eventi_eventi2invitati e2i JOIN eventi_invitati i ON e2i.id_invitato = i.id WHERE e2i.id_evento = ? ORDER BY i.cognome, i.nome");
@@ -168,6 +178,15 @@ include 'includes/header.php';
               <option value="<?= (int)$tipo['id'] ?>" <?= ($evento['id_tipo_evento'] ?? null) == $tipo['id'] ? 'selected' : '' ?>><?= htmlspecialchars($tipo['tipo_evento']) ?></option>
             <?php endforeach; ?>
           </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Famiglie</label>
+          <?php foreach ($allFamiglie as $fam): ?>
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" name="famiglie[]" id="fam<?= (int)$fam['id_famiglia'] ?>" value="<?= (int)$fam['id_famiglia'] ?>" <?= in_array((int)$fam['id_famiglia'], $famiglieEvento, true) ? 'checked' : '' ?>>
+              <label class="form-check-label" for="fam<?= (int)$fam['id_famiglia'] ?>"><?= htmlspecialchars($fam['nome_famiglia']) ?></label>
+            </div>
+          <?php endforeach; ?>
         </div>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
## Summary
- Add family selection checkboxes in event creation and editing modals
- Persist selected families via `eventi_eventi2famiglie` join table when adding or updating events

## Testing
- `php -l eventi.php eventi_dettaglio.php ajax/add_evento.php ajax/update_evento.php`

------
https://chatgpt.com/codex/tasks/task_e_689df1b3d5008331aef35ae82f5f27ff