### PR TITLE
Color shift calendar events by type

### DIFF
--- a/ajax/turni_get.php
+++ b/ajax/turni_get.php
@@ -27,13 +27,17 @@ while ($row = $res->fetch_assoc()) {
 }
 $stmt->close();
 
-$evStmt = $conn->prepare('SELECT e.id, e.titolo, e.data_evento FROM eventi e JOIN eventi_eventi2famiglie f ON e.id = f.id_evento WHERE f.id_famiglia = ? AND e.data_evento BETWEEN ? AND ? ORDER BY e.data_evento');
+$evStmt = $conn->prepare('SELECT e.id, e.titolo, e.data_evento, te.colore FROM eventi e JOIN eventi_eventi2famiglie f ON e.id = f.id_evento LEFT JOIN eventi_tipi_eventi te ON e.id_tipo_evento = te.id WHERE f.id_famiglia = ? AND e.data_evento BETWEEN ? AND ? ORDER BY e.data_evento');
 $evStmt->bind_param('iss', $idFamiglia, $start, $end);
 $evStmt->execute();
 $evRes = $evStmt->get_result();
 $eventi = [];
 while ($row = $evRes->fetch_assoc()) {
-    $eventi[$row['data_evento']][] = ['id' => (int)$row['id'], 'titolo' => $row['titolo']];
+    $eventi[$row['data_evento']][] = [
+        'id' => (int)$row['id'],
+        'titolo' => $row['titolo'],
+        'colore' => $row['colore']
+    ];
 }
 $evStmt->close();
 

--- a/js/turni.js
+++ b/js/turni.js
@@ -57,7 +57,8 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       if(eventi[dateStr]){
         eventi[dateStr].forEach(ev=>{
-          col.insertAdjacentHTML('beforeend', `<div class="event-link text-truncate"><a href="eventi_dettaglio.php?id=${ev.id}" class="text-white text-decoration-none">${ev.titolo}</a></div>`);
+          const bg = ev.colore || '#6c757d';
+          col.insertAdjacentHTML('beforeend', `<div class="event-link text-truncate" style="background:${bg}"><a href="eventi_dettaglio.php?id=${ev.id}" class="text-white text-decoration-none">${ev.titolo}</a></div>`);
         });
       }
       const t=new Date();


### PR DESCRIPTION
## Summary
- Fetch event color from `eventi_tipi_eventi`
- Render event background using the retrieved color in the turni calendar

## Testing
- `php -l ajax/turni_get.php`
- `node --check js/turni.js`


------
https://chatgpt.com/codex/tasks/task_e_689df4804ff0833199c2b5b0521193c8