### PR TITLE
Keep calendar cells a fixed width

### DIFF
--- a/turni.php
+++ b/turni.php
@@ -10,9 +10,9 @@ $tipiRes = $conn->query("SELECT id, descrizione, colore_bg, colore_testo FROM tu
 $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
 ?>
 <style>
-  #calendarContainer .col {height: 100px;}
+  #calendarContainer .col {height: 100px; min-width:0; overflow:hidden;}
   #pillContainer .pill.active {outline:2px solid #fff;}
-  #calendarContainer .event-link {font-size: .8rem;}
+  #calendarContainer .event-link {font-size: .8rem; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
   #calendarContainer .day-cell.multi-selected {outline:2px solid #0d6efd;}
 </style>
 <div id="shifter" class="d-flex flex-column min-vh-100 p-0">


### PR DESCRIPTION
## Summary
- Prevent calendar cells from expanding by forcing a minimum flex width and hiding overflow
- Ensure event labels ellipsize within fixed-width cells

## Testing
- `php -l turni.php`


------
https://chatgpt.com/codex/tasks/task_e_689df617087483318daf635b46e07141