### PR TITLE
Support multiple shifts per day in calendar

### DIFF
--- a/ajax/turni_get.php
+++ b/ajax/turni_get.php
@@ -17,13 +17,13 @@ if (!$year || !$month || !$idFamiglia) {
 }
 $start = sprintf('%04d-%02d-01', $year, $month);
 $end = date('Y-m-t', strtotime($start));
-$stmt = $conn->prepare('SELECT t.data, t.id_tipo, tp.descrizione, tp.colore_bg, tp.colore_testo FROM turni_calendario t JOIN turni_tipi tp ON t.id_tipo = tp.id WHERE t.id_famiglia = ? AND t.data BETWEEN ? AND ?');
+$stmt = $conn->prepare('SELECT t.data, t.id_tipo, tp.descrizione, tp.colore_bg, tp.colore_testo FROM turni_calendario t JOIN turni_tipi tp ON t.id_tipo = tp.id WHERE t.id_famiglia = ? AND t.data BETWEEN ? AND ? ORDER BY t.data');
 $stmt->bind_param('iss', $idFamiglia, $start, $end);
 $stmt->execute();
 $res = $stmt->get_result();
 $turni = [];
 while ($row = $res->fetch_assoc()) {
-    $turni[$row['data']] = $row;
+    $turni[$row['data']][] = $row;
 }
 $stmt->close();
 

--- a/ajax/turni_update.php
+++ b/ajax/turni_update.php
@@ -17,7 +17,7 @@ if (!$date || !$idFamiglia) {
     exit;
 }
 if ($idTipo) {
-    $stmt = $conn->prepare('INSERT INTO turni_calendario (id_famiglia, data, id_tipo) VALUES (?,?,?) ON DUPLICATE KEY UPDATE id_tipo = VALUES(id_tipo)');
+    $stmt = $conn->prepare('INSERT INTO turni_calendario (id_famiglia, data, id_tipo) VALUES (?,?,?)');
     $stmt->bind_param('isi', $idFamiglia, $date, $idTipo);
     $success = $stmt->execute();
     $stmt->close();

--- a/js/turni.js
+++ b/js/turni.js
@@ -44,22 +44,34 @@ document.addEventListener('DOMContentLoaded', () => {
         row.className='row row-cols-7 g-0';
       }
       const col=document.createElement('div');
-      col.className='col border p-2 position-relative day-cell';
+      col.className='col border position-relative day-cell';
       const dateStr=`${year}-${String(month+1).padStart(2,'0')}-${String(day).padStart(2,'0')}`;
       col.dataset.date=dateStr;
-      col.innerHTML=`<div class="small text-start">${day}</div>`;
+      const dateLabel=document.createElement('div');
+      dateLabel.className='small text-start p-1';
+      dateLabel.textContent=day;
+      col.appendChild(dateLabel);
       const info=turni[dateStr];
+      const turniContainer=document.createElement('div');
+      turniContainer.className='turni-container';
       if(info){
-        col.dataset.idTipo=info.id_tipo;
-        col.insertAdjacentHTML('beforeend', `<div class="text-center">${info.descrizione}</div>`);
-        col.style.background=info.colore_bg;
-        col.style.color=info.colore_testo;
+        info.forEach(t=>{
+          const turno=document.createElement('div');
+          turno.className='turno';
+          turno.textContent=t.descrizione;
+          turno.style.background=t.colore_bg;
+          turno.style.color=t.colore_testo;
+          turniContainer.appendChild(turno);
+        });
       }
+      col.appendChild(turniContainer);
       if(eventi[dateStr]){
+        const evWrap=document.createElement('div');
         eventi[dateStr].forEach(ev=>{
           const bg = ev.colore || '#6c757d';
-          col.insertAdjacentHTML('beforeend', `<div class="event-link text-truncate" style="background:${bg}"><a href="eventi_dettaglio.php?id=${ev.id}" class="text-white text-decoration-none">${ev.titolo}</a></div>`);
+          evWrap.insertAdjacentHTML('beforeend', `<div class="event-link text-truncate" style="background:${bg}"><a href="eventi_dettaglio.php?id=${ev.id}" class="text-white text-decoration-none">${ev.titolo}</a></div>`);
         });
+        col.appendChild(evWrap);
       }
       const t=new Date();
       if(year===t.getFullYear() && month===t.getMonth() && day===t.getDate()){

--- a/turni.php
+++ b/turni.php
@@ -11,6 +11,9 @@ $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
 ?>
 <style>
   #calendarContainer .col {height: 100px; min-width:0; overflow:hidden;}
+  #calendarContainer .day-cell {display:flex; flex-direction:column; padding:0;}
+  #calendarContainer .turni-container {flex:1; display:flex; flex-direction:column;}
+  #calendarContainer .turno {flex:1; display:flex; align-items:center; justify-content:center; font-size:.8rem;}
   #pillContainer .pill.active {outline:2px solid #fff;}
   #calendarContainer .event-link {font-size: .8rem; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
   #calendarContainer .day-cell.multi-selected {outline:2px solid #0d6efd;}


### PR DESCRIPTION
## Summary
- Render all daily shifts stacked within calendar cells and split height evenly
- Adjust backend endpoints to return and store multiple shifts per day
- Add calendar styling and layout for stacked shifts

## Testing
- `php -l turni.php`
- `php -l ajax/turni_get.php`
- `php -l ajax/turni_update.php`
- `node --check js/turni.js`


------
https://chatgpt.com/codex/tasks/task_e_689df8321b888331b48de275544ea470