### PR TITLE
Integrazione Google Calendar per i turni

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 includes/db_config.php
+config/

--- a/README.md
+++ b/README.md
@@ -30,3 +30,18 @@ Il file `includes/db_config.php` è già incluso in `.gitignore` per evitare che
 
 L'applicazione include una copia leggera di [PHPMailer](https://github.com/PHPMailer/PHPMailer) per l'invio di email. Le componenti relative a DSN, OAuth e POP3 sono state rimosse perché non utilizzate.
 
+## Sincronizzazione Google Calendar
+
+Per abilitare il pulsante **GOOGLE** nella pagina dei turni è necessario configurare le credenziali per le API di Google Calendar.
+
+1. Installare la libreria client:
+   ```bash
+   composer require google/apiclient:^2.0
+   ```
+2. Creare su [Google Cloud Console](https://console.cloud.google.com/) delle credenziali OAuth 2.0 o un account di servizio e scaricare il file JSON.
+3. Salvare il file delle credenziali in `config/google_credentials.json` e il token di accesso in `config/google_token.json` (entrambi **non versionati**).
+4. Il token deve includere l'ambito `https://www.googleapis.com/auth/calendar`. Se il token scade verrà aggiornato automaticamente.
+5. (Opzionale) impostare la variabile d'ambiente `GOOGLE_CALENDAR_ID` con l'ID del calendario da utilizzare; in assenza viene usato il calendario `primary`.
+
+Una volta completata la configurazione, il pulsante **GOOGLE** su `turni.php` sincronizzerà sul calendario gli eventi e i turni del mese visualizzato.
+

--- a/ajax/turni_sync_google.php
+++ b/ajax/turni_sync_google.php
@@ -1,0 +1,95 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+include '../includes/permissions.php';
+if (!has_permission($conn, 'page:turni.php', 'view')) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Accesso negato']);
+    exit;
+}
+$data = json_decode(file_get_contents('php://input'), true);
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+$year = isset($data['year']) ? (int)$data['year'] : 0;
+$month = isset($data['month']) ? (int)$data['month'] : -1; // 0-based
+if (!$idFamiglia || !$year || $month < 0) {
+    echo json_encode(['success' => false, 'message' => 'Parametri non validi']);
+    exit;
+}
+$month++; // convert to 1-based
+$start = sprintf('%04d-%02d-01', $year, $month);
+$end = date('Y-m-t', strtotime($start));
+// Query turni
+$stmt = $conn->prepare('SELECT t.data, t.id_tipo, tp.descrizione, tp.colore_bg, tp.colore_testo FROM turni_calendario t JOIN turni_tipi tp ON t.id_tipo = tp.id WHERE t.id_famiglia = ? AND t.data BETWEEN ? AND ? ORDER BY t.data');
+$stmt->bind_param('iss', $idFamiglia, $start, $end);
+$stmt->execute();
+$res = $stmt->get_result();
+$turni = [];
+while ($row = $res->fetch_assoc()) {
+    $turni[$row['data']][] = $row;
+}
+$stmt->close();
+// Query eventi
+$evStmt = $conn->prepare('SELECT e.id, e.titolo, e.data_evento, te.colore FROM eventi e JOIN eventi_eventi2famiglie f ON e.id = f.id_evento LEFT JOIN eventi_tipi_eventi te ON e.id_tipo_evento = te.id WHERE f.id_famiglia = ? AND e.data_evento BETWEEN ? AND ? ORDER BY e.data_evento');
+$evStmt->bind_param('iss', $idFamiglia, $start, $end);
+$evStmt->execute();
+$evRes = $evStmt->get_result();
+$eventi = [];
+while ($row = $evRes->fetch_assoc()) {
+    $eventi[$row['data_evento']][] = [
+        'id' => (int)$row['id'],
+        'titolo' => $row['titolo'],
+        'colore' => $row['colore']
+    ];
+}
+$evStmt->close();
+// Google Calendar integration
+require_once __DIR__ . '/../vendor/autoload.php';
+$credentialsFile = __DIR__ . '/../config/google_credentials.json';
+$tokenFile = __DIR__ . '/../config/google_token.json';
+if (!file_exists($credentialsFile)) {
+    echo json_encode(['success' => false, 'message' => 'Credenziali Google mancanti']);
+    exit;
+}
+try {
+    $client = new Google_Client();
+    $client->setAuthConfig($credentialsFile);
+    $client->addScope(Google_Service_Calendar::CALENDAR);
+    $client->setAccessType('offline');
+    if (file_exists($tokenFile)) {
+        $accessToken = json_decode(file_get_contents($tokenFile), true);
+        $client->setAccessToken($accessToken);
+        if ($client->isAccessTokenExpired()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+            file_put_contents($tokenFile, json_encode($client->getAccessToken()));
+        }
+    } else {
+        echo json_encode(['success' => false, 'message' => 'Token Google mancante']);
+        exit;
+    }
+    $service = new Google_Service_Calendar($client);
+    $calendarId = getenv('GOOGLE_CALENDAR_ID') ?: 'primary';
+    foreach ($turni as $date => $items) {
+        foreach ($items as $t) {
+            $event = new Google_Service_Calendar_Event([
+                'summary' => $t['descrizione'],
+                'start' => ['date' => $date],
+                'end' => ['date' => $date],
+            ]);
+            $service->events->insert($calendarId, $event);
+        }
+    }
+    foreach ($eventi as $date => $items) {
+        foreach ($items as $e) {
+            $event = new Google_Service_Calendar_Event([
+                'summary' => $e['titolo'],
+                'start' => ['date' => $date],
+                'end' => ['date' => $date],
+            ]);
+            $service->events->insert($calendarId, $event);
+        }
+    }
+    echo json_encode(['success' => true, 'message' => 'Sincronizzazione completata']);
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+}

--- a/js/turni.js
+++ b/js/turni.js
@@ -168,5 +168,16 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('prevMonth').addEventListener('click', ()=>{current.setMonth(current.getMonth()-1);loadTurni(current.getFullYear(),current.getMonth());});
   document.getElementById('nextMonth').addEventListener('click', ()=>{current.setMonth(current.getMonth()+1);loadTurni(current.getFullYear(),current.getMonth());});
 
+  document.getElementById('btnGoogle').addEventListener('click', ()=>{
+    fetch('ajax/turni_sync_google.php',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({year:current.getFullYear(),month:current.getMonth()})
+    })
+    .then(r=>r.json())
+    .then(res=>alert(res.message||'Operazione completata'))
+    .catch(()=>alert('Errore durante la sincronizzazione'));
+  });
+
   loadTurni(current.getFullYear(), current.getMonth());
 });

--- a/turni.php
+++ b/turni.php
@@ -33,7 +33,7 @@ $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
     <div id="stateA" class="d-flex justify-content-around">
       <button class="btn btn-outline-light flex-fill mx-1" id="btnSingolo">SINGOLA</button>
       <button class="btn btn-outline-light flex-fill mx-1" id="btnMultipla">MULTIPLA</button>
-      <button class="btn btn-outline-light flex-fill mx-1" disabled>TURNI</button>
+      <button class="btn btn-outline-light flex-fill mx-1" id="btnGoogle">GOOGLE</button>
     </div>
     <div id="stateB" class="d-none">
       <div class="d-flex align-items-center">


### PR DESCRIPTION
## Summary
- Sostituito il pulsante in basso con un'azione **GOOGLE** per sincronizzare il mese corrente.
- Aggiunto in `js/turni.js` l'handler che invia mese e anno correnti al nuovo endpoint `turni_sync_google.php` e mostra l'esito.
- Creato endpoint `ajax/turni_sync_google.php` che legge i turni e gli eventi, quindi li esporta su Google Calendar tramite le API.
- Documentata nel README la procedura per configurare le credenziali Google e ignorati i file di configurazione locali.

## Testing
- `php -l turni.php`
- `php -l ajax/turni_sync_google.php`
- `node --check js/turni.js`


------
https://chatgpt.com/codex/tasks/task_e_689dfd0b0e2883318658b0edfa611ebe