### PR TITLE
Gestione bambini nei turni e uniformazione eventi

### DIFF
--- a/ajax/turni_update.php
+++ b/ajax/turni_update.php
@@ -14,6 +14,8 @@ $date = $data['date'] ?? null;
 $idTipo = isset($data['id_tipo']) ? (int)$data['id_tipo'] : null;
 $oraInizio = $data['ora_inizio'] ?? null;
 $oraFine = $data['ora_fine'] ?? null;
+$idBambini = $data['id_utenti_bambini'] ?? '';
+$note = $data['note'] ?? '';
 $idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
 
 if ($id > 0) {
@@ -21,8 +23,8 @@ if ($id > 0) {
         echo json_encode(['success' => false]);
         exit;
     }
-    $stmt = $conn->prepare('UPDATE turni_calendario SET id_tipo = ?, ora_inizio = ?, ora_fine = ? WHERE id = ? AND id_famiglia = ?');
-    $stmt->bind_param('sssii', $idTipo, $oraInizio, $oraFine, $id, $idFamiglia);
+    $stmt = $conn->prepare('UPDATE turni_calendario SET id_tipo = ?, ora_inizio = ?, ora_fine = ?, id_utenti_bambini = ?, note = ? WHERE id = ? AND id_famiglia = ?');
+    $stmt->bind_param('issssii', $idTipo, $oraInizio, $oraFine, $idBambini, $note, $id, $idFamiglia);
     $success = $stmt->execute();
     $stmt->close();
 } else {

--- a/js/turni.js
+++ b/js/turni.js
@@ -71,18 +71,27 @@ document.addEventListener('DOMContentLoaded', () => {
           turno.dataset.id_tipo = t.id_tipo;
           turno.dataset.ora_inizio = t.ora_inizio;
           turno.dataset.ora_fine = t.ora_fine;
+          turno.dataset.bambini = t.id_utenti_bambini || '';
+          turno.dataset.note = t.note || '';
+          if(t.iniziali_bambini){
+            const b=document.createElement('div');
+            b.className='bambini';
+            b.textContent=t.iniziali_bambini;
+            turno.appendChild(b);
+          }
+          turniContainer.appendChild(turno);
+        });
+      }
+      if(eventi[dateStr]){
+        eventi[dateStr].forEach(ev=>{
+          const turno=document.createElement('div');
+          turno.className='turno event';
+          turno.style.background=ev.colore || '#6c757d';
+          turno.innerHTML=`<a href="eventi_dettaglio.php?id=${ev.id}" class="text-white text-decoration-none">${ev.titolo}</a>`;
           turniContainer.appendChild(turno);
         });
       }
       col.appendChild(turniContainer);
-      if(eventi[dateStr]){
-        const evWrap=document.createElement('div');
-        eventi[dateStr].forEach(ev=>{
-          const bg = ev.colore || '#6c757d';
-          evWrap.insertAdjacentHTML('beforeend', `<div class="event-link text-truncate" style="background:${bg}"><a href="eventi_dettaglio.php?id=${ev.id}" class="text-white text-decoration-none">${ev.titolo}</a></div>`);
-        });
-        col.appendChild(evWrap);
-      }
       const t=new Date();
       if(year===t.getFullYear() && month===t.getMonth() && day===t.getDate()){
         col.classList.add('border-primary');
@@ -112,13 +121,18 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('turnoTipo').value = el.dataset.id_tipo;
     document.getElementById('turnoOraInizio').value = el.dataset.ora_inizio;
     document.getElementById('turnoOraFine').value = el.dataset.ora_fine;
+    const bambini = el.dataset.bambini ? el.dataset.bambini.split(',') : [];
+    document.querySelectorAll('#turnoBambini input[type="checkbox"]').forEach(cb=>{
+      cb.checked = bambini.includes(cb.value);
+    });
+    document.getElementById('turnoNote').value = el.dataset.note || '';
     editModal.show();
   }
 
   calendarContainer.addEventListener('click', e=>{
     if(e.target.closest('a')) return;
     const turnoEl = e.target.closest('.turno');
-    if(!multiMode && selectedType===null && turnoEl){
+    if(!multiMode && selectedType===null && turnoEl && !turnoEl.classList.contains('event')){
       openEditModal(turnoEl);
       return;
     }
@@ -161,7 +175,9 @@ document.addEventListener('DOMContentLoaded', () => {
         id: document.getElementById('turnoId').value,
         id_tipo: document.getElementById('turnoTipo').value,
         ora_inizio: document.getElementById('turnoOraInizio').value,
-        ora_fine: document.getElementById('turnoOraFine').value
+        ora_fine: document.getElementById('turnoOraFine').value,
+        id_utenti_bambini: Array.from(document.querySelectorAll('#turnoBambini input:checked')).map(cb=>cb.value).join(','),
+        note: document.getElementById('turnoNote').value
       };
       fetch('ajax/turni_update.php',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)})
         .then(r=>r.json())

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -959,7 +959,9 @@ CREATE TABLE `turni_calendario` (
   `ora_inizio` time NOT NULL,
   `ora_fine` time NOT NULL,
   `id_tipo` int(11) NOT NULL,
-  `google_calendar_eventid` varchar(255) DEFAULT NULL
+  `google_calendar_eventid` varchar(255) DEFAULT NULL,
+  `id_utenti_bambini` varchar(255) DEFAULT NULL,
+  `note` text DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------

--- a/sql/turni.sql
+++ b/sql/turni.sql
@@ -10,7 +10,12 @@ CREATE TABLE turni_calendario (
     id INT AUTO_INCREMENT PRIMARY KEY,
     id_famiglia INT NOT NULL,
     data DATE NOT NULL,
+    ora_inizio TIME NOT NULL,
+    ora_fine TIME NOT NULL,
     id_tipo INT NOT NULL,
+    google_calendar_eventid VARCHAR(255) DEFAULT NULL,
+    id_utenti_bambini VARCHAR(255) DEFAULT NULL,
+    note TEXT DEFAULT NULL,
     UNIQUE KEY uniq_turno (id_famiglia, data),
     FOREIGN KEY (id_famiglia) REFERENCES famiglie(id_famiglia),
     FOREIGN KEY (id_tipo) REFERENCES turni_tipi(id)

--- a/turni.php
+++ b/turni.php
@@ -8,14 +8,17 @@ include 'includes/header.php';
 $idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
 $tipiRes = $conn->query("SELECT id, descrizione, colore_bg, colore_testo FROM turni_tipi WHERE attivo = 1 ORDER BY descrizione");
 $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
+$bambiniRes = $conn->query("SELECT u.id, COALESCE(NULLIF(u.soprannome,''), CONCAT(u.nome,' ',u.cognome)) AS nome FROM utenti u JOIN utenti2famiglie uf ON u.id = uf.id_utente WHERE uf.id_famiglia = $idFamiglia ORDER BY nome");
+$bambini = $bambiniRes ? $bambiniRes->fetch_all(MYSQLI_ASSOC) : [];
 ?>
 <style>
   #calendarContainer .col {height: 100px; min-width:0; overflow:hidden;}
   #calendarContainer .day-cell {display:flex; flex-direction:column; padding:0;}
   #calendarContainer .turni-container {flex:1; display:flex; flex-direction:column;}
-  #calendarContainer .turno {flex:1; display:flex; align-items:center; justify-content:center; font-size:.8rem;}
+  #calendarContainer .turno {flex:1; display:flex; align-items:center; justify-content:center; font-size:.8rem; position:relative; overflow:hidden;}
+  #calendarContainer .turno.event a {color:inherit; text-decoration:none; width:100%; display:block; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
+  #calendarContainer .turno .bambini {position:absolute; bottom:0; right:0; font-size:.6rem; padding:0 2px;}
   #pillContainer .pill.active {outline:2px solid #fff;}
-  #calendarContainer .event-link {font-size: .8rem; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
   #calendarContainer .day-cell.multi-selected {outline:2px solid #0d6efd;}
 </style>
 <div id="shifter" class="d-flex flex-column min-vh-100 p-0">
@@ -79,6 +82,21 @@ $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
           <div class="mb-3">
             <label for="turnoOraFine" class="form-label">Ora fine</label>
             <input type="time" class="form-control bg-dark text-white border-secondary" id="turnoOraFine" name="ora_fine" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Bambini</label>
+            <div id="turnoBambini">
+              <?php foreach ($bambini as $b): ?>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="bambino<?= (int)$b['id'] ?>" value="<?= (int)$b['id'] ?>">
+                <label class="form-check-label" for="bambino<?= (int)$b['id'] ?>"><?= htmlspecialchars($b['nome']) ?></label>
+              </div>
+              <?php endforeach; ?>
+            </div>
+          </div>
+          <div class="mb-3">
+            <label for="turnoNote" class="form-label">Note</label>
+            <textarea class="form-control bg-dark text-white border-secondary" id="turnoNote" name="note"></textarea>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- Estesi turni per associare bambini e note, con visualizzazione delle iniziali.
- Uniformata la resa degli eventi ai turni, condividendo lo spazio nella cella.
- Modal turno ora mostra orari di default del tipo e permette selezione bambini e note.

## Testing
- `php -l turni.php`
- `php -l ajax/turni_get.php`
- `php -l ajax/turni_update.php`
- `node --check js/turni.js`


------
https://chatgpt.com/codex/tasks/task_e_689f0792f6588331804d8c872c49dfc6