### PR TITLE
Add event type management page

### DIFF
--- a/eventi_tipi.php
+++ b/eventi_tipi.php
@@ -1,0 +1,33 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+require_once 'includes/render_evento_tipo.php';
+if (!has_permission($conn, 'page:eventi_tipi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+include 'includes/header.php';
+
+$stmt = $conn->prepare('SELECT * FROM eventi_tipi_eventi ORDER BY tipo_evento');
+$stmt->execute();
+$res = $stmt->get_result();
+$canInsert = has_permission($conn, 'table:eventi_tipi_eventi', 'insert');
+?>
+<div class="d-flex mb-3 justify-content-between">
+  <h4>Tipi evento</h4>
+  <?php if ($canInsert): ?>
+  <a href="evento_tipo_dettaglio.php" class="btn btn-outline-light btn-sm">Aggiungi nuovo</a>
+  <?php endif; ?>
+</div>
+<div class="d-flex mb-3 align-items-center">
+  <input type="text" id="search" class="form-control bg-dark text-white border-secondary me-2" placeholder="Cerca">
+  <div class="form-check form-switch text-nowrap">
+    <input class="form-check-input" type="checkbox" id="showInactive">
+    <label class="form-check-label" for="showInactive">Mostra non attivi</label>
+  </div>
+</div>
+<div id="tipiList">
+<?php while ($row = $res->fetch_assoc()): ?>
+  <?php render_evento_tipo($row); ?>
+<?php endwhile; ?>
+</div>
+<script src="js/eventi_tipi.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/evento_tipo_dettaglio.php
+++ b/evento_tipo_dettaglio.php
@@ -1,0 +1,85 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+if (!has_permission($conn, 'page:eventi_tipi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+include 'includes/header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$data = [
+    'id' => 0,
+    'tipo_evento' => '',
+    'colore' => '#71843f',
+    'attivo' => 1
+];
+if ($id > 0) {
+    $stmt = $conn->prepare('SELECT * FROM eventi_tipi_eventi WHERE id=?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($res && $res->num_rows > 0) {
+        $data = $res->fetch_assoc();
+    } else {
+        echo '<p class="text-danger">Record non trovato.</p>';
+        include 'includes/footer.php';
+        exit;
+    }
+    $stmt->close();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+    if (isset($_POST['delete']) && $id > 0) {
+        $stmt = $conn->prepare('DELETE FROM eventi_tipi_eventi WHERE id=?');
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $stmt->close();
+        header('Location: eventi_tipi.php');
+        exit;
+    }
+    $tipo = $_POST['tipo_evento'] ?? '';
+    $colore = $_POST['colore'] ?? '';
+    $attivo = isset($_POST['attivo']) ? 1 : 0;
+    if ($id > 0) {
+        $stmt = $conn->prepare('UPDATE eventi_tipi_eventi SET tipo_evento=?, colore=?, attivo=? WHERE id=?');
+        $stmt->bind_param('ssii', $tipo, $colore, $attivo, $id);
+        $stmt->execute();
+        $stmt->close();
+    } else {
+        $stmt = $conn->prepare('INSERT INTO eventi_tipi_eventi (tipo_evento, colore, attivo) VALUES (?,?,?)');
+        $stmt->bind_param('ssi', $tipo, $colore, $attivo);
+        $stmt->execute();
+        $stmt->close();
+    }
+    header('Location: eventi_tipi.php');
+    exit;
+}
+?>
+<div class="container text-white">
+  <a href="javascript:history.back()" class="btn btn-outline-light mb-3">&larr; Indietro</a>
+  <h4 class="mb-4"><?= $id > 0 ? 'Modifica tipo evento' : 'Nuovo tipo evento' ?></h4>
+</div>
+<form method="post" class="bg-dark text-white p-3 rounded">
+  <div class="mb-3">
+    <label class="form-label">Tipo evento</label>
+    <input type="text" name="tipo_evento" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['tipo_evento']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Colore</label>
+    <input type="color" name="colore" class="form-control form-control-color" value="<?= htmlspecialchars($data['colore']) ?>" title="Scegli colore">
+  </div>
+  <div class="form-check form-switch mb-3">
+    <input class="form-check-input" type="checkbox" id="attivo" name="attivo" <?= ($data['attivo'] ?? 1) ? 'checked' : '' ?>>
+    <label class="form-check-label" for="attivo">Attivo</label>
+  </div>
+  <?php if ($id > 0): ?>
+    <input type="hidden" name="id" value="<?= (int)$data['id'] ?>">
+  <?php endif; ?>
+  <div class="d-flex">
+    <?php if ($id > 0): ?>
+    <button type="submit" name="delete" value="1" class="btn btn-danger me-auto">Elimina</button>
+    <?php endif; ?>
+    <button type="submit" class="btn btn-primary ms-auto">Salva</button>
+  </div>
+</form>
+<?php include 'includes/footer.php'; ?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -236,7 +236,7 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
       <li class="mb-3">
         <div class="dropdown w-100">
           <button class="btn btn-outline-light w-100 text-start dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-            <i class="bi bi-table me-2 text-white"></i> Tabelle
+            <i class="bi bi-gear me-2 text-white"></i> Configurazione
           </button>
           <ul class="dropdown-menu dropdown-menu-dark w-100">
             <li><h6 class="dropdown-header">Bilancio</h6></li>
@@ -271,9 +271,12 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
             <?php if (isset($tableLinks['userlevels'])): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/table_manager.php?table=userlevels">User Levels</a></li>
             <?php endif; ?>
-            <?php if (has_permission($conn, 'page:invitati_eventi.php', 'view') || has_permission($conn, 'page:invitati_cibo.php', 'view')): ?>
+            <?php if (has_permission($conn, 'page:invitati_eventi.php', 'view') || has_permission($conn, 'page:invitati_cibo.php', 'view') || has_permission($conn, 'page:eventi_tipi.php', 'view')): ?>
             <li><hr class="dropdown-divider"></li>
             <li><h6 class="dropdown-header">Eventi</h6></li>
+            <?php if (has_permission($conn, 'page:eventi_tipi.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/eventi_tipi.php">Tipi eventi</a></li>
+            <?php endif; ?>
             <?php if (has_permission($conn, 'page:invitati_eventi.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/invitati_eventi.php">Invitati</a></li>
             <?php endif; ?>

--- a/includes/render_evento_tipo.php
+++ b/includes/render_evento_tipo.php
@@ -1,0 +1,22 @@
+<?php
+function render_evento_tipo(array $row) {
+    $isActive = (int)($row['attivo'] ?? 0) === 1;
+    $classes = 'evento-tipo-card movement d-flex justify-content-between align-items-center text-white text-decoration-none';
+    if (!$isActive) {
+        $classes .= ' inactive';
+    }
+    $search = strtolower(($row['tipo_evento'] ?? '') . ' ' . ($row['colore'] ?? ''));
+    $searchAttr = htmlspecialchars($search, ENT_QUOTES);
+    $url = 'evento_tipo_dettaglio.php?id=' . (int)($row['id'] ?? 0);
+    echo '<div class="' . $classes . '" data-search="' . $searchAttr . '" onclick="window.location.href=\'' . $url . '\'">';
+    echo '  <div class="flex-grow-1">';
+    echo '    <div class="fw-semibold">' . htmlspecialchars($row['tipo_evento'] ?? '') . '</div>';
+    echo '  </div>';
+    echo '  <div class="ms-2 d-flex align-items-center">';
+    $color = htmlspecialchars($row['colore'] ?? '#000000');
+    echo '    <span class="rounded me-2" style="width:20px;height:20px;background:' . $color . ';border:1px solid #fff;"></span>';
+    echo $isActive ? '    <i class="bi bi-check-circle-fill text-success"></i>' : '    <i class="bi bi-x-circle-fill text-danger"></i>';
+    echo '  </div>';
+    echo '</div>';
+}
+?>

--- a/js/eventi_tipi.js
+++ b/js/eventi_tipi.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const search = document.getElementById('search');
+  const showInactive = document.getElementById('showInactive');
+  const cards = Array.from(document.querySelectorAll('.evento-tipo-card'));
+
+  function filter() {
+    const q = search.value.trim().toLowerCase();
+    cards.forEach(card => {
+      const text = card.dataset.search || '';
+      const isInactive = card.classList.contains('inactive');
+      const match = text.includes(q);
+      const visible = match && (!isInactive || showInactive.checked || q !== '');
+      if (visible) {
+        card.style.removeProperty('display');
+      } else {
+        card.style.setProperty('display', 'none', 'important');
+      }
+    });
+  }
+
+  search.addEventListener('input', filter);
+  showInactive.addEventListener('input', filter);
+  filter();
+});


### PR DESCRIPTION
## Summary
- add event type listing and detail pages with real-time search and CRUD
- rename "Tabelle" menu to "Configurazione" and include event type link

## Testing
- `php -l eventi_tipi.php evento_tipo_dettaglio.php includes/render_evento_tipo.php includes/header.php`
- `node --check js/eventi_tipi.js`

------
https://chatgpt.com/codex/tasks/task_e_689f080797788331bebd69cd05784727