### PR TITLE
Track Google Calendar sync status for shifts

### DIFF
--- a/ajax/turni_sync_google.php
+++ b/ajax/turni_sync_google.php
@@ -131,11 +131,15 @@ try {
         if (!empty($t['google_calendar_eventid'])) {
             try {
                 $service->events->patch($calendarIdTurni, $t['google_calendar_eventid'], new Google_Service_Calendar_Event($eventData));
+                $upd = $conn->prepare('UPDATE turni_calendario SET data_ultima_sincronizzazione=NOW() WHERE id=?');
+                $upd->bind_param('i', $t['id']);
+                $upd->execute();
+                $upd->close();
             } catch (Google_Service_Exception $e) {
                 if ($e->getCode() != 404) throw $e;
                 $created = $service->events->insert($calendarIdTurni, new Google_Service_Calendar_Event($eventData));
                 $newId = $created->getId();
-                $upd = $conn->prepare('UPDATE turni_calendario SET google_calendar_eventid=? WHERE id=?');
+                $upd = $conn->prepare('UPDATE turni_calendario SET google_calendar_eventid=?, data_ultima_sincronizzazione=NOW() WHERE id=?');
                 $upd->bind_param('si', $newId, $t['id']);
                 $upd->execute();
                 $upd->close();
@@ -143,7 +147,7 @@ try {
         } else {
             $created = $service->events->insert($calendarIdTurni, new Google_Service_Calendar_Event($eventData));
             $newId = $created->getId();
-            $upd = $conn->prepare('UPDATE turni_calendario SET google_calendar_eventid=? WHERE id=?');
+            $upd = $conn->prepare('UPDATE turni_calendario SET google_calendar_eventid=?, data_ultima_sincronizzazione=NOW() WHERE id=?');
             $upd->bind_param('si', $newId, $t['id']);
             $upd->execute();
             $upd->close();

--- a/sql/add_sync_fields_to_turni_calendario.sql
+++ b/sql/add_sync_fields_to_turni_calendario.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `turni_calendario`
+  ADD COLUMN `aggiornato_il` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `note`,
+  ADD COLUMN `data_ultima_sincronizzazione` datetime DEFAULT NULL AFTER `aggiornato_il`;

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -961,7 +961,9 @@ CREATE TABLE `turni_calendario` (
   `id_tipo` int(11) NOT NULL,
   `google_calendar_eventid` varchar(255) DEFAULT NULL,
   `id_utenti_bambini` varchar(255) DEFAULT NULL,
-  `note` text DEFAULT NULL
+  `note` text DEFAULT NULL,
+  `aggiornato_il` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `data_ultima_sincronizzazione` datetime DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------

--- a/sql/turni.sql
+++ b/sql/turni.sql
@@ -16,6 +16,8 @@ CREATE TABLE turni_calendario (
     google_calendar_eventid VARCHAR(255) DEFAULT NULL,
     id_utenti_bambini VARCHAR(255) DEFAULT NULL,
     note TEXT DEFAULT NULL,
+    aggiornato_il DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    data_ultima_sincronizzazione DATETIME DEFAULT NULL,
     UNIQUE KEY uniq_turno (id_famiglia, data),
     FOREIGN KEY (id_famiglia) REFERENCES famiglie(id_famiglia),
     FOREIGN KEY (id_tipo) REFERENCES turni_tipi(id)

--- a/turni.php
+++ b/turni.php
@@ -10,7 +10,12 @@ $tipiRes = $conn->query("SELECT id, descrizione, colore_bg, colore_testo FROM tu
 $tipi = $tipiRes ? $tipiRes->fetch_all(MYSQLI_ASSOC) : [];
 $bambiniRes = $conn->query("SELECT u.id, COALESCE(NULLIF(u.soprannome,''), CONCAT(u.nome,' ',u.cognome)) AS nome FROM utenti u JOIN utenti2famiglie uf ON u.id = uf.id_utente WHERE uf.id_famiglia = $idFamiglia ORDER BY nome");
 $bambini = $bambiniRes ? $bambiniRes->fetch_all(MYSQLI_ASSOC) : [];
+$syncRes = $conn->query("SELECT COUNT(*) AS cnt FROM turni_calendario WHERE id_famiglia = $idFamiglia AND (data_ultima_sincronizzazione IS NULL OR aggiornato_il > data_ultima_sincronizzazione)");
+$needSync = $syncRes ? ($syncRes->fetch_assoc()['cnt'] > 0) : false;
 ?>
+<?php if ($needSync): ?>
+<div class="alert alert-warning text-center m-0">Alcuni turni non sono sincronizzati con Google Calendar.</div>
+<?php endif; ?>
 <style>
   #calendarContainer .col {height: 100px; min-width:0; overflow:hidden;}
   #calendarContainer .day-cell {display:flex; flex-direction:column; padding:0;}


### PR DESCRIPTION
## Summary
- add updated and last sync timestamps to `turni_calendario`
- flag unsynced shifts on turni.php
- update Google sync script to record last sync time

## Testing
- `php -l turni.php ajax/turni_sync_google.php`


------
https://chatgpt.com/codex/tasks/task_e_689f0a16aa948331be09e47584cd7070