### PR TITLE
Support multi-day events in calendar

### DIFF
--- a/ajax/add_evento.php
+++ b/ajax/add_evento.php
@@ -7,6 +7,10 @@ $titolo = trim($_POST['titolo'] ?? '');
 $descrizione = trim($_POST['descrizione'] ?? '');
 $data_evento = $_POST['data_evento'] ?? null;
 $ora_evento = $_POST['ora_evento'] ?? null;
+$data_fine = $_POST['data_fine'] ?? null;
+if ($data_fine === '') { $data_fine = null; }
+$ora_fine = $_POST['ora_fine'] ?? null;
+if ($ora_fine === '') { $ora_fine = null; }
 $id_tipo_evento = (int)($_POST['id_tipo_evento'] ?? 0);
 $famiglie = $_POST['famiglie'] ?? [];
 if (!is_array($famiglie)) { $famiglie = []; }
@@ -16,8 +20,8 @@ if ($titolo === '') {
     exit;
 }
 
-$stmt = $conn->prepare('INSERT INTO eventi (titolo, descrizione, data_evento, ora_evento, id_tipo_evento) VALUES (?,?,?,?,?)');
-$stmt->bind_param('ssssi', $titolo, $descrizione, $data_evento, $ora_evento, $id_tipo_evento);
+$stmt = $conn->prepare('INSERT INTO eventi (titolo, descrizione, data_evento, ora_evento, data_fine, ora_fine, id_tipo_evento) VALUES (?,?,?,?,?,?,?)');
+$stmt->bind_param('ssssssi', $titolo, $descrizione, $data_evento, $ora_evento, $data_fine, $ora_fine, $id_tipo_evento);
 $ok = $stmt->execute();
 $eventoId = $conn->insert_id;
 $stmt->close();

--- a/ajax/turni_get.php
+++ b/ajax/turni_get.php
@@ -51,16 +51,18 @@ while ($row = $res->fetch_assoc()) {
 }
 $stmt->close();
 
-$evStmt = $conn->prepare('SELECT e.id, e.titolo, e.data_evento, te.colore FROM eventi e JOIN eventi_eventi2famiglie f ON e.id = f.id_evento LEFT JOIN eventi_tipi_eventi te ON e.id_tipo_evento = te.id WHERE f.id_famiglia = ? AND e.data_evento BETWEEN ? AND ? ORDER BY e.data_evento');
-$evStmt->bind_param('iss', $idFamiglia, $start, $end);
+$evStmt = $conn->prepare('SELECT e.id, e.titolo, e.data_evento, e.data_fine, te.colore FROM eventi e JOIN eventi_eventi2famiglie f ON e.id = f.id_evento LEFT JOIN eventi_tipi_eventi te ON e.id_tipo_evento = te.id WHERE f.id_famiglia = ? AND e.data_evento <= ? AND COALESCE(e.data_fine, e.data_evento) >= ? ORDER BY e.data_evento');
+$evStmt->bind_param('iss', $idFamiglia, $end, $start);
 $evStmt->execute();
 $evRes = $evStmt->get_result();
 $eventi = [];
 while ($row = $evRes->fetch_assoc()) {
-    $eventi[$row['data_evento']][] = [
+    $eventi[] = [
         'id' => (int)$row['id'],
         'titolo' => $row['titolo'],
-        'colore' => $row['colore']
+        'colore' => $row['colore'],
+        'data_evento' => $row['data_evento'],
+        'data_fine' => $row['data_fine']
     ];
 }
 $evStmt->close();

--- a/ajax/update_evento.php
+++ b/ajax/update_evento.php
@@ -15,6 +15,10 @@ $titolo = trim($_POST['titolo'] ?? '');
 $descrizione = trim($_POST['descrizione'] ?? '');
 $data_evento = $_POST['data_evento'] ?? null;
 $ora_evento = $_POST['ora_evento'] ?? null;
+$data_fine = $_POST['data_fine'] ?? null;
+if ($data_fine === '') { $data_fine = null; }
+$ora_fine = $_POST['ora_fine'] ?? null;
+if ($ora_fine === '') { $ora_fine = null; }
 $id_tipo_evento = (int)($_POST['id_tipo_evento'] ?? 0);
 if ($id_tipo_evento === 0) { $id_tipo_evento = null; }
 $famiglie = $_POST['famiglie'] ?? [];
@@ -25,8 +29,8 @@ if (!$id) {
     exit;
 }
 
-$stmt = $conn->prepare('UPDATE eventi SET titolo = ?, descrizione = ?, data_evento = ?, ora_evento = ?, id_tipo_evento = ? WHERE id = ?');
-$stmt->bind_param('ssssii', $titolo, $descrizione, $data_evento, $ora_evento, $id_tipo_evento, $id);
+$stmt = $conn->prepare('UPDATE eventi SET titolo = ?, descrizione = ?, data_evento = ?, ora_evento = ?, data_fine = ?, ora_fine = ?, id_tipo_evento = ? WHERE id = ?');
+$stmt->bind_param('ssssssii', $titolo, $descrizione, $data_evento, $ora_evento, $data_fine, $ora_fine, $id_tipo_evento, $id);
 $success = $stmt->execute();
 $stmt->close();
 

--- a/eventi.php
+++ b/eventi.php
@@ -56,6 +56,14 @@ $famigliaDefault = $_SESSION['id_famiglia_gestione'] ?? 0;
           <input type="time" name="ora_evento" class="form-control bg-secondary text-white">
         </div>
         <div class="mb-3">
+          <label class="form-label">Data fine</label>
+          <input type="date" name="data_fine" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Ora fine</label>
+          <input type="time" name="ora_fine" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
           <label class="form-label">Tipo evento</label>
           <select name="id_tipo_evento" class="form-select bg-secondary text-white">
             <option value="">-- nessuno --</option>

--- a/eventi_dettaglio.php
+++ b/eventi_dettaglio.php
@@ -34,6 +34,13 @@ $stmtFam->close();
 $allFamRes = $conn->query('SELECT id_famiglia, nome_famiglia FROM famiglie ORDER BY nome_famiglia');
 $allFamiglie = $allFamRes ? $allFamRes->fetch_all(MYSQLI_ASSOC) : [];
 
+$periodo = '';
+if (!empty($evento['data_evento']) || !empty($evento['ora_evento'])) {
+    $start = trim(($evento['data_evento'] ?? '') . ' ' . ($evento['ora_evento'] ?? ''));
+    $endPart = trim(($evento['data_fine'] ?? '') . ' ' . ($evento['ora_fine'] ?? ''));
+    $periodo = $endPart && $endPart !== $start ? $start . ' - ' . $endPart : $start;
+}
+
 // Invitati già collegati all'evento con stato e note
 $invitati = [];
 $stmtInv = $conn->prepare("SELECT e2i.id_e2i, i.nome, i.cognome, e2i.partecipa, e2i.forse, e2i.assente, e2i.note FROM eventi_eventi2invitati e2i JOIN eventi_invitati i ON e2i.id_invitato = i.id WHERE e2i.id_evento = ? ORDER BY i.cognome, i.nome");
@@ -81,8 +88,8 @@ include 'includes/header.php';
       <i class="bi bi-pencil-square" id="editEventoBtn" style="cursor:pointer"></i>
     <?php endif; ?>
   </div>
-  <?php if (!empty($evento['data_evento']) || !empty($evento['ora_evento'])): ?>
-    <div class="mb-3"><?= htmlspecialchars(trim(($evento['data_evento'] ?? '') . ' ' . ($evento['ora_evento'] ?? ''))) ?></div>
+  <?php if ($periodo !== ''): ?>
+    <div class="mb-3"><?= htmlspecialchars($periodo) ?></div>
   <?php endif; ?>
   <?php if (!empty($evento['descrizione'])): ?>
     <p><?= nl2br(htmlspecialchars($evento['descrizione'])) ?></p>
@@ -169,6 +176,14 @@ include 'includes/header.php';
         <div class="mb-3">
           <label class="form-label">Ora</label>
           <input type="time" name="ora_evento" class="form-control bg-secondary text-white" value="<?= htmlspecialchars($evento['ora_evento'] ?? '') ?>">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Data fine</label>
+          <input type="date" name="data_fine" class="form-control bg-secondary text-white" value="<?= htmlspecialchars($evento['data_fine'] ?? '') ?>">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Ora fine</label>
+          <input type="time" name="ora_fine" class="form-control bg-secondary text-white" value="<?= htmlspecialchars($evento['ora_fine'] ?? '') ?>">
         </div>
         <div class="mb-3">
           <label class="form-label">Tipo evento</label>

--- a/includes/render_evento.php
+++ b/includes/render_evento.php
@@ -2,15 +2,21 @@
 function render_evento(array $row): void {
     $search = strtolower(trim(($row['titolo'] ?? '') . ' ' . ($row['descrizione'] ?? '') . ' ' . ($row['tipo_evento'] ?? '')));
     $searchAttr = htmlspecialchars($search, ENT_QUOTES);
-    $data = !empty($row['data_evento']) ? date('d/m/Y', strtotime($row['data_evento'])) : '';
-    $ora = $row['ora_evento'] ?? '';
+    $startDate = !empty($row['data_evento']) ? date('d/m/Y', strtotime($row['data_evento'])) : '';
+    $endDate = !empty($row['data_fine']) ? date('d/m/Y', strtotime($row['data_fine'])) : '';
+    $startTime = $row['ora_evento'] ?? '';
+    $endTime = $row['ora_fine'] ?? '';
+    $periodo = trim($startDate . ' ' . $startTime);
+    $endPart = trim(($endDate ?: $startDate) . ' ' . $endTime);
+    if ($endPart && $endPart !== $periodo) {
+        $periodo .= ' - ' . $endPart;
+    }
     $url = 'eventi_dettaglio.php?id=' . (int)($row['id'] ?? 0);
     echo '<div class="event-card movement d-flex justify-content-between align-items-start text-white text-decoration-none" data-search="' . $searchAttr . '" onclick="window.location.href=\'' . $url . '\'">';
     echo '  <div class="flex-grow-1">';
     echo '    <div class="fw-semibold">' . htmlspecialchars($row['titolo']) . '</div>';
-    if ($data || $ora) {
-        $dataOra = trim($data . ' ' . $ora);
-        echo '    <div class="small">' . htmlspecialchars($dataOra) . '</div>';
+    if ($periodo !== '') {
+        echo '    <div class="small">' . htmlspecialchars($periodo) . '</div>';
     }
     if (!empty($row['descrizione'])) {
         echo '    <div class="small text-muted">' . htmlspecialchars($row['descrizione']) . '</div>';

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -369,6 +369,8 @@ CREATE TABLE `eventi` (
   `titolo` varchar(100) DEFAULT NULL,
   `data_evento` date DEFAULT NULL,
   `ora_evento` varchar(10) DEFAULT NULL,
+  `data_fine` date DEFAULT NULL,
+  `ora_fine` varchar(10) DEFAULT NULL,
   `descrizione` varchar(100) DEFAULT NULL,
   `id_tipo_evento` int(11) DEFAULT NULL,
   `icon` varchar(50) DEFAULT NULL,

--- a/turni.php
+++ b/turni.php
@@ -13,13 +13,16 @@ $bambini = $bambiniRes ? $bambiniRes->fetch_all(MYSQLI_ASSOC) : [];
 ?>
 <style>
   #calendarContainer .col {height: 100px; min-width:0; overflow:hidden;}
-  #calendarContainer .day-cell {display:flex; flex-direction:column; padding:0;}
+  #calendarContainer .day-cell {display:flex; flex-direction:column; padding:0; padding-top:20px;}
   #calendarContainer .turni-container {flex:1; display:flex; flex-direction:column;}
   #calendarContainer .turno {flex:1; display:flex; align-items:center; justify-content:center; font-size:.8rem; position:relative; overflow:hidden;}
   #calendarContainer .turno.event a {color:inherit; text-decoration:none; width:100%; display:block; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
   #calendarContainer .turno .bambini {position:absolute; bottom:0; right:0; font-size:.6rem; padding:0 2px;}
   #pillContainer .pill.active {outline:2px solid #fff;}
   #calendarContainer .day-cell.multi-selected {outline:2px solid #0d6efd;}
+  #calendarContainer .week-row {position:relative;}
+  #calendarContainer .multi-event {position:absolute; top:0; height:20px; display:flex; align-items:center; justify-content:center; font-size:.8rem; overflow:hidden; border-radius:4px;}
+  #calendarContainer .multi-event a {color:inherit; text-decoration:none; width:100%; display:block; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 </style>
 <div id="shifter" class="d-flex flex-column min-vh-100 p-0">
   <div class="bg-dark text-white p-3 position-sticky top-0">


### PR DESCRIPTION
## Summary
- allow events to have end date and time
- show multi-day events in the calendar as a single horizontal bar
- include end date/time fields in event forms

## Testing
- `php -l ajax/add_evento.php`
- `php -l ajax/update_evento.php`
- `php -l eventi.php`
- `php -l eventi_dettaglio.php`
- `php -l includes/render_evento.php`
- `php -l ajax/turni_get.php`
- `php -l turni.php`
- `node --check js/turni.js`


------
https://chatgpt.com/codex/tasks/task_e_689f0bc7245083318333e148fe768ad8