### PR TITLE
Add venue management to event detail

### DIFF
--- a/ajax/add_e2l.php
+++ b/ajax/add_e2l.php
@@ -1,0 +1,32 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_evento = (int)($_POST['id_evento'] ?? 0);
+$luogo = trim($_POST['luogo'] ?? '');
+
+if(!$id_evento || $luogo === ''){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT id FROM eventi_luogo WHERE indirizzo = ?');
+$stmt->bind_param('s', $luogo);
+$stmt->execute();
+$stmt->bind_result($id_luogo);
+if(!$stmt->fetch()){
+    $stmt->close();
+    $stmt = $conn->prepare('INSERT INTO eventi_luogo (indirizzo) VALUES (?)');
+    $stmt->bind_param('s', $luogo);
+    $stmt->execute();
+    $id_luogo = $stmt->insert_id;
+}
+$stmt->close();
+
+$stmt = $conn->prepare('INSERT INTO eventi_eventi2luogo (id_evento, id_luogo) VALUES (?,?)');
+$stmt->bind_param('ii', $id_evento, $id_luogo);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/ajax/delete_e2l.php
+++ b/ajax/delete_e2l.php
@@ -1,0 +1,17 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_e2l = (int)($_POST['id_e2l'] ?? 0);
+if(!$id_e2l){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('DELETE FROM eventi_eventi2luogo WHERE id_e2l=?');
+$stmt->bind_param('i', $id_e2l);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/ajax/update_e2l.php
+++ b/ajax/update_e2l.php
@@ -1,0 +1,32 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_e2l = (int)($_POST['id_e2l'] ?? 0);
+$luogo = trim($_POST['luogo'] ?? '');
+
+if(!$id_e2l || $luogo === ''){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT id FROM eventi_luogo WHERE indirizzo = ?');
+$stmt->bind_param('s', $luogo);
+$stmt->execute();
+$stmt->bind_result($id_luogo);
+if(!$stmt->fetch()){
+    $stmt->close();
+    $stmt = $conn->prepare('INSERT INTO eventi_luogo (indirizzo) VALUES (?)');
+    $stmt->bind_param('s', $luogo);
+    $stmt->execute();
+    $id_luogo = $stmt->insert_id;
+}
+$stmt->close();
+
+$stmt = $conn->prepare('UPDATE eventi_eventi2luogo SET id_luogo=? WHERE id_e2l=?');
+$stmt->bind_param('ii', $id_luogo, $id_e2l);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -1,6 +1,10 @@
 // JavaScript for eventi_dettaglio.php
 
 document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('toggleLuoghi')?.addEventListener('click', function(){
+    document.querySelectorAll('#luoghiList .extra-row').forEach(el=>el.classList.toggle('d-none'));
+    this.textContent = this.textContent === 'Mostra tutti' ? 'Mostra meno' : 'Mostra tutti';
+  });
   document.getElementById('toggleInvitati')?.addEventListener('click', function(){
     document.querySelectorAll('#invitatiList .extra-row').forEach(el=>el.classList.toggle('d-none'));
     this.textContent = this.textContent === 'Mostra tutti' ? 'Mostra meno' : 'Mostra tutti';
@@ -54,6 +58,20 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
   });
 
+  document.getElementById('addLuogoBtn')?.addEventListener('click', () => {
+    const form = document.getElementById('addLuogoForm');
+    form.reset();
+    new bootstrap.Modal(document.getElementById('addLuogoModal')).show();
+  });
+
+  document.getElementById('addLuogoForm')?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    fetch('ajax/add_e2l.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
   document.getElementById('addCiboBtn')?.addEventListener('click', () => {
     const form = document.getElementById('addCiboForm');
     form.reset();
@@ -83,6 +101,34 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const fd = new FormData(this);
     fetch('ajax/update_e2c.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
+  // apertura modal modifica luogo
+  document.querySelectorAll('#luoghiList .luogo-row').forEach(li => {
+    li.addEventListener('click', () => {
+      const form = document.getElementById('luogoForm');
+      form.id_e2l.value = li.dataset.id;
+      form.luogo.value = li.dataset.luogo;
+      new bootstrap.Modal(document.getElementById('luogoModal')).show();
+    });
+  });
+
+  document.getElementById('luogoForm')?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    fetch('ajax/update_e2l.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
+  document.getElementById('deleteLuogoBtn')?.addEventListener('click', function(){
+    const id = document.getElementById('luogoForm')?.id_e2l.value;
+    if(!id || !confirm('Eliminare questo luogo dall\'evento?')) return;
+    const fd = new FormData();
+    fd.append('id_e2l', id);
+    fetch('ajax/delete_e2l.php', {method:'POST', body:fd})
       .then(r=>r.json())
       .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
   });


### PR DESCRIPTION
## Summary
- Display locations associated with an event before the guest list
- Allow adding, editing, and removing locations via new modals and AJAX endpoints
- Extend event detail scripts to handle location CRUD operations

## Testing
- `php -l eventi_dettaglio.php`
- `php -l ajax/add_e2l.php`
- `php -l ajax/update_e2l.php`
- `php -l ajax/delete_e2l.php`


------
https://chatgpt.com/codex/tasks/task_e_689f140cdf94833182554be2bdae59cb