### PR TITLE
Link events to piggybanks and labels with budget preview

### DIFF
--- a/ajax/add_e2se.php
+++ b/ajax/add_e2se.php
@@ -1,0 +1,20 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_evento = (int)($_POST['id_evento'] ?? 0);
+$id_salvadanaio = (int)($_POST['id_salvadanaio'] ?? 0);
+$id_etichetta = (int)($_POST['id_etichetta'] ?? 0);
+
+if(!$id_evento || !$id_salvadanaio || !$id_etichetta){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('INSERT INTO eventi_eventi2salvadanai_etichette (id_evento, id_salvadanaio, id_etichetta) VALUES (?,?,?)');
+$stmt->bind_param('iii', $id_evento, $id_salvadanaio, $id_etichetta);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/ajax/delete_e2se.php
+++ b/ajax/delete_e2se.php
@@ -1,0 +1,17 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_e2se = (int)($_POST['id_e2se'] ?? 0);
+if(!$id_e2se){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('DELETE FROM eventi_eventi2salvadanai_etichette WHERE id_e2se=?');
+$stmt->bind_param('i', $id_e2se);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/ajax/update_e2se.php
+++ b/ajax/update_e2se.php
@@ -1,0 +1,20 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_e2se = (int)($_POST['id_e2se'] ?? 0);
+$id_salvadanaio = (int)($_POST['id_salvadanaio'] ?? 0);
+$id_etichetta = (int)($_POST['id_etichetta'] ?? 0);
+
+if(!$id_e2se || !$id_salvadanaio || !$id_etichetta){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('UPDATE eventi_eventi2salvadanai_etichette SET id_salvadanaio=?, id_etichetta=? WHERE id_e2se=?');
+$stmt->bind_param('iii', $id_salvadanaio, $id_etichetta, $id_e2se);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -13,6 +13,10 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('#ciboList .extra-row').forEach(el=>el.classList.toggle('d-none'));
     this.textContent = this.textContent === 'Mostra tutti' ? 'Mostra meno' : 'Mostra tutti';
   });
+  document.getElementById('toggleSe')?.addEventListener('click', function(){
+    document.querySelectorAll('#seList .extra-row').forEach(el=>el.classList.toggle('d-none'));
+    this.textContent = this.textContent === 'Mostra tutti' ? 'Mostra meno' : 'Mostra tutti';
+  });
 
   // apertura modal modifica invitato
   document.querySelectorAll('#invitatiList .inv-row').forEach(li => {
@@ -58,6 +62,20 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
   });
 
+  document.getElementById('addSeBtn')?.addEventListener('click', () => {
+    const form = document.getElementById('addSeForm');
+    form.reset();
+    new bootstrap.Modal(document.getElementById('addSeModal')).show();
+  });
+
+  document.getElementById('addSeForm')?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    fetch('ajax/add_e2se.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
   document.getElementById('addLuogoBtn')?.addEventListener('click', () => {
     const form = document.getElementById('addLuogoForm');
     form.reset();
@@ -82,6 +100,35 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const fd = new FormData(this);
     fetch('ajax/add_e2c.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
+  // apertura modal modifica salvadanaio/etichetta
+  document.querySelectorAll('#seList .se-row').forEach(li => {
+    li.addEventListener('click', () => {
+      const form = document.getElementById('seForm');
+      form.id_e2se.value = li.dataset.id;
+      form.id_salvadanaio.value = li.dataset.idSalvadanaio;
+      form.id_etichetta.value = li.dataset.idEtichetta;
+      new bootstrap.Modal(document.getElementById('seModal')).show();
+    });
+  });
+
+  document.getElementById('seForm')?.addEventListener('submit', function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    fetch('ajax/update_e2se.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
+  document.getElementById('deleteSeBtn')?.addEventListener('click', function(){
+    const id = document.getElementById('seForm')?.id_e2se.value;
+    if(!id || !confirm('Eliminare questo collegamento?')) return;
+    const fd = new FormData();
+    fd.append('id_e2se', id);
+    fetch('ajax/delete_e2se.php', {method:'POST', body:fd})
       .then(r=>r.json())
       .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
   });

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -477,6 +477,19 @@ CREATE TABLE `eventi_eventi2luogo` (
 -- --------------------------------------------------------
 
 --
+-- Struttura della tabella `eventi_eventi2salvadanai_etichette`
+--
+
+CREATE TABLE `eventi_eventi2salvadanai_etichette` (
+  `id_e2se` int(11) NOT NULL,
+  `id_evento` int(11) NOT NULL,
+  `id_salvadanaio` int(11) NOT NULL,
+  `id_etichetta` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+
+--
 -- Struttura della tabella `eventi_invitati`
 --
 
@@ -1324,6 +1337,15 @@ ALTER TABLE `eventi_eventi2luogo`
   ADD PRIMARY KEY (`id_e2l`);
 
 --
+-- Indici per le tabelle `eventi_eventi2salvadanai_etichette`
+--
+ALTER TABLE `eventi_eventi2salvadanai_etichette`
+  ADD PRIMARY KEY (`id_e2se`),
+  ADD KEY `idx_e2se_id_evento` (`id_evento`),
+  ADD KEY `idx_e2se_id_salvadanaio` (`id_salvadanaio`),
+  ADD KEY `idx_e2se_id_etichetta` (`id_etichetta`);
+
+--
 -- Indici per le tabelle `eventi_invitati`
 --
 ALTER TABLE `eventi_invitati`
@@ -1783,6 +1805,12 @@ ALTER TABLE `eventi_eventi2luogo`
   MODIFY `id_e2l` int(11) NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT per la tabella `eventi_eventi2salvadanai_etichette`
+--
+ALTER TABLE `eventi_eventi2salvadanai_etichette`
+  MODIFY `id_e2se` int(11) NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT per la tabella `eventi_invitati`
 --
 ALTER TABLE `eventi_invitati`
@@ -2084,6 +2112,14 @@ ALTER TABLE `budget`
 ALTER TABLE `eventi_eventi2invitati`
   ADD CONSTRAINT `fk_eventi2invitati_evento` FOREIGN KEY (`id_evento`) REFERENCES `eventi` (`id`),
   ADD CONSTRAINT `fk_eventi2invitati_invitato` FOREIGN KEY (`id_invitato`) REFERENCES `eventi_invitati` (`id`);
+
+--
+-- Limiti per la tabella `eventi_eventi2salvadanai_etichette`
+--
+ALTER TABLE `eventi_eventi2salvadanai_etichette`
+  ADD CONSTRAINT `fk_e2se_evento` FOREIGN KEY (`id_evento`) REFERENCES `eventi` (`id`),
+  ADD CONSTRAINT `fk_e2se_salvadanaio` FOREIGN KEY (`id_salvadanaio`) REFERENCES `salvadanai` (`id_salvadanaio`),
+  ADD CONSTRAINT `fk_e2se_etichetta` FOREIGN KEY (`id_etichetta`) REFERENCES `bilancio_etichette` (`id_etichetta`);
 
 --
 -- Limiti per la tabella `gestione_account_password`


### PR DESCRIPTION
## Summary
- Add `eventi_eventi2salvadanai_etichette` join table and wire up foreign keys
- Display and manage piggybank/label links in event detail with related budget rows
- Implement JS and AJAX handlers for adding, editing and deleting these associations

## Testing
- `php -l eventi_dettaglio.php`
- `php -l ajax/add_e2se.php`
- `php -l ajax/update_e2se.php`
- `php -l ajax/delete_e2se.php`


------
https://chatgpt.com/codex/tasks/task_e_689f3ab218f48331889b54281abbb04a