### PR TITLE
Migliora modali finanze ed evita notice gruppo

### DIFF
--- a/etichetta.php
+++ b/etichetta.php
@@ -350,17 +350,21 @@ $salvadanaiDisponibili = $resSalv ? $resSalv->fetch_all(MYSQLI_ASSOC) : [];
           </div>
           <div class="modal-body">
             <input type="hidden" name="id_etichetta" value="<?= (int)$etichettaInfo['id_etichetta'] ?>">
-            <div class="mb-3">
+            <div class="mb-3 select-search">
               <label class="form-label">Evento</label>
+              <input type="text" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
               <select name="id_evento" class="form-select bg-secondary text-white">
+                <option value=""></option>
                 <?php foreach ($eventiDisponibili as $e): ?>
                   <option value="<?= (int)$e['id'] ?>"><?= htmlspecialchars($e['titolo']) ?></option>
                 <?php endforeach; ?>
               </select>
             </div>
-            <div class="mb-3">
+            <div class="mb-3 select-search">
               <label class="form-label">Salvadanaio</label>
+              <input type="text" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
               <select name="id_salvadanaio" class="form-select bg-secondary text-white">
+                <option value=""></option>
                 <?php foreach ($salvadanaiDisponibili as $s): ?>
                   <option value="<?= (int)$s['id_salvadanaio'] ?>"><?= htmlspecialchars($s['nome_salvadanaio']) ?></option>
                 <?php endforeach; ?>
@@ -643,11 +647,13 @@ $salvadanaiDisponibili = $resSalv ? $resSalv->fetch_all(MYSQLI_ASSOC) : [];
         </thead>
         <tbody>
           <?php foreach ($gruppi as $g): ?>
+            <?php $entrate = $g['entrate'] ?? 0; ?>
+            <?php $uscite = $g['uscite'] ?? 0; ?>
             <tr>
               <!--<td><?= htmlspecialchars($g['categoria']) ?></td>-->
               <td><?= htmlspecialchars($g['gruppo'] ?? $g['id_gruppo_transazione']) ?></td>
-              <td class="text-end text-nowrap"><?= ($g['entrate'] > 0 ? '+' : '') . number_format($g['entrate'], 2, ',', '.') ?> €</td>
-              <td class="text-end text-nowrap"><?= number_format($g['uscite'], 2, ',', '.') ?> €</td>
+              <td class="text-end text-nowrap"><?= ($entrate > 0 ? '+' : '') . number_format($entrate, 2, ',', '.') ?> €</td>
+              <td class="text-end text-nowrap"><?= number_format($uscite, 2, ',', '.') ?> €</td>
             </tr>
           <?php endforeach; ?>
             <tr>

--- a/eventi_dettaglio.php
+++ b/eventi_dettaglio.php
@@ -472,6 +472,7 @@ include 'includes/header.php';
           <label class="form-label">Salvadanaio</label>
           <input type="text" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
           <select name="id_salvadanaio" id="seSalvadanaio" class="form-select bg-secondary text-white">
+            <option value=""></option>
             <?php foreach ($salvadanaiTutti as $s): ?>
               <option value="<?= (int)$s['id_salvadanaio'] ?>"><?= htmlspecialchars($s['nome_salvadanaio']) ?></option>
             <?php endforeach; ?>
@@ -481,6 +482,7 @@ include 'includes/header.php';
           <label class="form-label">Etichetta</label>
           <input type="text" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
           <select name="id_etichetta" id="seEtichetta" class="form-select bg-secondary text-white">
+            <option value=""></option>
             <?php foreach ($etichetteTutte as $et): ?>
               <option value="<?= (int)$et['id_etichetta'] ?>"><?= htmlspecialchars($et['descrizione']) ?></option>
             <?php endforeach; ?>
@@ -509,6 +511,7 @@ include 'includes/header.php';
           <label class="form-label">Salvadanaio</label>
           <input type="text" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
           <select name="id_salvadanaio" class="form-select bg-secondary text-white">
+            <option value=""></option>
             <?php foreach ($salvadanaiAttivi as $s): ?>
               <option value="<?= (int)$s['id_salvadanaio'] ?>"><?= htmlspecialchars($s['nome_salvadanaio']) ?></option>
             <?php endforeach; ?>
@@ -518,6 +521,7 @@ include 'includes/header.php';
           <label class="form-label">Etichetta</label>
           <input type="text" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
           <select name="id_etichetta" class="form-select bg-secondary text-white">
+            <option value=""></option>
             <?php foreach ($etichetteAttive as $et): ?>
               <option value="<?= (int)$et['id_etichetta'] ?>"><?= htmlspecialchars($et['descrizione']) ?></option>
             <?php endforeach; ?>

--- a/salvadanaio_dettaglio.php
+++ b/salvadanaio_dettaglio.php
@@ -115,17 +115,21 @@ if ($id > 0): ?>
       <div class="modal-body">
         <input type="hidden" name="id_e2se" id="id_e2se">
         <input type="hidden" name="id_salvadanaio" value="<?= (int)$id ?>">
-        <div class="mb-3">
+        <div class="mb-3 select-search">
           <label class="form-label">Evento</label>
+          <input type="text" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
           <select name="id_evento" id="seEvento" class="form-select bg-secondary text-white">
+            <option value=""></option>
             <?php foreach ($eventiDisponibili as $ev): ?>
               <option value="<?= (int)$ev['id'] ?>"><?= htmlspecialchars($ev['titolo']) ?></option>
             <?php endforeach; ?>
           </select>
         </div>
-        <div class="mb-3">
+        <div class="mb-3 select-search">
           <label class="form-label">Etichetta</label>
+          <input type="text" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
           <select name="id_etichetta" id="seEtichetta" class="form-select bg-secondary text-white">
+            <option value=""></option>
             <?php foreach ($etichetteDisponibili as $et): ?>
               <option value="<?= (int)$et['id_etichetta'] ?>"><?= htmlspecialchars($et['descrizione']) ?></option>
             <?php endforeach; ?>
@@ -149,17 +153,21 @@ if ($id > 0): ?>
       </div>
       <div class="modal-body">
         <input type="hidden" name="id_salvadanaio" value="<?= (int)$id ?>">
-        <div class="mb-3">
+        <div class="mb-3 select-search">
           <label class="form-label">Evento</label>
+          <input type="text" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
           <select name="id_evento" class="form-select bg-secondary text-white">
+            <option value=""></option>
             <?php foreach ($eventiDisponibili as $ev): ?>
               <option value="<?= (int)$ev['id'] ?>"><?= htmlspecialchars($ev['titolo']) ?></option>
             <?php endforeach; ?>
           </select>
         </div>
-        <div class="mb-3">
+        <div class="mb-3 select-search">
           <label class="form-label">Etichetta</label>
+          <input type="text" class="form-control bg-secondary text-white mb-2" placeholder="Cerca">
           <select name="id_etichetta" class="form-select bg-secondary text-white">
+            <option value=""></option>
             <?php foreach ($etichetteDisponibili as $et): ?>
               <option value="<?= (int)$et['id_etichetta'] ?>"><?= htmlspecialchars($et['descrizione']) ?></option>
             <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Consenti la selezione opzionale di salvadanaio ed etichetta nei modali finanze degli eventi
- Aggiungi modali di inserimento/modifica finanze in dettaglio salvadanaio con ricerca e scelte facoltative
- Allinea il modale di aggiunta finanze nelle etichette e gestisci i totali per gruppo senza notice

## Testing
- `php -l eventi_dettaglio.php`
- `php -l salvadanaio_dettaglio.php`
- `php -l etichetta.php`


------
https://chatgpt.com/codex/tasks/task_e_689f4afec7e08331b155f423799eaf8c