### PR TITLE
Save Google event creator and create rules

### DIFF
--- a/ajax/add_evento_google_rule.php
+++ b/ajax/add_evento_google_rule.php
@@ -1,0 +1,51 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+include '../includes/permissions.php';
+if (!has_permission($conn, 'table:eventi_google_rules', 'insert')) {
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Accesso negato']);
+    exit;
+}
+$idEvento = isset($_POST['id_evento']) ? (int)$_POST['id_evento'] : 0;
+if (!$idEvento) {
+    echo json_encode(['success'=>false,'error'=>'ID evento mancante']);
+    exit;
+}
+$stmt = $conn->prepare('SELECT creator_email, id_tipo_evento FROM eventi WHERE id=?');
+$stmt->bind_param('i', $idEvento);
+$stmt->execute();
+$res = $stmt->get_result();
+$ev = $res->fetch_assoc();
+$stmt->close();
+if (!$ev || empty($ev['creator_email'])) {
+    echo json_encode(['success'=>false,'error'=>'Dati evento non validi']);
+    exit;
+}
+$idTipo = $ev['id_tipo_evento'] ? (int)$ev['id_tipo_evento'] : null;
+$inv = [];
+$invStmt = $conn->prepare('SELECT id_invitato FROM eventi_eventi2invitati WHERE id_evento=?');
+$invStmt->bind_param('i', $idEvento);
+$invStmt->execute();
+$invRes = $invStmt->get_result();
+while ($row = $invRes->fetch_assoc()) { $inv[] = (int)$row['id_invitato']; }
+$invStmt->close();
+if (!$idTipo && !$inv) {
+    echo json_encode(['success'=>false,'error'=>'Nessun tipo evento o invitati']);
+    exit;
+}
+$stmt = $conn->prepare('INSERT INTO eventi_google_rules (creator_email, id_tipo_evento, attiva) VALUES (?,?,1)');
+$stmt->bind_param('si', $ev['creator_email'], $idTipo);
+$stmt->execute();
+$ruleId = $stmt->insert_id;
+$stmt->close();
+if ($inv) {
+    $insInv = $conn->prepare('INSERT INTO eventi_google_rules_invitati (id_rule, id_invitato) VALUES (?,?)');
+    foreach ($inv as $idInv) {
+        $insInv->bind_param('ii', $ruleId, $idInv);
+        $insInv->execute();
+    }
+    $insInv->close();
+}
+echo json_encode(['success'=>true]);

--- a/ajax/turni_sync_google.php
+++ b/ajax/turni_sync_google.php
@@ -286,14 +286,14 @@ try {
 
             if (isset($eventiByGcId[$gcId])) {
                 $dbId = $eventiByGcId[$gcId];
-                $upd = $conn->prepare('UPDATE eventi SET titolo=?, data_evento=?, ora_evento=?,data_fine=?, ora_fine=?, descrizione=?, id_tipo_evento=IFNULL(?, id_tipo_evento) WHERE id=?');
-                $upd->bind_param('ssssssii', $summary, $date, $time, $data_fine, $ora_fine, $description, $idTipoEvento, $dbId);
+                $upd = $conn->prepare('UPDATE eventi SET titolo=?, data_evento=?, ora_evento=?,data_fine=?, ora_fine=?, descrizione=?, id_tipo_evento=IFNULL(?, id_tipo_evento), creator_email=? WHERE id=?');
+                $upd->bind_param('ssssssisi', $summary, $date, $time, $data_fine, $ora_fine, $description, $idTipoEvento, $creatorEmail, $dbId);
                 $upd->execute();
                 $upd->close();
                 $eventId = $dbId;
             } else {
-                $ins = $conn->prepare('INSERT INTO eventi (titolo, data_evento, ora_evento, data_fine, ora_fine, descrizione, id_tipo_evento, google_calendar_eventid) VALUES (?,?,?,?,?,?,?,?)');
-                $ins->bind_param('ssssssis', $summary, $date, $time, $data_fine, $ora_fine, $description, $idTipoEvento, $gcId);
+                $ins = $conn->prepare('INSERT INTO eventi (titolo, data_evento, ora_evento, data_fine, ora_fine, descrizione, id_tipo_evento, google_calendar_eventid, creator_email) VALUES (?,?,?,?,?,?,?,?,?)');
+                $ins->bind_param('ssssssiss', $summary, $date, $time, $data_fine, $ora_fine, $description, $idTipoEvento, $gcId, $creatorEmail);
                 $ins->execute();
                 $newId = $ins->insert_id;
                 $ins->close();

--- a/eventi_dettaglio.php
+++ b/eventi_dettaglio.php
@@ -82,6 +82,8 @@ $resDisp = $stmtDisp->get_result();
 while ($row = $resDisp->fetch_assoc()) { $invitatiDisponibili[] = $row; }
 $stmtDisp->close();
 
+$showAddRule = !empty($evento['creator_email']) && (!empty($evento['id_tipo_evento']) || count($invitati) > 0);
+
 // Cibo collegato all'evento
 $cibi = [];
 $stmtCibo = $conn->prepare("SELECT e2c.id_e2c, c.piatto, c.um, e2c.quantita FROM eventi_eventi2cibo e2c JOIN eventi_cibo c ON e2c.id_cibo = c.id WHERE e2c.id_evento = ? ORDER BY c.piatto");
@@ -129,11 +131,16 @@ include 'includes/header.php';
 ?>
 <div class="container text-white">
   <a href="javascript:history.back()" class="btn btn-outline-light mb-3">← Indietro</a>
-  <div class="d-flex align-items-center mb-3">
-    <h4 class="mb-0 me-2" id="eventoTitolo"><?= htmlspecialchars($evento['titolo'] ?? '') ?></h4>
-    <?php if ($canUpdate): ?>
-      <i class="bi bi-pencil-square" id="editEventoBtn" style="cursor:pointer"></i>
-    <?php endif; ?>
+  <div class="d-flex align-items-center mb-3 justify-content-between">
+    <h4 class="mb-0" id="eventoTitolo"><?= htmlspecialchars($evento['titolo'] ?? '') ?></h4>
+    <div>
+      <?php if ($showAddRule): ?>
+        <i class="bi bi-star me-2" id="addRuleBtn" data-id="<?= $id ?>" style="cursor:pointer"></i>
+      <?php endif; ?>
+      <?php if ($canUpdate): ?>
+        <i class="bi bi-pencil-square" id="editEventoBtn" style="cursor:pointer"></i>
+      <?php endif; ?>
+    </div>
   </div>
   <?php if ($periodo !== ''): ?>
     <div class="mb-3"><?= htmlspecialchars($periodo) ?></div>

--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -202,4 +202,20 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(r=>r.json())
       .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
   });
+
+  document.getElementById('addRuleBtn')?.addEventListener('click', function(){
+    if(!confirm('Salvare regola per questo evento?')) return;
+    const fd = new FormData();
+    fd.append('id_evento', this.dataset.id);
+    fetch('ajax/add_evento_google_rule.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{
+        if(res.success){
+          alert('Regola salvata');
+          this.classList.replace('bi-star','bi-star-fill');
+        } else {
+          alert(res.error||'Errore');
+        }
+      });
+  });
 });

--- a/sql/add_creator_email_to_eventi.sql
+++ b/sql/add_creator_email_to_eventi.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `eventi`
+  ADD COLUMN `creator_email` varchar(255) DEFAULT NULL AFTER `google_calendar_eventid`;

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -375,7 +375,8 @@ CREATE TABLE `eventi` (
   `id_tipo_evento` int(11) DEFAULT NULL,
   `icon` varchar(50) DEFAULT NULL,
   `note` mediumtext,
-  `google_calendar_eventid` varchar(255) DEFAULT NULL
+  `google_calendar_eventid` varchar(255) DEFAULT NULL,
+  `creator_email` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
## Summary
- Store Google event creator email in events
- Allow adding Google rule from event detail with star icon
- Add migration for creator_email field

## Testing
- `php -l ajax/turni_sync_google.php`
- `php -l eventi_dettaglio.php`
- `php -l ajax/add_evento_google_rule.php`


------
https://chatgpt.com/codex/tasks/task_e_689f4c5386d88331ad9e345fd7242233