### PR TITLE
Allow choosing text color for event types

### DIFF
--- a/ajax/turni_get.php
+++ b/ajax/turni_get.php
@@ -51,7 +51,7 @@ while ($row = $res->fetch_assoc()) {
 }
 $stmt->close();
 
-$evStmt = $conn->prepare('SELECT e.id, e.titolo, e.data_evento, e.data_fine, te.colore FROM eventi e JOIN eventi_eventi2famiglie f ON e.id = f.id_evento LEFT JOIN eventi_tipi_eventi te ON e.id_tipo_evento = te.id WHERE f.id_famiglia = ? AND e.data_evento <= ? AND COALESCE(e.data_fine, e.data_evento) >= ? ORDER BY e.data_evento');
+$evStmt = $conn->prepare('SELECT e.id, e.titolo, e.data_evento, e.data_fine, te.colore, te.colore_testo FROM eventi e JOIN eventi_eventi2famiglie f ON e.id = f.id_evento LEFT JOIN eventi_tipi_eventi te ON e.id_tipo_evento = te.id WHERE f.id_famiglia = ? AND e.data_evento <= ? AND COALESCE(e.data_fine, e.data_evento) >= ? ORDER BY e.data_evento');
 $evStmt->bind_param('iss', $idFamiglia, $end, $start);
 $evStmt->execute();
 $evRes = $evStmt->get_result();
@@ -61,6 +61,7 @@ while ($row = $evRes->fetch_assoc()) {
         'id' => (int)$row['id'],
         'titolo' => $row['titolo'],
         'colore' => $row['colore'],
+        'colore_testo' => $row['colore_testo'],
         'data_evento' => $row['data_evento'],
         'data_fine' => $row['data_fine']
     ];

--- a/eventi.php
+++ b/eventi.php
@@ -6,7 +6,7 @@ if (!has_permission($conn, 'page:eventi.php', 'view')) { http_response_code(403)
 require_once 'includes/render_evento.php';
 include 'includes/header.php';
 
-$stmt = $conn->prepare("SELECT e.*, t.tipo_evento, t.colore FROM eventi e LEFT JOIN eventi_tipi_eventi t ON e.id_tipo_evento = t.id ORDER BY e.data_evento DESC, e.ora_evento DESC");
+$stmt = $conn->prepare("SELECT e.*, t.tipo_evento, t.colore, t.colore_testo FROM eventi e LEFT JOIN eventi_tipi_eventi t ON e.id_tipo_evento = t.id ORDER BY e.data_evento DESC, e.ora_evento DESC");
 $stmt->execute();
 $res = $stmt->get_result();
 $canInsert = has_permission($conn, 'table:eventi', 'insert');

--- a/eventi_dettaglio.php
+++ b/eventi_dettaglio.php
@@ -6,7 +6,7 @@ if (!has_permission($conn, 'page:eventi.php', 'view')) { http_response_code(403)
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
-$stmt = $conn->prepare("SELECT e.*, t.tipo_evento, t.colore FROM eventi e LEFT JOIN eventi_tipi_eventi t ON e.id_tipo_evento = t.id WHERE e.id = ?");
+$stmt = $conn->prepare("SELECT e.*, t.tipo_evento, t.colore, t.colore_testo FROM eventi e LEFT JOIN eventi_tipi_eventi t ON e.id_tipo_evento = t.id WHERE e.id = ?");
 $stmt->bind_param('i', $id);
 $stmt->execute();
 $res = $stmt->get_result();

--- a/evento_tipo_dettaglio.php
+++ b/evento_tipo_dettaglio.php
@@ -10,6 +10,7 @@ $data = [
     'id' => 0,
     'tipo_evento' => '',
     'colore' => '#71843f',
+    'colore_testo' => '#ffffff',
     'attivo' => 1
 ];
 if ($id > 0) {
@@ -39,15 +40,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     $tipo = $_POST['tipo_evento'] ?? '';
     $colore = $_POST['colore'] ?? '';
+    $coloreTesto = $_POST['colore_testo'] ?? '';
     $attivo = isset($_POST['attivo']) ? 1 : 0;
     if ($id > 0) {
-        $stmt = $conn->prepare('UPDATE eventi_tipi_eventi SET tipo_evento=?, colore=?, attivo=? WHERE id=?');
-        $stmt->bind_param('ssii', $tipo, $colore, $attivo, $id);
+        $stmt = $conn->prepare('UPDATE eventi_tipi_eventi SET tipo_evento=?, colore=?, colore_testo=?, attivo=? WHERE id=?');
+        $stmt->bind_param('sssii', $tipo, $colore, $coloreTesto, $attivo, $id);
         $stmt->execute();
         $stmt->close();
     } else {
-        $stmt = $conn->prepare('INSERT INTO eventi_tipi_eventi (tipo_evento, colore, attivo) VALUES (?,?,?)');
-        $stmt->bind_param('ssi', $tipo, $colore, $attivo);
+        $stmt = $conn->prepare('INSERT INTO eventi_tipi_eventi (tipo_evento, colore, colore_testo, attivo) VALUES (?,?,?,?)');
+        $stmt->bind_param('sssi', $tipo, $colore, $coloreTesto, $attivo);
         $stmt->execute();
         $stmt->close();
     }
@@ -65,8 +67,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <input type="text" name="tipo_evento" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['tipo_evento']) ?>" required>
   </div>
   <div class="mb-3">
-    <label class="form-label">Colore</label>
+    <label class="form-label">Colore sfondo</label>
     <input type="color" name="colore" class="form-control form-control-color" value="<?= htmlspecialchars($data['colore']) ?>" title="Scegli colore">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Colore testo</label>
+    <input type="color" name="colore_testo" class="form-control form-control-color" value="<?= htmlspecialchars($data['colore_testo']) ?>" title="Scegli colore">
   </div>
   <div class="form-check form-switch mb-3">
     <input class="form-check-input" type="checkbox" id="attivo" name="attivo" <?= ($data['attivo'] ?? 1) ? 'checked' : '' ?>>

--- a/includes/render_evento.php
+++ b/includes/render_evento.php
@@ -23,8 +23,9 @@ function render_evento(array $row): void {
     }
     echo '  </div>';
     if (!empty($row['tipo_evento'])) {
-        $color = htmlspecialchars($row['colore'] ?? '#71843f', ENT_QUOTES);
-        echo '  <span class="badge ms-2" style="background-color: ' . $color . '">' . htmlspecialchars($row['tipo_evento']) . '</span>';
+        $bg = htmlspecialchars($row['colore'] ?? '#71843f', ENT_QUOTES);
+        $txt = htmlspecialchars($row['colore_testo'] ?? '#ffffff', ENT_QUOTES);
+        echo '  <span class="badge ms-2" style="background-color: ' . $bg . ';color:' . $txt . '">' . htmlspecialchars($row['tipo_evento']) . '</span>';
     }
     echo '</div>';
 }

--- a/includes/render_evento_tipo.php
+++ b/includes/render_evento_tipo.php
@@ -5,7 +5,7 @@ function render_evento_tipo(array $row) {
     if (!$isActive) {
         $classes .= ' inactive';
     }
-    $search = strtolower(($row['tipo_evento'] ?? '') . ' ' . ($row['colore'] ?? ''));
+    $search = strtolower(($row['tipo_evento'] ?? '') . ' ' . ($row['colore'] ?? '') . ' ' . ($row['colore_testo'] ?? ''));
     $searchAttr = htmlspecialchars($search, ENT_QUOTES);
     $url = 'evento_tipo_dettaglio.php?id=' . (int)($row['id'] ?? 0);
     echo '<div class="' . $classes . '" data-search="' . $searchAttr . '" onclick="window.location.href=\'' . $url . '\'">';
@@ -13,8 +13,9 @@ function render_evento_tipo(array $row) {
     echo '    <div class="fw-semibold">' . htmlspecialchars($row['tipo_evento'] ?? '') . '</div>';
     echo '  </div>';
     echo '  <div class="ms-2 d-flex align-items-center">';
-    $color = htmlspecialchars($row['colore'] ?? '#000000');
-    echo '    <span class="rounded me-2" style="width:20px;height:20px;background:' . $color . ';border:1px solid #fff;"></span>';
+    $bg = htmlspecialchars($row['colore'] ?? '#000000');
+    $txt = htmlspecialchars($row['colore_testo'] ?? '#ffffff');
+    echo '    <span class="badge me-2" style="background:' . $bg . ';color:' . $txt . '">Aa</span>';
     echo $isActive ? '    <i class="bi bi-check-circle-fill text-success"></i>' : '    <i class="bi bi-x-circle-fill text-danger"></i>';
     echo '  </div>';
     echo '</div>';

--- a/js/turni.js
+++ b/js/turni.js
@@ -109,7 +109,8 @@ document.addEventListener('DOMContentLoaded', () => {
           const turno=document.createElement('div');
           turno.className='turno event';
           turno.style.background=ev.colore || '#6c757d';
-          turno.innerHTML=`<a href="eventi_dettaglio.php?id=${ev.id}" class="text-white text-decoration-none">${ev.titolo}</a>`;
+          const tCol=ev.colore_testo||'#ffffff';
+          turno.innerHTML=`<a href="eventi_dettaglio.php?id=${ev.id}" class="text-decoration-none" style="color:${tCol}">${ev.titolo}</a>`;
           info.cell.querySelector('.turni-container').appendChild(turno);
         }
         return;
@@ -128,9 +129,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const bar=document.createElement('div');
         bar.className='multi-event';
         bar.style.background=ev.colore || '#6c757d';
+        const tCol=ev.colore_testo||'#ffffff';
         bar.style.left=(startIdx/7*100)+'%';
         bar.style.width=(spanDays/7*100)+'%';
-        bar.innerHTML=`<a href="eventi_dettaglio.php?id=${ev.id}">${ev.titolo}</a>`;
+        bar.innerHTML=`<a href="eventi_dettaglio.php?id=${ev.id}" style="color:${tCol}">${ev.titolo}</a>`;
         rowEl.appendChild(bar);
         segStart.setDate(segEnd.getDate()+1);
       }

--- a/sql/add_colore_testo_to_eventi_tipi_eventi.sql
+++ b/sql/add_colore_testo_to_eventi_tipi_eventi.sql
@@ -1,0 +1,2 @@
+ALTER TABLE eventi_tipi_eventi
+  ADD COLUMN colore_testo VARCHAR(7) NOT NULL DEFAULT '#ffffff' AFTER colore;

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -537,6 +537,7 @@ CREATE TABLE `eventi_tipi_eventi` (
   `id` int(11) NOT NULL,
   `tipo_evento` varchar(100) NOT NULL,
   `colore` varchar(10) NOT NULL DEFAULT '#71843f',
+  `colore_testo` varchar(7) NOT NULL DEFAULT '#ffffff',
   `attivo` int(11) NOT NULL DEFAULT '1'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 


### PR DESCRIPTION
## Summary
- Support storing a text color for event types
- UI for selecting text color and displaying it with type badges
- Expose text color in event listings and calendar

## Testing
- `php -l evento_tipo_dettaglio.php includes/render_evento_tipo.php eventi.php includes/render_evento.php eventi_dettaglio.php ajax/turni_get.php`
- `node --check js/turni.js`


------
https://chatgpt.com/codex/tasks/task_e_68a02a393df883319d88026410dd0bc2