### PR TITLE
Refine calendar layout and event ordering

### DIFF
--- a/ajax/turni_get.php
+++ b/ajax/turni_get.php
@@ -23,7 +23,8 @@ $stmt = $conn->prepare('SELECT t.id, t.data, t.id_tipo,
     t.id_utenti_bambini, t.note,
     tp.descrizione, tp.colore_bg, tp.colore_testo
     FROM turni_calendario t JOIN turni_tipi tp ON t.id_tipo = tp.id
-    WHERE t.id_famiglia = ? AND t.data BETWEEN ? AND ? ORDER BY t.data');
+    WHERE t.id_famiglia = ? AND t.data BETWEEN ? AND ?
+    ORDER BY t.data, IF(t.ora_inizio = "00:00:00", tp.ora_inizio, t.ora_inizio)');
 $stmt->bind_param('iss', $idFamiglia, $start, $end);
 $stmt->execute();
 $res = $stmt->get_result();

--- a/turni.php
+++ b/turni.php
@@ -23,15 +23,17 @@ $needSync = !empty($unsyncedMonths);
 ?>
 <style>
   #calendarContainer .col {height: 100px; min-width:0; overflow:hidden;}
-  #calendarContainer .day-cell {display:flex; flex-direction:column; padding:0; padding-top:20px;}
-  #calendarContainer .turni-container {flex:1; display:flex; flex-direction:column;}
+  #calendarContainer .day-cell {display:flex; flex-direction:column; padding:0;}
+  #calendarContainer .date-label {position:absolute; top:0; left:0; z-index:2; font-size:.8rem; padding:2px;}
+  #calendarContainer .turni-container {flex:1; display:flex; flex-direction:column; margin-top:20px;}
+  #calendarContainer .week-row.multi-events .turni-container {margin-top:40px;}
   #calendarContainer .turno {flex:1; display:flex; align-items:center; justify-content:center; font-size:.8rem; position:relative; overflow:hidden;}
   #calendarContainer .turno.event a {color:inherit; text-decoration:none; width:100%; display:block; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
   #calendarContainer .turno .bambini {position:absolute; bottom:0; right:0; font-size:.6rem; padding:0 2px;}
   #pillContainer .pill.active {outline:2px solid #fff;}
   #calendarContainer .day-cell.multi-selected {outline:2px solid #0d6efd;}
   #calendarContainer .week-row {position:relative;}
-  #calendarContainer .multi-event {position:absolute; top:0; height:20px; display:flex; align-items:center; justify-content:center; font-size:.8rem; overflow:hidden; border-radius:4px;}
+  #calendarContainer .multi-event {position:absolute; top:20px; height:20px; display:flex; align-items:center; justify-content:center; font-size:.8rem; overflow:hidden; border-radius:4px;}
   #calendarContainer .multi-event a {color:inherit; text-decoration:none; width:100%; display:block; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 </style>
 <div id="shifter" class="d-flex flex-column min-vh-100 p-0">


### PR DESCRIPTION
## Summary
- Place day numbers at the top-left and keep multi-day event bars below them
- Sort shifts and single-day events by start time
- Order shift query by date and start time for consistent display

## Testing
- `php -l turni.php`
- `php -l ajax/turni_get.php`
- `node --check js/turni.js`


------
https://chatgpt.com/codex/tasks/task_e_68a02a9a3ab883319501c696058c8300