### PR TITLE
Gestione orari turni per sincronizzazione Google Calendar

### DIFF
--- a/ajax/turni_sync_google.php
+++ b/ajax/turni_sync_google.php
@@ -128,10 +128,18 @@ try {
     $timeZone = 'Europe/Rome';
     
     // Helper: normalizza "HH:MM" -> "HH:MM:00"
+    // Ritorna null se l'orario è vuoto o impostato a mezzanotte,
+    // così da poter usare il fallback sugli orari del tipo turno.
     $normTime = function($t) {
-        if (!$t) return null;
-        if (preg_match('/^\d{2}:\d{2}$/', $t)) return $t . ':00';
-        if (preg_match('/^\d{2}:\d{2}:\d{2}$/', $t)) return $t;
+        if (!$t || $t === '00:00' || $t === '00:00:00') {
+            return null;
+        }
+        if (preg_match('/^\\d{2}:\\d{2}$/', $t)) {
+            return $t . ':00';
+        }
+        if (preg_match('/^\\d{2}:\\d{2}:\\d{2}$/', $t)) {
+            return $t;
+        }
         return null; // formato non valido
     };
     


### PR DESCRIPTION
## Summary
- Considera l'orario specifico del turno, con fallback agli orari del tipo turno, quando viene creato l'evento su Google Calendar.

## Testing
- `php -l ajax/turni_sync_google.php`

------
https://chatgpt.com/codex/tasks/task_e_68a02b83b78c8331a959bf25eb24c388