### PR TITLE
Uniform turni types layout and ensure redirects to list

### DIFF
--- a/includes/render_turno_tipo.php
+++ b/includes/render_turno_tipo.php
@@ -1,0 +1,31 @@
+<?php
+function render_turno_tipo(array $row) {
+    $isActive = (int)($row['attivo'] ?? 0) === 1;
+    $classes = 'turno-tipo-card movement d-flex justify-content-between align-items-center text-white text-decoration-none';
+    if (!$isActive) {
+        $classes .= ' inactive';
+    }
+    $searchParts = [
+        $row['descrizione'] ?? '',
+        $row['ora_inizio'] ?? '',
+        $row['ora_fine'] ?? '',
+        $row['colore_bg'] ?? '',
+        $row['colore_testo'] ?? ''
+    ];
+    $search = strtolower(implode(' ', $searchParts));
+    $searchAttr = htmlspecialchars($search, ENT_QUOTES);
+    $url = 'turno_tipo_dettaglio.php?id=' . (int)($row['id'] ?? 0);
+    echo '<div class="' . $classes . '" data-search="' . $searchAttr . '" onclick="window.location.href=\'' . $url . '\'">';
+    echo '  <div class="flex-grow-1">';
+    echo '    <div class="fw-semibold">' . htmlspecialchars($row['descrizione'] ?? '') . '</div>';
+    echo '    <div class="small">' . htmlspecialchars(($row['ora_inizio'] ?? '') . ' - ' . ($row['ora_fine'] ?? '')) . '</div>';
+    echo '  </div>';
+    echo '  <div class="ms-2 d-flex align-items-center">';
+    $bg = htmlspecialchars($row['colore_bg'] ?? '#000000');
+    $txt = htmlspecialchars($row['colore_testo'] ?? '#ffffff');
+    echo '    <span class="badge me-2" style="background:' . $bg . ';color:' . $txt . '">Aa</span>';
+    echo $isActive ? '    <i class="bi bi-check-circle-fill text-success"></i>' : '    <i class="bi bi-x-circle-fill text-danger"></i>';
+    echo '  </div>';
+    echo '</div>';
+}
+?>

--- a/js/turni_tipi.js
+++ b/js/turni_tipi.js
@@ -1,58 +1,24 @@
 document.addEventListener('DOMContentLoaded', () => {
   const search = document.getElementById('search');
   const showInactive = document.getElementById('showInactive');
-  const rows = Array.from(document.querySelectorAll('.type-row'));
-  const modalEl = document.getElementById('typeModal');
-  const modal = new bootstrap.Modal(modalEl);
-  const form = document.getElementById('typeForm');
+  const cards = Array.from(document.querySelectorAll('.turno-tipo-card'));
 
   function filter() {
     const q = search.value.trim().toLowerCase();
-    rows.forEach(row => {
-      const text = row.dataset.search || '';
-      const isInactive = row.classList.contains('inactive');
+    cards.forEach(card => {
+      const text = card.dataset.search || '';
+      const isInactive = card.classList.contains('inactive');
       const match = text.includes(q);
       const visible = match && (!isInactive || showInactive.checked || q !== '');
-      row.style.display = visible ? '' : 'none';
+      if (visible) {
+        card.style.removeProperty('display');
+      } else {
+        card.style.setProperty('display', 'none', 'important');
+      }
     });
   }
 
   search.addEventListener('input', filter);
   showInactive.addEventListener('input', filter);
   filter();
-
-  function openModal(row) {
-    if (row) {
-      document.getElementById('typeId').value = row.dataset.id;
-      document.getElementById('descrizione').value = row.dataset.descrizione;
-      document.getElementById('ora_inizio').value = row.dataset.ora_inizio;
-      document.getElementById('ora_fine').value = row.dataset.ora_fine;
-      document.getElementById('colore_bg').value = row.dataset.colore_bg;
-      document.getElementById('colore_testo').value = row.dataset.colore_testo;
-      document.getElementById('attivo').checked = row.dataset.attivo === '1';
-    } else {
-      form.reset();
-      document.getElementById('typeId').value = '';
-      document.getElementById('ora_inizio').value = '';
-      document.getElementById('ora_fine').value = '';
-      document.getElementById('colore_bg').value = '#ffffff';
-      document.getElementById('colore_testo').value = '#000000';
-      document.getElementById('attivo').checked = true;
-    }
-    modal.show();
-  }
-
-  document.getElementById('addType').addEventListener('click', () => openModal(null));
-  rows.forEach(row => row.addEventListener('click', () => openModal(row)));
-
-  document.getElementById('saveType').addEventListener('click', () => {
-    const formData = new FormData(form);
-    fetch('ajax/turni_tipi_save.php', { method: 'POST', body: formData })
-      .then(r => r.json())
-      .then(res => {
-        if (res.success) {
-          location.reload();
-        }
-      });
-  });
 });

--- a/turni_tipi.php
+++ b/turni_tipi.php
@@ -1,17 +1,21 @@
 <?php include 'includes/session_check.php'; ?>
 <?php
-include 'includes/db.php';
+require_once 'includes/db.php';
+require_once 'includes/permissions.php';
+require_once 'includes/render_turno_tipo.php';
+if (!has_permission($conn, 'page:turni_tipi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
 include 'includes/header.php';
 
-$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
-
-$stmt = $conn->prepare("SELECT id, descrizione, ora_inizio, ora_fine, colore_bg, colore_testo, attivo FROM turni_tipi ORDER BY descrizione");
+$stmt = $conn->prepare('SELECT * FROM turni_tipi ORDER BY descrizione');
 $stmt->execute();
 $res = $stmt->get_result();
+$canInsert = has_permission($conn, 'table:turni_tipi', 'insert');
 ?>
 <div class="d-flex mb-3 justify-content-between">
-  <h4>Tipi turni</h4>
-  <button class="btn btn-outline-light btn-sm" id="addType">Aggiungi nuovo</button>
+  <h4>Tipi turno</h4>
+  <?php if ($canInsert): ?>
+  <a href="turno_tipo_dettaglio.php" class="btn btn-outline-light btn-sm">Aggiungi nuovo</a>
+  <?php endif; ?>
 </div>
 <div class="d-flex mb-3 align-items-center">
   <input type="text" id="search" class="form-control bg-dark text-white border-secondary me-2" placeholder="Cerca">
@@ -20,84 +24,10 @@ $res = $stmt->get_result();
     <label class="form-check-label" for="showInactive">Mostra non attivi</label>
   </div>
 </div>
-<table class="table table-dark table-hover" id="typesTable">
-  <tbody>
-    <?php while ($row = $res->fetch_assoc()): ?>
-    <?php
-      $search = strtolower($row['descrizione']);
-      $searchAttr = htmlspecialchars($search, ENT_QUOTES);
-      $descrizione = htmlspecialchars($row['descrizione']);
-      $coloreBg = htmlspecialchars($row['colore_bg']);
-      $coloreTesto = htmlspecialchars($row['colore_testo']);
-      $attivo = (int)$row['attivo'] === 1;
-      $class = $attivo ? '' : 'inactive';
-    ?>
-    <tr class="type-row <?php echo $class; ?>"
-        data-id="<?php echo (int)$row['id']; ?>"
-        data-descrizione="<?php echo htmlspecialchars($row['descrizione'], ENT_QUOTES); ?>"
-        data-ora_inizio="<?php echo htmlspecialchars($row['ora_inizio']); ?>"
-        data-ora_fine="<?php echo htmlspecialchars($row['ora_fine']); ?>"
-        data-colore_bg="<?php echo $coloreBg; ?>"
-        data-colore_testo="<?php echo $coloreTesto; ?>"
-        data-attivo="<?php echo $attivo ? 1 : 0; ?>"
-        data-search="<?php echo $searchAttr; ?>">
-      <td><?php echo $descrizione; ?></td>
-      <td><span class="badge" style="background:<?php echo $coloreBg; ?>;color:<?php echo $coloreTesto; ?>">Aa</span></td>
-      <td class="text-end">
-        <?php if ($attivo): ?>
-          <i class="bi bi-check-circle-fill text-success"></i>
-        <?php else: ?>
-          <i class="bi bi-x-circle-fill text-danger"></i>
-        <?php endif; ?>
-      </td>
-    </tr>
-    <?php endwhile; ?>
-  </tbody>
-</table>
-
-<div class="modal fade" id="typeModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content bg-dark text-white">
-      <div class="modal-header">
-        <h5 class="modal-title">Tipo turno</h5>
-        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <form id="typeForm">
-          <input type="hidden" name="id" id="typeId">
-          <div class="mb-3">
-            <label for="descrizione" class="form-label">Descrizione</label>
-            <input type="text" class="form-control bg-dark text-white border-secondary" name="descrizione" id="descrizione" required>
-          </div>
-          <div class="mb-3">
-            <label for="ora_inizio" class="form-label">Ora inizio</label>
-            <input type="time" class="form-control bg-dark text-white border-secondary" name="ora_inizio" id="ora_inizio" required>
-          </div>
-          <div class="mb-3">
-            <label for="ora_fine" class="form-label">Ora fine</label>
-            <input type="time" class="form-control bg-dark text-white border-secondary" name="ora_fine" id="ora_fine" required>
-          </div>
-          <div class="mb-3">
-            <label for="colore_bg" class="form-label">Colore sfondo</label>
-            <input type="color" class="form-control form-control-color" id="colore_bg" name="colore_bg" value="#ffffff" title="Scegli colore">
-          </div>
-          <div class="mb-3">
-            <label for="colore_testo" class="form-label">Colore testo</label>
-            <input type="color" class="form-control form-control-color" id="colore_testo" name="colore_testo" value="#000000" title="Scegli colore">
-          </div>
-          <div class="form-check form-switch mb-3">
-            <input class="form-check-input" type="checkbox" id="attivo" name="attivo">
-            <label class="form-check-label" for="attivo">Attivo</label>
-          </div>
-        </form>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Chiudi</button>
-        <button type="button" class="btn btn-primary" id="saveType">Salva</button>
-      </div>
-    </div>
-  </div>
+<div id="tipiList">
+<?php while ($row = $res->fetch_assoc()): ?>
+  <?php render_turno_tipo($row); ?>
+<?php endwhile; ?>
 </div>
-
 <script src="js/turni_tipi.js"></script>
 <?php include 'includes/footer.php'; ?>

--- a/turno_tipo_dettaglio.php
+++ b/turno_tipo_dettaglio.php
@@ -2,18 +2,20 @@
 <?php
 require_once 'includes/db.php';
 require_once 'includes/permissions.php';
-if (!has_permission($conn, 'page:eventi_tipi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+if (!has_permission($conn, 'page:turni_tipi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $data = [
     'id' => 0,
-    'tipo_evento' => '',
-    'colore' => '#71843f',
-    'colore_testo' => '#ffffff',
+    'descrizione' => '',
+    'ora_inizio' => '',
+    'ora_fine' => '',
+    'colore_bg' => '#ffffff',
+    'colore_testo' => '#000000',
     'attivo' => 1
 ];
 if ($id > 0) {
-    $stmt = $conn->prepare('SELECT * FROM eventi_tipi_eventi WHERE id=?');
+    $stmt = $conn->prepare('SELECT * FROM turni_tipi WHERE id=?');
     $stmt->bind_param('i', $id);
     $stmt->execute();
     $res = $stmt->get_result();
@@ -31,29 +33,31 @@ if ($id > 0) {
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
     if (isset($_POST['delete']) && $id > 0) {
-        $stmt = $conn->prepare('DELETE FROM eventi_tipi_eventi WHERE id=?');
+        $stmt = $conn->prepare('DELETE FROM turni_tipi WHERE id=?');
         $stmt->bind_param('i', $id);
         $stmt->execute();
         $stmt->close();
-        header('Location: eventi_tipi.php');
+        header('Location: turni_tipi.php');
         exit;
     }
-    $tipo = $_POST['tipo_evento'] ?? '';
-    $colore = $_POST['colore'] ?? '';
+    $descrizione = $_POST['descrizione'] ?? '';
+    $oraInizio = $_POST['ora_inizio'] ?? '';
+    $oraFine = $_POST['ora_fine'] ?? '';
+    $coloreBg = $_POST['colore_bg'] ?? '';
     $coloreTesto = $_POST['colore_testo'] ?? '';
     $attivo = isset($_POST['attivo']) ? 1 : 0;
     if ($id > 0) {
-        $stmt = $conn->prepare('UPDATE eventi_tipi_eventi SET tipo_evento=?, colore=?, colore_testo=?, attivo=? WHERE id=?');
-        $stmt->bind_param('sssii', $tipo, $colore, $coloreTesto, $attivo, $id);
+        $stmt = $conn->prepare('UPDATE turni_tipi SET descrizione=?, ora_inizio=?, ora_fine=?, colore_bg=?, colore_testo=?, attivo=? WHERE id=?');
+        $stmt->bind_param('ssssssi', $descrizione, $oraInizio, $oraFine, $coloreBg, $coloreTesto, $attivo, $id);
         $stmt->execute();
         $stmt->close();
     } else {
-        $stmt = $conn->prepare('INSERT INTO eventi_tipi_eventi (tipo_evento, colore, colore_testo, attivo) VALUES (?,?,?,?)');
-        $stmt->bind_param('sssi', $tipo, $colore, $coloreTesto, $attivo);
+        $stmt = $conn->prepare('INSERT INTO turni_tipi (descrizione, ora_inizio, ora_fine, colore_bg, colore_testo, attivo) VALUES (?,?,?,?,?,?)');
+        $stmt->bind_param('sssssi', $descrizione, $oraInizio, $oraFine, $coloreBg, $coloreTesto, $attivo);
         $stmt->execute();
         $stmt->close();
     }
-    header('Location: eventi_tipi.php');
+    header('Location: turni_tipi.php');
     exit;
 }
 
@@ -61,16 +65,24 @@ include 'includes/header.php';
 ?>
 <div class="container text-white">
   <a href="javascript:history.back()" class="btn btn-outline-light mb-3">&larr; Indietro</a>
-  <h4 class="mb-4"><?= $id > 0 ? 'Modifica tipo evento' : 'Nuovo tipo evento' ?></h4>
+  <h4 class="mb-4"><?= $id > 0 ? 'Modifica tipo turno' : 'Nuovo tipo turno' ?></h4>
 </div>
 <form method="post" class="bg-dark text-white p-3 rounded">
   <div class="mb-3">
-    <label class="form-label">Tipo evento</label>
-    <input type="text" name="tipo_evento" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['tipo_evento']) ?>" required>
+    <label class="form-label">Descrizione</label>
+    <input type="text" name="descrizione" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['descrizione']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Ora inizio</label>
+    <input type="time" name="ora_inizio" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['ora_inizio']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Ora fine</label>
+    <input type="time" name="ora_fine" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['ora_fine']) ?>" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Colore sfondo</label>
-    <input type="color" name="colore" class="form-control form-control-color" value="<?= htmlspecialchars($data['colore']) ?>" title="Scegli colore">
+    <input type="color" name="colore_bg" class="form-control form-control-color" value="<?= htmlspecialchars($data['colore_bg']) ?>" title="Scegli colore">
   </div>
   <div class="mb-3">
     <label class="form-label">Colore testo</label>


### PR DESCRIPTION
## Summary
- Rework `turni_tipi.php` to match `eventi_tipi.php` layout via card-based list and search filter
- Add `turno_tipo_dettaglio.php` for managing turni types and redirect to list after saving or deleting
- Fix `evento_tipo_dettaglio.php` redirect handling and streamline `turni_tipi` JS filter

## Testing
- `php -l includes/render_turno_tipo.php turni_tipi.php turno_tipo_dettaglio.php evento_tipo_dettaglio.php`


------
https://chatgpt.com/codex/tasks/task_e_68a02ce68ec48331871ccb5825adb679