### PR TITLE
Limit turn type background colors to predefined palette

### DIFF
--- a/ajax/turni_tipi_save.php
+++ b/ajax/turni_tipi_save.php
@@ -7,7 +7,11 @@ $id = (int)($_POST['id'] ?? 0);
 $descrizione = trim($_POST['descrizione'] ?? '');
 $oraInizio = $_POST['ora_inizio'] ?? '00:00';
 $oraFine = $_POST['ora_fine'] ?? '00:00';
-$coloreBg = $_POST['colore_bg'] ?? '#ffffff';
+$allowedColors = ['#a4bdfc', '#7ae7bf', '#dbadff', '#ff887c', '#fbd75b', '#ffb878', '#46d6db', '#e1e1e1', '#5484ed', '#51b749'];
+$coloreBg = $_POST['colore_bg'] ?? $allowedColors[0];
+if (!in_array($coloreBg, $allowedColors, true)) {
+    $coloreBg = $allowedColors[0];
+}
 $coloreTesto = $_POST['colore_testo'] ?? '#000000';
 $attivo = isset($_POST['attivo']) ? 1 : 0;
 

--- a/turno_tipo_dettaglio.php
+++ b/turno_tipo_dettaglio.php
@@ -5,12 +5,13 @@ require_once 'includes/permissions.php';
 if (!has_permission($conn, 'page:turni_tipi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$allowedColors = ['#a4bdfc', '#7ae7bf', '#dbadff', '#ff887c', '#fbd75b', '#ffb878', '#46d6db', '#e1e1e1', '#5484ed', '#51b749'];
 $data = [
     'id' => 0,
     'descrizione' => '',
     'ora_inizio' => '',
     'ora_fine' => '',
-    'colore_bg' => '#ffffff',
+    'colore_bg' => $allowedColors[0],
     'colore_testo' => '#000000',
     'attivo' => 1
 ];
@@ -44,6 +45,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $oraInizio = $_POST['ora_inizio'] ?? '';
     $oraFine = $_POST['ora_fine'] ?? '';
     $coloreBg = $_POST['colore_bg'] ?? '';
+    if (!in_array($coloreBg, $allowedColors, true)) {
+        $coloreBg = $allowedColors[0];
+    }
     $coloreTesto = $_POST['colore_testo'] ?? '';
     $attivo = isset($_POST['attivo']) ? 1 : 0;
     if ($id > 0) {
@@ -82,7 +86,11 @@ include 'includes/header.php';
   </div>
   <div class="mb-3">
     <label class="form-label">Colore sfondo</label>
-    <input type="color" name="colore_bg" class="form-control form-control-color" value="<?= htmlspecialchars($data['colore_bg']) ?>" title="Scegli colore">
+    <select name="colore_bg" class="form-select">
+      <?php foreach ($allowedColors as $color): ?>
+        <option value="<?= $color ?>" style="background-color: <?= $color ?>; color: #000;" <?= $data['colore_bg'] === $color ? 'selected' : '' ?>><?= $color ?></option>
+      <?php endforeach; ?>
+    </select>
   </div>
   <div class="mb-3">
     <label class="form-label">Colore testo</label>


### PR DESCRIPTION
## Summary
- Restrict shift type background colors to a fixed palette and enforce server-side validation.
- Ensure AJAX save endpoint validates background colors against the allowed palette.

## Testing
- `php -l turno_tipo_dettaglio.php`
- `php -l ajax/turni_tipi_save.php`


------
https://chatgpt.com/codex/tasks/task_e_68a03b8aa5488331b9c7cc533c6fb3dc