### PR TITLE
Gestisci disponibile_per_soso per gli utenti

### DIFF
--- a/gestione_utenti_dettaglio.php
+++ b/gestione_utenti_dettaglio.php
@@ -10,7 +10,7 @@ $table = 'utenti';
 $columns = $config[$table]['columns'];
 $primaryKey = $config[$table]['primary_key'];
 $displayColumns = array_values(array_filter($columns, fn($c) => $c !== $primaryKey));
-$booleanColumns = ['attivo'];
+$booleanColumns = ['attivo','disponibile_per_soso'];
 $lookups = [];
 foreach ($displayColumns as $col) {
     if (isset($foreignMap[$col])) {

--- a/includes/table_config.php
+++ b/includes/table_config.php
@@ -38,7 +38,7 @@ return [
     ],
     'utenti' => [
         'primary_key' => 'id',
-        'columns' => ['id','username','nome','cognome','soprannome','email','id_famiglia_attuale','id_famiglia_gestione','id_tema','attivo']
+        'columns' => ['id','username','nome','cognome','soprannome','email','id_famiglia_attuale','id_famiglia_gestione','id_tema','attivo','disponibile_per_soso']
     ],
     'utenti2famiglie' => [
         'primary_key' => 'id_u2f',


### PR DESCRIPTION
## Summary
- Consenti la gestione del flag `disponibile_per_soso` nella pagina di dettaglio utente
- Configura il campo `disponibile_per_soso` nel mapping della tabella `utenti`

## Testing
- `php -l includes/table_config.php`
- `php -l gestione_utenti_dettaglio.php`


------
https://chatgpt.com/codex/tasks/task_e_68a03e9dba5c833184c482e53882bbe2