### PR TITLE
Enable creating events from shift calendar

### DIFF
--- a/js/eventi.js
+++ b/js/eventi.js
@@ -26,10 +26,13 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
-function openEventoModal(){
+function openEventoModal(date){
   const form = document.getElementById('eventoForm');
   if(form){
     form.reset();
+    if(date){
+      form.querySelector('[name="data_evento"]').value = date;
+    }
     new bootstrap.Modal(document.getElementById('eventoModal')).show();
   }
 }

--- a/js/turni.js
+++ b/js/turni.js
@@ -185,12 +185,16 @@ document.addEventListener('DOMContentLoaded', () => {
   calendarContainer.addEventListener('click', e=>{
     if(e.target.closest('a')) return;
     const turnoEl = e.target.closest('.turno');
-    if(!multiMode && selectedType===null && turnoEl && !turnoEl.classList.contains('event')){
-      openEditModal(turnoEl);
+    const cell = e.target.closest('.day-cell');
+    if(!multiMode && selectedType===null){
+      if(turnoEl && !turnoEl.classList.contains('event')){
+        openEditModal(turnoEl);
+      }else if(cell && !turnoEl && typeof openEventoModal === 'function'){
+        openEventoModal(cell.dataset.date);
+      }
       return;
     }
     if(multiMode) return;
-    const cell=e.target.closest('.day-cell');
     if(!cell || selectedType===null) return;
     const date=cell.dataset.date;
     const payload = selectedType==='delete' ? {date} : {date,id_tipo:selectedType};


### PR DESCRIPTION
## Summary
- allow opening event creation modal from empty calendar slots in `turni.php`
- support pre-filling event date via `openEventoModal`
- add event creation modal and supporting data to `turni.php`

## Testing
- `php -l turni.php`
- `node --check js/turni.js`
- `node --check js/eventi.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0423afd1c8331a11623d3f7d468be