### PR TITLE
Add event deletion with confirmation modal

### DIFF
--- a/ajax/delete_evento.php
+++ b/ajax/delete_evento.php
@@ -1,0 +1,56 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+include '../includes/permissions.php';
+
+if (!has_permission($conn, 'table:eventi', 'delete')) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Accesso negato']);
+    exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+if (!$id) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$conn->begin_transaction();
+try {
+    $stmt = $conn->prepare('DELETE FROM eventi_eventi2luogo WHERE id_evento = ?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $stmt->close();
+
+    $stmt = $conn->prepare('DELETE FROM eventi_eventi2invitati WHERE id_evento = ?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $stmt->close();
+
+    $stmt = $conn->prepare('DELETE FROM eventi_eventi2cibo WHERE id_evento = ?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $stmt->close();
+
+    $stmt = $conn->prepare('DELETE FROM eventi_eventi2famiglie WHERE id_evento = ?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $stmt->close();
+
+    $stmt = $conn->prepare('DELETE FROM eventi_eventi2salvadanai_etichette WHERE id_evento = ?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $stmt->close();
+
+    $stmt = $conn->prepare('DELETE FROM eventi WHERE id = ?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $stmt->close();
+
+    $conn->commit();
+    echo json_encode(['success' => true]);
+} catch (Exception $e) {
+    $conn->rollback();
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}

--- a/eventi_dettaglio.php
+++ b/eventi_dettaglio.php
@@ -257,15 +257,16 @@ include 'includes/header.php';
       </li>
     <?php endforeach; ?>
   </ul>
-  <?php if (count($salvEt) > 3): ?>
-    <div class="text-center mt-3">
-      <button id="toggleSe" class="btn btn-outline-light btn-sm">Mostra tutti</button>
-    </div>
-  <?php endif; ?>
-</div>
+    <?php if (count($salvEt) > 3): ?>
+      <div class="text-center mt-3">
+        <button id="toggleSe" class="btn btn-outline-light btn-sm">Mostra tutti</button>
+      </div>
+    <?php endif; ?>
+    <button type="button" class="btn btn-danger w-100 mt-4" id="deleteEventoBtn" data-id="<?= (int)$id ?>">Elimina</button>
+  </div>
 
-<?php if ($canUpdate): ?>
-<div class="modal fade" id="eventoModal" tabindex="-1">
+  <?php if ($canUpdate): ?>
+  <div class="modal fade" id="eventoModal" tabindex="-1">
   <div class="modal-dialog">
     <form class="modal-content bg-dark text-white" id="eventoForm">
       <div class="modal-header">
@@ -610,6 +611,23 @@ include 'includes/header.php';
         <button type="submit" class="btn btn-primary w-100">Aggiungi</button>
       </div>
     </form>
+  </div>
+</div>
+
+<!-- Modal elimina evento -->
+<div class="modal fade" id="deleteEventoModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content bg-dark text-white">
+      <div class="modal-header">
+        <h5 class="modal-title">Conferma eliminazione</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">Sei sicuro di voler eliminare questo evento?</div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+        <button type="button" class="btn btn-danger" id="confirmDeleteEventoBtn">Elimina</button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -195,18 +195,34 @@ document.addEventListener('DOMContentLoaded', () => {
     new bootstrap.Modal(document.getElementById('eventoModal')).show();
   });
 
-  document.getElementById('eventoForm')?.addEventListener('submit', function(e){
-    e.preventDefault();
-    const fd = new FormData(this);
-    fetch('ajax/update_evento.php', {method:'POST', body:fd})
-      .then(r=>r.json())
-      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
-  });
+    document.getElementById('eventoForm')?.addEventListener('submit', function(e){
+      e.preventDefault();
+      const fd = new FormData(this);
+      fetch('ajax/update_evento.php', {method:'POST', body:fd})
+        .then(r=>r.json())
+        .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+    });
 
-  document.getElementById('addRuleBtn')?.addEventListener('click', function(){
-    if(!confirm('Salvare regola per questo evento?')) return;
-    const fd = new FormData();
-    fd.append('id_evento', this.dataset.id);
+    const deleteEventoBtn = document.getElementById('deleteEventoBtn');
+    const deleteEventoModalEl = document.getElementById('deleteEventoModal');
+    const confirmDeleteEventoBtn = document.getElementById('confirmDeleteEventoBtn');
+    let deleteEventoModal;
+    deleteEventoBtn?.addEventListener('click', () => {
+      if(!deleteEventoModal) deleteEventoModal = new bootstrap.Modal(deleteEventoModalEl);
+      deleteEventoModal.show();
+    });
+    confirmDeleteEventoBtn?.addEventListener('click', () => {
+      const fd = new FormData();
+      fd.append('id', deleteEventoBtn.dataset.id);
+      fetch('ajax/delete_evento.php', {method:'POST', body:fd})
+        .then(r=>r.json())
+        .then(res=>{ if(res.success) window.location.href = 'eventi.php'; else alert(res.error||'Errore'); });
+    });
+
+    document.getElementById('addRuleBtn')?.addEventListener('click', function(){
+      if(!confirm('Salvare regola per questo evento?')) return;
+      const fd = new FormData();
+      fd.append('id_evento', this.dataset.id);
     fetch('ajax/add_evento_google_rule.php', {method:'POST', body:fd})
       .then(r=>r.json())
       .then(res=>{


### PR DESCRIPTION
## Summary
- allow deleting events from detail page via new button
- add confirmation modal and backend endpoint for event removal

## Testing
- `php -l eventi_dettaglio.php`
- `php -l ajax/delete_evento.php`
- `node --check js/eventi_dettaglio.js`


------
https://chatgpt.com/codex/tasks/task_e_68a042d63e7c8331a9d8f4dd83487063