### PR TITLE
Rendi facoltativi gli orari nei tipi di turno

### DIFF
--- a/ajax/turni_tipi_save.php
+++ b/ajax/turni_tipi_save.php
@@ -5,8 +5,10 @@ header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
 $descrizione = trim($_POST['descrizione'] ?? '');
-$oraInizio = $_POST['ora_inizio'] ?? '00:00';
-$oraFine = $_POST['ora_fine'] ?? '00:00';
+$oraInizio = trim($_POST['ora_inizio'] ?? '');
+$oraInizio = $oraInizio !== '' ? $oraInizio : null;
+$oraFine = trim($_POST['ora_fine'] ?? '');
+$oraFine = $oraFine !== '' ? $oraFine : null;
 $allowedColors = ['#a4bdfc', '#7ae7bf', '#dbadff', '#ff887c', '#fbd75b', '#ffb878', '#46d6db', '#e1e1e1', '#5484ed', '#51b749'];
 $coloreBg = $_POST['colore_bg'] ?? $allowedColors[0];
 if (!in_array($coloreBg, $allowedColors, true)) {

--- a/includes/render_turno_tipo.php
+++ b/includes/render_turno_tipo.php
@@ -18,7 +18,12 @@ function render_turno_tipo(array $row) {
     echo '<div class="' . $classes . '" data-search="' . $searchAttr . '" onclick="window.location.href=\'' . $url . '\'">';
     echo '  <div class="flex-grow-1">';
     echo '    <div class="fw-semibold">' . htmlspecialchars($row['descrizione'] ?? '') . '</div>';
-    echo '    <div class="small">' . htmlspecialchars(($row['ora_inizio'] ?? '') . ' - ' . ($row['ora_fine'] ?? '')) . '</div>';
+    $start = $row['ora_inizio'] ?? '';
+    $end = $row['ora_fine'] ?? '';
+    $timeText = trim($start . ' - ' . $end, ' -');
+    if ($timeText !== '') {
+        echo '    <div class="small">' . htmlspecialchars($timeText) . '</div>';
+    }
     echo '  </div>';
     echo '  <div class="ms-2 d-flex align-items-center">';
     $bg = htmlspecialchars($row['colore_bg'] ?? '#000000');

--- a/sql/allow_null_ora_inizio_fine_to_turni_tipi.sql
+++ b/sql/allow_null_ora_inizio_fine_to_turni_tipi.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `turni_tipi`
+  MODIFY `ora_inizio` time DEFAULT NULL,
+  MODIFY `ora_fine` time DEFAULT NULL;
+

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -1018,8 +1018,8 @@ CREATE TABLE `turni_calendario` (
 CREATE TABLE `turni_tipi` (
   `id` int(11) NOT NULL,
   `descrizione` varchar(100) NOT NULL,
-  `ora_inizio` time NOT NULL,
-  `ora_fine` time NOT NULL,
+  `ora_inizio` time DEFAULT NULL,
+  `ora_fine` time DEFAULT NULL,
   `colore_bg` varchar(7) NOT NULL,
   `colore_testo` varchar(7) NOT NULL DEFAULT '#000000',
   `attivo` tinyint(1) NOT NULL DEFAULT '1'

--- a/sql/turni.sql
+++ b/sql/turni.sql
@@ -1,6 +1,8 @@
 CREATE TABLE turni_tipi (
     id INT AUTO_INCREMENT PRIMARY KEY,
     descrizione VARCHAR(100) NOT NULL,
+    ora_inizio TIME DEFAULT NULL,
+    ora_fine TIME DEFAULT NULL,
     colore_bg VARCHAR(7) NOT NULL,
     colore_testo VARCHAR(7) NOT NULL DEFAULT '#000000',
     attivo TINYINT(1) NOT NULL DEFAULT 1

--- a/turno_tipo_dettaglio.php
+++ b/turno_tipo_dettaglio.php
@@ -42,8 +42,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit;
     }
     $descrizione = $_POST['descrizione'] ?? '';
-    $oraInizio = $_POST['ora_inizio'] ?? '';
-    $oraFine = $_POST['ora_fine'] ?? '';
+    $oraInizio = trim($_POST['ora_inizio'] ?? '');
+    $oraInizio = $oraInizio !== '' ? $oraInizio : null;
+    $oraFine = trim($_POST['ora_fine'] ?? '');
+    $oraFine = $oraFine !== '' ? $oraFine : null;
     $coloreBg = $_POST['colore_bg'] ?? '';
     if (!in_array($coloreBg, $allowedColors, true)) {
         $coloreBg = $allowedColors[0];
@@ -78,11 +80,11 @@ include 'includes/header.php';
   </div>
   <div class="mb-3">
     <label class="form-label">Ora inizio</label>
-    <input type="time" name="ora_inizio" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['ora_inizio']) ?>" required>
+    <input type="time" name="ora_inizio" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['ora_inizio'] ?? '') ?>">
   </div>
   <div class="mb-3">
     <label class="form-label">Ora fine</label>
-    <input type="time" name="ora_fine" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['ora_fine']) ?>" required>
+    <input type="time" name="ora_fine" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['ora_fine'] ?? '') ?>">
   </div>
   <div class="mb-3">
     <label class="form-label">Colore sfondo</label>


### PR DESCRIPTION
## Summary
- Permetti di salvare i tipi di turno senza specificare ora iniziale e finale
- Mostra gli orari del tipo turno solo se presenti
- Aggiorna lo schema e aggiunge script SQL per consentire valori NULL

## Testing
- `php -l turno_tipo_dettaglio.php`
- `php -l ajax/turni_tipi_save.php`
- `php -l includes/render_turno_tipo.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0449aeb6c8331a60afe1c41e552e0