### PR TITLE
Add loading modal for Google sync

### DIFF
--- a/js/turni.js
+++ b/js/turni.js
@@ -9,6 +9,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const editModalEl = document.getElementById('turnoModal');
   const editModal = editModalEl ? new bootstrap.Modal(editModalEl) : null;
   const editForm = document.getElementById('turnoForm');
+  const loadingModalEl = document.getElementById('loadingModal');
+  const loadingModal = loadingModalEl ? new bootstrap.Modal(loadingModalEl) : null;
   let firstRender = true;
 
   function loadTurni(year, month){
@@ -278,6 +280,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('nextMonth').addEventListener('click', ()=>{current.setMonth(current.getMonth()+1);loadTurni(current.getFullYear(),current.getMonth());});
 
   document.getElementById('btnGoogle').addEventListener('click', ()=>{
+    loadingModal && loadingModal.show();
     fetch('ajax/turni_sync_google.php',{
       method:'POST',
       headers:{'Content-Type':'application/json'},
@@ -285,7 +288,8 @@ document.addEventListener('DOMContentLoaded', () => {
     })
     .then(r=>r.json())
     .then(res=>alert(res.message||'Operazione completata'))
-    .catch(()=>alert('Errore durante la sincronizzazione'));
+    .catch(()=>alert('Errore durante la sincronizzazione'))
+    .finally(()=>{ loadingModal && loadingModal.hide(); });
   });
 
   loadTurni(current.getFullYear(), current.getMonth());

--- a/turni.php
+++ b/turni.php
@@ -187,9 +187,21 @@ $needSync = !empty($unsyncedMonths);
         <button type="submit" class="btn btn-primary w-100">Salva</button>
       </div>
     </form>
-  </div>
+</div>
 </div>
 <?php endif; ?>
+<div class="modal fade" id="loadingModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content bg-dark text-white">
+      <div class="modal-body text-center">
+        <div class="spinner-border text-light" role="status">
+          <span class="visually-hidden">Caricamento...</span>
+        </div>
+        <div class="mt-2">Sincronizzazione in corso...</div>
+      </div>
+    </div>
+  </div>
+</div>
 <script>
   const turniTipi = <?= json_encode($tipi) ?>;
 </script>


### PR DESCRIPTION
## Summary
- Add Bootstrap modal to show loading status during Google Calendar synchronization
- Use JavaScript to display and hide modal around sync fetch request

## Testing
- `php -l turni.php`
- `node --check js/turni.js`


------
https://chatgpt.com/codex/tasks/task_e_68a04822ea888331b918636e50f34bb3