### PR TITLE
Fix extra description modal when apostrophes are present

### DIFF
--- a/dettaglio.php
+++ b/dettaglio.php
@@ -199,7 +199,7 @@ include 'includes/header.php';
       <span>Descrizione Extra</span>
       <div class="ms-auto d-flex align-items-center">
         <span class="text-end"><?= htmlspecialchars($movimento['descrizione_extra']) ?></span>
-        <i class="bi bi-pencil ms-2" onclick="openModal('descrizione_extra', '<?= htmlspecialchars($movimento['descrizione_extra'], ENT_QUOTES) ?>')"></i>
+        <i class="bi bi-pencil ms-2" onclick="openModal('descrizione_extra', <?= htmlspecialchars(json_encode($movimento['descrizione_extra'] ?? ''), ENT_QUOTES) ?>)"></i>
       </div>
     </li>
 
@@ -208,7 +208,7 @@ include 'includes/header.php';
       <span>Note</span>
       <div class="ms-auto d-flex align-items-center">
         <span class="text-end"><?= htmlspecialchars($movimento['note']) ?></span>
-        <i class="bi bi-pencil ms-2" onclick="openModal('note', '<?= htmlspecialchars($movimento['note'], ENT_QUOTES) ?>')"></i>
+        <i class="bi bi-pencil ms-2" onclick="openModal('note', <?= htmlspecialchars(json_encode($movimento['note'] ?? ''), ENT_QUOTES) ?>)"></i>
       </div>
     </li>
 


### PR DESCRIPTION
## Summary
- Encode modal fields with `json_encode` and escape for HTML to handle apostrophes in extra description and notes

## Testing
- `php -l dettaglio.php`


------
https://chatgpt.com/codex/tasks/task_e_68a04a5adc008331bd00645cff46d4b1