### PR TITLE
Log event data for Google Calendar sync

### DIFF
--- a/includes/table_config.php
+++ b/includes/table_config.php
@@ -50,7 +50,7 @@ return [
     ],
     'turni_sync_google_log' => [
         'primary_key' => 'id',
-        'columns' => ['id','id_turno','id_evento','azione','esito','messaggio','data_creazione']
+        'columns' => ['id','id_turno','id_evento','azione','esito','messaggio','dati_evento','data_creazione']
     ]
 ];
 ?>

--- a/sql/add_turni_sync_google_log.sql
+++ b/sql/add_turni_sync_google_log.sql
@@ -5,6 +5,7 @@ CREATE TABLE turni_sync_google_log (
     azione VARCHAR(50) NOT NULL,
     esito ENUM('success','error') NOT NULL,
     messaggio TEXT,
+    dati_evento TEXT,
     data_creazione DATETIME DEFAULT CURRENT_TIMESTAMP,
     INDEX idx_turno (id_turno),
     INDEX idx_evento (id_evento)

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -1038,6 +1038,7 @@ CREATE TABLE `turni_sync_google_log` (
   `azione` varchar(50) NOT NULL,
   `esito` enum('success','error') NOT NULL,
   `messaggio` text,
+  `dati_evento` text,
   `data_creazione` datetime DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 


### PR DESCRIPTION
## Summary
- Extend log_sync to store dati_evento in turni_sync_google_log
- Save JSON payload of events sent to Google Calendar for turni and eventi
- Expose new dati_evento column in table configuration and SQL schema

## Testing
- `php -l ajax/turni_sync_google.php`
- `php -l includes/table_config.php`


------
https://chatgpt.com/codex/tasks/task_e_68a04b375b9c83319d8ada679fc982db