### PR TITLE
Open event modal from turni calendar cells

### DIFF
--- a/js/turni.js
+++ b/js/turni.js
@@ -195,7 +195,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if(multiMode) return;
     const cell=e.target.closest('.day-cell');
-    if(!cell || selectedType===null) return;
+    if(!cell) return;
+    if(selectedType===null){
+      if(typeof openEventoModal==='function'){
+        openEventoModal(cell.dataset.date);
+      }
+      return;
+    }
     const date=cell.dataset.date;
     const payload = selectedType==='delete' ? {date} : {date,id_tipo:selectedType};
     fetch('ajax/turni_update.php',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)})


### PR DESCRIPTION
## Summary
- allow clicking a day cell with no turni selection to open the new event modal

## Testing
- `node --check js/turni.js`


------
https://chatgpt.com/codex/tasks/task_e_68a04eef18c083319cd4037b934809a4