### PR TITLE
Add option to hide event label entries from finances

### DIFF
--- a/ajax/toggle_e2o_finanze.php
+++ b/ajax/toggle_e2o_finanze.php
@@ -1,0 +1,17 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id = intval($_POST['id_e2o'] ?? 0);
+$escludi = intval($_POST['escludi'] ?? 0);
+if (!$id) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+$stmt = $conn->prepare('UPDATE bilancio_etichette2operazioni SET escludi_da_finanze_evento = ? WHERE id_e2o = ?');
+$stmt->bind_param('ii', $escludi, $id);
+$ok = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $ok]);

--- a/etichetta.php
+++ b/etichetta.php
@@ -57,21 +57,21 @@ $sqlM = "SELECT DATE_FORMAT(data_operazione,'%Y-%m') AS ym, DATE_FORMAT(data_ope
                    (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                     WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette
+                     WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut' AND eo.escludi_da_finanze_evento = 0) AS etichette
             FROM movimenti_revolut bm
             UNION ALL
             SELECT be.data_operazione,
                    (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                     WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette
+                     WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate' AND eo.escludi_da_finanze_evento = 0) AS etichette
             FROM bilancio_entrate be
             UNION ALL
             SELECT bu.data_operazione,
                    (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                     WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette
+                     WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite' AND eo.escludi_da_finanze_evento = 0) AS etichette
             FROM bilancio_uscite bu
           ) t
           WHERE FIND_IN_SET(?, etichette)
@@ -90,25 +90,25 @@ if ($mese !== '') {
     $sqlTot = "SELECT SUM(CASE WHEN amount>=0 THEN amount ELSE 0 END) AS entrate,
                         SUM(CASE WHEN amount<0 THEN amount ELSE 0 END) AS uscite
                  FROM (
-                    SELECT amount, bm.started_date as data_operazione, 
+                    SELECT amount, bm.started_date as data_operazione,
                            (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
                               FROM bilancio_etichette2operazioni eo
                               JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                             WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette
+                             WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut' AND eo.escludi_da_finanze_evento = 0) AS etichette
                     FROM movimenti_revolut bm
                     UNION ALL
                     SELECT importo AS amount, data_operazione,
                            (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
                               FROM bilancio_etichette2operazioni eo
                               JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                             WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette
+                             WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate' AND eo.escludi_da_finanze_evento = 0) AS etichette
                     FROM bilancio_entrate be
                     UNION ALL
                     SELECT -importo AS amount, data_operazione,
                            (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
                               FROM bilancio_etichette2operazioni eo
                               JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                             WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette
+                             WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite' AND eo.escludi_da_finanze_evento = 0) AS etichette
                     FROM bilancio_uscite bu
                  ) t
                  WHERE FIND_IN_SET(?, etichette) AND DATE_FORMAT(data_operazione,'%Y-%m')=?";
@@ -118,25 +118,25 @@ if ($mese !== '') {
     $sqlTot = "SELECT SUM(CASE WHEN amount>=0 THEN amount ELSE 0 END) AS entrate,
                         SUM(CASE WHEN amount<0 THEN amount ELSE 0 END) AS uscite
                  FROM (
-                    SELECT amount, bm.started_date as data_operazione, 
+                    SELECT amount, bm.started_date as data_operazione,
                            (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
                               FROM bilancio_etichette2operazioni eo
                               JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                             WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette
+                             WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut' AND eo.escludi_da_finanze_evento = 0) AS etichette
                     FROM movimenti_revolut bm
                     UNION ALL
                     SELECT importo AS amount, data_operazione,
                            (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
                               FROM bilancio_etichette2operazioni eo
                               JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                             WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette
+                             WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate' AND eo.escludi_da_finanze_evento = 0) AS etichette
                     FROM bilancio_entrate be
                     UNION ALL
                     SELECT -importo AS amount, data_operazione,
                            (SELECT GROUP_CONCAT(e.id_etichetta SEPARATOR ',')
                               FROM bilancio_etichette2operazioni eo
                               JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                             WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette
+                             WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite' AND eo.escludi_da_finanze_evento = 0) AS etichette
                     FROM bilancio_uscite bu
                  ) t
                  WHERE FIND_IN_SET(?, etichette)";
@@ -156,7 +156,7 @@ $stmtTot->close();
                          (SELECT GROUP_CONCAT(e.descrizione SEPARATOR ',')
                             FROM bilancio_etichette2operazioni eo
                             JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                           WHERE eo.id_tabella = v.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette,
+                           WHERE eo.id_tabella = v.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut' AND eo.escludi_da_finanze_evento = 0) AS etichette,
                          id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella
                   FROM v_movimenti_revolut v
                   UNION ALL
@@ -165,7 +165,7 @@ $stmtTot->close();
                          (SELECT GROUP_CONCAT(e.descrizione SEPARATOR ',')
                             FROM bilancio_etichette2operazioni eo
                             JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                           WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
+                           WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate' AND eo.escludi_da_finanze_evento = 0) AS etichette,
                          be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella
                   FROM bilancio_entrate be
                   UNION ALL
@@ -174,11 +174,11 @@ $stmtTot->close();
                          (SELECT GROUP_CONCAT(e.descrizione SEPARATOR ',')
                             FROM bilancio_etichette2operazioni eo
                             JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
-                           WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
+                           WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite' AND eo.escludi_da_finanze_evento = 0) AS etichette,
                          bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella
                   FROM bilancio_uscite bu
              ) m
-             JOIN bilancio_etichette2operazioni e2o ON e2o.id_tabella = m.id AND e2o.tabella_operazione = m.tabella
+             JOIN bilancio_etichette2operazioni e2o ON e2o.id_tabella = m.id AND e2o.tabella_operazione = m.tabella AND e2o.escludi_da_finanze_evento = 0
              JOIN bilancio_etichette e ON e.id_etichetta = e2o.id_etichetta
              WHERE e.id_etichetta = ?";
   if ($mese !== '') {

--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -223,7 +223,7 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(res=>{ if(res.success) window.location.href = 'eventi.php'; else alert(res.error||'Errore'); });
     });
 
-    document.getElementById('addRuleBtn')?.addEventListener('click', function(){
+  document.getElementById('addRuleBtn')?.addEventListener('click', function(){
       if(!confirm('Salvare regola per questo evento?')) return;
       const fd = new FormData();
       fd.append('id_evento', this.dataset.id);
@@ -237,5 +237,18 @@ document.addEventListener('DOMContentLoaded', () => {
           alert(res.error||'Errore');
         }
       });
+  });
+
+  document.querySelectorAll('.toggle-finanze').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.dataset.id;
+      const escludi = btn.dataset.escludi === '1' ? 0 : 1;
+      const fd = new FormData();
+      fd.append('id_e2o', id);
+      fd.append('escludi', escludi);
+      fetch('ajax/toggle_e2o_finanze.php', {method:'POST', body:fd})
+        .then(r=>r.json())
+        .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+    });
   });
 });

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -150,7 +150,8 @@ CREATE TABLE `bilancio_etichette2operazioni` (
   `descrizione_extra` varchar(250) DEFAULT NULL,
   `importo` decimal(11,2) DEFAULT NULL,
   `dividere_rimborsare` varchar(20) NOT NULL DEFAULT 'dividere',
-  `allegato` varchar(100) DEFAULT NULL
+  `allegato` varchar(100) DEFAULT NULL,
+  `escludi_da_finanze_evento` int(11) NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `escludi_da_finanze_evento` column to label-operation table in SQL structure
- Allow toggling inclusion of event label operations in finances listing
- Filter label views to skip excluded operations

## Testing
- `php -l eventi_dettaglio.php`
- `php -l ajax/toggle_e2o_finanze.php`
- `php -l etichetta.php`
- `node -c js/eventi_dettaglio.js`


------
https://chatgpt.com/codex/tasks/task_e_68a07c1d9f5c83319cb380a35d4bd8c7