### PR TITLE
Use eye icons for event finances and show hidden entries

### DIFF
--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -83,6 +83,11 @@ document.addEventListener('DOMContentLoaded', () => {
     new bootstrap.Modal(document.getElementById('addSeModal')).show();
   });
 
+  document.getElementById('toggleHiddenFinBtn')?.addEventListener('click', function(){
+    document.querySelectorAll('.fin-hidden').forEach(el=>el.classList.toggle('d-none'));
+    this.textContent = this.textContent === 'Mostra nascoste' ? 'Nascondi nascoste' : 'Mostra nascoste';
+  });
+
   document.getElementById('addSeForm')?.addEventListener('submit', function(e){
     e.preventDefault();
     const fd = new FormData(this);


### PR DESCRIPTION
## Summary
- Replace show/hide buttons with eye and eye-slash icons for event finance movements
- Add "Mostra nascoste" button near the finance add button when hidden movements exist
- Ensure hidden movements are excluded from totals and can be toggled into view

## Testing
- `php -l eventi_dettaglio.php`
- `node --check js/eventi_dettaglio.js`


------
https://chatgpt.com/codex/tasks/task_e_68a07ec983a483318a701bc390968835