### PR TITLE
fix: prevent theme caching in login

### DIFF
--- a/includes/theme.php
+++ b/includes/theme.php
@@ -17,6 +17,9 @@ if (!$theme) {
 }
 $rgb = sscanf($theme['text_color'], "#%02x%02x%02x");
 $textRgb = implode(',', $rgb);
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+header('Expires: 0');
 header('Content-Type: text/css');
 ?>
 :root {


### PR DESCRIPTION
## Summary
- avoid browser caching of theme.php to ensure user-selected theme loads

## Testing
- `php -l includes/theme.php`


------
https://chatgpt.com/codex/tasks/task_e_68a09c5dd25c8331a637683363674ae1