### PR TITLE
feat: refine service worker caching

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -14,7 +14,7 @@
   <script>
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/Gestionale25/service-worker.js?ver=v3-2024-08-16', { scope: '/Gestionale25/' })
+    navigator.serviceWorker.register('/Gestionale25/service-worker.js?ver=v4-2025-08-16', { scope: '/Gestionale25/' })
       .catch(console.error);
   });
 }

--- a/offline.html
+++ b/offline.html
@@ -8,6 +8,6 @@
 </style>
 </head>
 <body>
-<p>Sei offline</p>
+<p>Sei offline. Riprova più tardi.</p>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,30 +1,37 @@
 // Gestionale25/service-worker.js
-const CACHE_VERSION = 'v3-2024-08-16';
-const APP_SHELL = [
-  '/Gestionale25/offline.html'
-];
+const CACHE_VERSION = 'v4-2025-08-16';
+const RUNTIME = CACHE_VERSION;
+const APP_SHELL = ['/Gestionale25/offline.html'];
 
+// Install
 self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(CACHE_VERSION).then(c => c.addAll(APP_SHELL))
-  );
+  event.waitUntil(caches.open(RUNTIME).then(c => c.addAll(APP_SHELL)));
   self.skipWaiting();
 });
 
+// Activate: pulizia vecchie cache
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then(keys =>
-      Promise.all(keys.filter(k => k !== CACHE_VERSION).map(k => caches.delete(k)))
+      Promise.all(keys.filter(k => k !== RUNTIME).map(k => caches.delete(k)))
     )
   );
   self.clients.claim();
 });
 
+// Fetch
 self.addEventListener('fetch', (event) => {
-  const url = new URL(event.request.url);
-  const p = url.pathname;
+  const req = event.request;
+  const url = new URL(req.url);
 
-  // Bypass totale per root e pagine di autenticazione
+  // 1) Ignora TUTTO ciò che non è GET (POST/PUT/DELETE ecc.)
+  if (req.method !== 'GET') {
+    event.respondWith(fetch(req));
+    return;
+  }
+
+  // 2) Bypass per root e pagine di autenticazione
+  const p = url.pathname;
   const isAuthOrRoot =
     p === '/Gestionale25/' ||
     p.startsWith('/Gestionale25/login') ||
@@ -32,18 +39,33 @@ self.addEventListener('fetch', (event) => {
     p.includes('/Gestionale25/verifica_2fa');
 
   if (isAuthOrRoot) {
-    event.respondWith(fetch(event.request));
+    event.respondWith(fetch(req));
     return;
   }
 
-  // Cache-first con fallback offline per il resto
+  // 3) Solo stesso dominio in cache
+  const sameOrigin = url.origin === self.location.origin;
+
+  // 4) Navigazioni HTML: network-first con fallback offline
+  if (sameOrigin && req.mode === 'navigate') {
+    event.respondWith(
+      fetch(req).catch(() => caches.match('/Gestionale25/offline.html'))
+    );
+    return;
+  }
+
+  // 5) GET statici: cache-first + aggiornamento in background
   event.respondWith(
-    caches.match(event.request, { ignoreSearch: true }).then(resp => {
-      return resp || fetch(event.request).then(networkResp => {
-        const clone = networkResp.clone();
-        caches.open(CACHE_VERSION).then(c => c.put(event.request, clone));
-        return networkResp;
-      });
-    }).catch(() => caches.match('/Gestionale25/offline.html'))
+    caches.match(req, { ignoreSearch: true }).then((cached) => {
+      const fetchPromise = fetch(req).then((netRes) => {
+        if (sameOrigin && netRes && netRes.status === 200 && netRes.type === 'basic') {
+          const clone = netRes.clone();
+          caches.open(RUNTIME).then((c) => c.put(req, clone));
+        }
+        return netRes;
+      }).catch(() => cached || caches.match('/Gestionale25/offline.html'));
+
+      return cached || fetchPromise;
+    })
   );
 });


### PR DESCRIPTION
## Summary
- prevent caching of non-GET requests and auth pages via new service worker
- add offline fallback page and register updated service worker version
- update offline page message

## Testing
- `node --check service-worker.js`
- `php -l includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68a09d681de08331b3353d0d674be03d