### PR TITLE
Add Revolut-style passcode login

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -116,3 +116,40 @@ body {
   padding-bottom: .25rem;
   color: var(--text-color);
 }
+
+.pin-keypad {
+  display: grid;
+  grid-template-columns: repeat(3, 80px);
+  gap: 10px;
+  justify-content: center;
+  margin: 0 auto;
+}
+
+.pin-key {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background-color: var(--primary-color);
+  color: var(--text-color);
+  font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+}
+
+.pin-key:active {
+  background-color: var(--secondary-color);
+}
+
+#pin-dots .dot {
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  border: 1px solid var(--text-color);
+  margin: 0 5px;
+}
+
+#pin-dots .dot.filled {
+  background-color: var(--text-color);
+}


### PR DESCRIPTION
## Summary
- Introduce on-screen numeric keypad with dots, fingerprint and backspace buttons for passcode entry
- Greet user with centered Gestione Famiglia icon and personalized message
- Add CSS styles supporting keypad layout and dot indicators

## Testing
- `php -l login_passcode.php`


------
https://chatgpt.com/codex/tasks/task_e_68a44910cda48331a7531bf9c1b1b2ea