### PR TITLE
Fix undefined loginWebAuthn error on passcode login

### DIFF
--- a/login_passcode.php
+++ b/login_passcode.php
@@ -153,7 +153,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       btn.addEventListener('click', () => addDigit(btn.dataset.number));
     });
     document.getElementById('backspace').addEventListener('click', removeDigit);
-    document.getElementById('fingerprint').addEventListener('click', loginWebAuthn);
+    document.getElementById('fingerprint').addEventListener('click', () => loginWebAuthn());
   </script>
   <?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary
- Fix ReferenceError in passcode login by wrapping WebAuthn trigger in an arrow function so it executes after the script loads.

## Testing
- `php -l login_passcode.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4511f054883319585d629c0661915