### PR TITLE
Prompt passkey creation when none

### DIFF
--- a/js/webauthn.js
+++ b/js/webauthn.js
@@ -28,6 +28,12 @@ async function loginWebAuthn() {
     c.id = Uint8Array.from(atob(c.id), d => d.charCodeAt(0));
     return c;
   });
+  if (!options.allowCredentials.length) {
+    if (confirm('Nessuna passkey presente. Vuoi crearne una adesso?')) {
+      await registerWebAuthn();
+    }
+    return;
+  }
   const cred = await navigator.credentials.get({ publicKey: options });
   const assertion = {
     id: cred.id,


### PR DESCRIPTION
## Summary
- Alert users when no WebAuthn passkeys are available and offer to create one

## Testing
- `node --check js/webauthn.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4704b58688331b675aea097d5961a