### PR TITLE
Handle WebAuthn registration 403 gracefully

### DIFF
--- a/js/webauthn.js
+++ b/js/webauthn.js
@@ -1,27 +1,40 @@
 async function registerWebAuthn() {
-  const resp = await fetch('/Gestionale25/webauthn_register.php');
-  const options = await resp.json();
-  options.challenge = Uint8Array.from(atob(options.challenge), c => c.charCodeAt(0));
-  options.user.id = Uint8Array.from(atob(options.user.id), c => c.charCodeAt(0));
-  const cred = await navigator.credentials.create({ publicKey: options });
-  const attestation = {
-    id: cred.id,
-    rawId: btoa(String.fromCharCode(...new Uint8Array(cred.rawId))),
-    type: cred.type,
-    response: {
-      clientDataJSON: btoa(String.fromCharCode(...new Uint8Array(cred.response.clientDataJSON))),
-      attestationObject: btoa(String.fromCharCode(...new Uint8Array(cred.response.attestationObject)))
+  try {
+    const resp = await fetch('/Gestionale25/webauthn_register.php');
+    if (!resp.ok) {
+      alert('Impossibile registrare una passkey. Effettua prima l\'accesso.');
+      return;
     }
-  };
-  await fetch('/Gestionale25/webauthn_register.php', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(attestation)
-  });
+    const options = await resp.json();
+    options.challenge = Uint8Array.from(atob(options.challenge), c => c.charCodeAt(0));
+    options.user.id = Uint8Array.from(atob(options.user.id), c => c.charCodeAt(0));
+    const cred = await navigator.credentials.create({ publicKey: options });
+    const attestation = {
+      id: cred.id,
+      rawId: btoa(String.fromCharCode(...new Uint8Array(cred.rawId))),
+      type: cred.type,
+      response: {
+        clientDataJSON: btoa(String.fromCharCode(...new Uint8Array(cred.response.clientDataJSON))),
+        attestationObject: btoa(String.fromCharCode(...new Uint8Array(cred.response.attestationObject)))
+      }
+    };
+    await fetch('/Gestionale25/webauthn_register.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(attestation)
+    });
+  } catch (err) {
+    console.error('Errore nella registrazione WebAuthn', err);
+    alert('Registrazione WebAuthn non riuscita.');
+  }
 }
 
 async function loginWebAuthn() {
   const resp = await fetch('/Gestionale25/webauthn_login.php');
+  if (!resp.ok) {
+    console.error('Impossibile ottenere le opzioni di login WebAuthn');
+    return;
+  }
   const options = await resp.json();
   options.challenge = Uint8Array.from(atob(options.challenge), c => c.charCodeAt(0));
   options.allowCredentials = options.allowCredentials.map(c => {


### PR DESCRIPTION
## Summary
- handle 403 responses in WebAuthn registration
- add basic error handling for WebAuthn login fetch

## Testing
- `node -c js/webauthn.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4881e74f08331af0ff76dde71cba0