### PR TITLE
Add passkey creation section under security

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -204,7 +204,7 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
         </div>
       </li>
       <?php endif; ?>
-      <?php $showSecurity = has_permission($conn, 'page:change_password.php', 'view') || has_permission($conn, 'page:setup_passcode.php', 'view');
+      <?php $showSecurity = has_permission($conn, 'page:change_password.php', 'view') || has_permission($conn, 'page:setup_passcode.php', 'view') || has_permission($conn, 'page:setup_passkey.php', 'view');
       if ($showSecurity): ?>
       <li class="mb-3">
         <div class="dropdown w-100">
@@ -217,6 +217,9 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
             <?php endif; ?>
             <?php if (has_permission($conn, 'page:setup_passcode.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/setup_passcode.php"><i class="bi bi-lock me-2 text-white"></i>Imposta Passcode</a></li>
+            <?php endif; ?>
+            <?php if (has_permission($conn, 'page:setup_passkey.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/setup_passkey.php"><i class="bi bi-fingerprint me-2 text-white"></i>Crea passkey</a></li>
             <?php endif; ?>
             <li><a class="dropdown-item text-white" href="/Gestionale"><i class="bi bi-arrow-return-left me-2 text-white"></i>Torna al vecchio</a></li>
           </ul>

--- a/setup_passkey.php
+++ b/setup_passkey.php
@@ -1,0 +1,16 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+include 'includes/header.php';
+?>
+<div class="row justify-content-center">
+  <div class="col-md-6">
+    <div class="card bg-dark text-white p-4">
+      <h4 class="mb-3">Crea passkey</h4>
+      <p class="mb-3">Le passkey permettono di accedere in modo sicuro senza inserire la password. Premi il pulsante per crearne una sul tuo dispositivo.</p>
+      <button class="btn btn-primary" onclick="registerWebAuthn()">Crea passkey</button>
+    </div>
+  </div>
+</div>
+<?php include 'includes/footer.php'; ?>
+


### PR DESCRIPTION
## Summary
- allow showing security menu when passkey setup is permitted
- add `Crea passkey` option and new setup page using WebAuthn

## Testing
- `php -l includes/header.php`
- `php -l setup_passkey.php`


------
https://chatgpt.com/codex/tasks/task_e_68a48b2c3b508331affe73873589b24d