### PR TITLE
Fix WebAuthn passkey registration and login

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,6 +1,6 @@
 </div> <!-- Chiude container -->
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script src="/Gestionale25/js/webauthn.js"></script>
+<script src="js/webauthn.js"></script>
 </body>
 </html>

--- a/js/webauthn.js
+++ b/js/webauthn.js
@@ -1,6 +1,6 @@
 async function registerWebAuthn() {
   try {
-    const resp = await fetch('/Gestionale25/webauthn_register.php');
+    const resp = await fetch('webauthn_register.php');
     if (!resp.ok) {
       alert('Impossibile registrare una passkey. Effettua prima l\'accesso.');
       return;
@@ -18,11 +18,16 @@ async function registerWebAuthn() {
         attestationObject: btoa(String.fromCharCode(...new Uint8Array(cred.response.attestationObject)))
       }
     };
-    await fetch('/Gestionale25/webauthn_register.php', {
+    const save = await fetch('webauthn_register.php', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(attestation)
     });
+    if (save.ok) {
+      alert('Passkey registrata con successo.');
+    } else {
+      alert('Salvataggio passkey non riuscito.');
+    }
   } catch (err) {
     console.error('Errore nella registrazione WebAuthn', err);
     alert('Registrazione WebAuthn non riuscita.');
@@ -30,7 +35,7 @@ async function registerWebAuthn() {
 }
 
 async function loginWebAuthn() {
-  const resp = await fetch('/Gestionale25/webauthn_login.php');
+  const resp = await fetch('webauthn_login.php');
   if (!resp.ok) {
     console.error('Impossibile ottenere le opzioni di login WebAuthn');
     return;
@@ -59,14 +64,14 @@ async function loginWebAuthn() {
       userHandle: cred.response.userHandle ? btoa(String.fromCharCode(...new Uint8Array(cred.response.userHandle))) : null
     }
   };
-  const verify = await fetch('/Gestionale25/webauthn_login.php', {
+  const verify = await fetch('webauthn_login.php', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(assertion)
   });
   const result = await verify.json();
   if (result.success) {
-    window.location.href = '/Gestionale25/index.php';
+    window.location.href = 'index.php';
   } else {
     alert('Autenticazione WebAuthn fallita');
   }

--- a/webauthn_login.php
+++ b/webauthn_login.php
@@ -31,7 +31,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $res = $stmt->get_result();
     $creds = [];
     while ($row = $res->fetch_assoc()) {
-        $creds[] = ['type' => 'public-key', 'id' => base64_encode($row['credential_id'])];
+        $creds[] = ['type' => 'public-key', 'id' => $row['credential_id']];
     }
     echo json_encode([
         'challenge' => base64_encode($challenge),
@@ -53,7 +53,7 @@ if (!isset($_SESSION['webauthn_challenge'], $_SESSION['webauthn_user']) || $_SES
     exit;
 }
 
-$credentialId = $input['id'] ?? '';
+$credentialId = $input['rawId'] ?? '';
 $stmt = $conn->prepare('SELECT public_key FROM webauthn_credentials WHERE user_id = ? AND credential_id = ?');
 $stmt->bind_param('is', $userId, $credentialId);
 $stmt->execute();

--- a/webauthn_register.php
+++ b/webauthn_register.php
@@ -35,10 +35,10 @@ if (!$input) {
     exit;
 }
 
-$credentialId = $input['id'] ?? '';
+$credentialId = $input['rawId'] ?? '';
 $publicKey = $input['response']['attestationObject'] ?? '';
 $stmt = $conn->prepare("INSERT INTO webauthn_credentials (user_id, credential_id, public_key) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE public_key=VALUES(public_key)");
 $stmt->bind_param('iss', $_SESSION['utente_id'], $credentialId, $publicKey);
-$stmt->execute();
+$ok = $stmt->execute();
 
-echo json_encode(['success' => true]);
+echo json_encode(['success' => $ok]);


### PR DESCRIPTION
## Summary
- Store credential rawId and handle errors when saving passkeys
- Return stored credential IDs during login and use relative JS paths
- Load WebAuthn script locally and add user feedback

## Testing
- `php -l webauthn_register.php`
- `php -l webauthn_login.php`
- `php -l includes/footer.php`
- `node --check js/webauthn.js`


------
https://chatgpt.com/codex/tasks/task_e_68a48d4305448331929de63a818e1554