### PR TITLE
Fix password detail save by deferring header output

### DIFF
--- a/password_dettaglio.php
+++ b/password_dettaglio.php
@@ -1,7 +1,6 @@
 <?php include 'includes/session_check.php'; ?>
 <?php
 include 'includes/db.php';
-include 'includes/header.php';
 
 $idUtente = $_SESSION['utente_id'] ?? ($_SESSION['id_utente'] ?? 0);
 $idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
@@ -31,6 +30,7 @@ if ($id > 0) {
     if ($res && $res->num_rows > 0) {
         $data = $res->fetch_assoc();
     } else {
+        include 'includes/header.php';
         echo '<p class="text-danger">Record non trovato.</p>';
         include 'includes/footer.php';
         exit;
@@ -55,6 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $row = $res->fetch_assoc();
         $stmt->close();
         if (!$row || (int)$row['id_utente'] !== $idUtente) {
+            include 'includes/header.php';
             echo '<p class="text-danger">Operazione non autorizzata.</p>';
             include 'includes/footer.php';
             exit;
@@ -72,6 +73,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     header('Location: password.php');
     exit;
 }
+include 'includes/header.php';
 ?>
 <div class="container text-white">
   <a href="javascript:history.back()" class="btn btn-outline-light mb-3">← Indietro</a>


### PR DESCRIPTION
## Summary
- Delay header rendering in `password_dettaglio.php` until after POST handling to prevent premature output and enable redirect
- Ensure error cases load the header before displaying messages

## Testing
- `php -l password_dettaglio.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac56a66bac8331b1d23e3b33df7d26