### PR TITLE
Fix extra description modal when text contains apostrophes

### DIFF
--- a/dettaglio.php
+++ b/dettaglio.php
@@ -201,7 +201,10 @@ include 'includes/header.php';
       <span>Descrizione Extra</span>
       <div class="ms-auto d-flex align-items-center">
         <span class="text-end"><?= htmlspecialchars($movimento['descrizione_extra']) ?></span>
-        <i class="bi bi-pencil ms-2" onclick="openModal('descrizione_extra', <?= htmlspecialchars(json_encode($movimento['descrizione_extra'] ?? ''), ENT_QUOTES) ?>)"></i>
+        <i
+          class="bi bi-pencil ms-2"
+          data-value="<?= htmlspecialchars($movimento['descrizione_extra'] ?? '', ENT_QUOTES) ?>"
+          onclick="openModal('descrizione_extra', this.dataset.value)"></i>
       </div>
     </li>
 
@@ -210,7 +213,10 @@ include 'includes/header.php';
       <span>Note</span>
       <div class="ms-auto d-flex align-items-center">
         <span class="text-end"><?= htmlspecialchars($movimento['note']) ?></span>
-        <i class="bi bi-pencil ms-2" onclick="openModal('note', <?= htmlspecialchars(json_encode($movimento['note'] ?? ''), ENT_QUOTES) ?>)"></i>
+        <i
+          class="bi bi-pencil ms-2"
+          data-value="<?= htmlspecialchars($movimento['note'] ?? '', ENT_QUOTES) ?>"
+          onclick="openModal('note', this.dataset.value)"></i>
       </div>
     </li>
 


### PR DESCRIPTION
## Summary
- store editable values in data attributes to avoid breaking inline handlers
- support apostrophes in extra description and notes modals

## Testing
- `php -l dettaglio.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac596b05cc8331bc8eaeb93389cfa5