### PR TITLE
Aggiungi promemoria tagliandi

### DIFF
--- a/cron/tagliandi_notifica.php
+++ b/cron/tagliandi_notifica.php
@@ -1,0 +1,59 @@
+<?php
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../lib/mezzi_tagliandi.php';
+require_once __DIR__ . '/../libs/PHPMailer/PHPMailer.php';
+require_once __DIR__ . '/../libs/PHPMailer/SMTP.php';
+require_once __DIR__ . '/../libs/PHPMailer/Exception.php';
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+$daysThreshold = (int) getenv('TAGLIANDO_GIORNI_SOGLIA');
+if ($daysThreshold <= 0) { $daysThreshold = 30; }
+$kmThreshold = (int) getenv('TAGLIANDO_KM_SOGLIA');
+if ($kmThreshold <= 0) { $kmThreshold = 1000; }
+
+$scadenze = get_tagliandi_scadenze($conn);
+
+foreach ($scadenze as $s) {
+    $inScadenza = false;
+    if ($s['days_remaining'] !== null && $s['days_remaining'] <= $daysThreshold) {
+        $inScadenza = true;
+    }
+    if ($s['km_remaining'] !== null && $s['km_remaining'] <= $kmThreshold) {
+        $inScadenza = true;
+    }
+    if (!$inScadenza) { continue; }
+
+    try {
+        $mail = new PHPMailer(true);
+        $mail->isSMTP();
+        $mail->Host       = 'smtps.aruba.it';
+        $mail->SMTPAuth   = true;
+        $mail->Username   = $config['mail_user'];
+        $mail->Password   = $config['mail_pwd'];
+        $mail->SMTPSecure = 'ssl';
+        $mail->Port       = 465;
+        $mail->SMTPOptions = [
+            'ssl' => [
+                'verify_peer'       => false,
+                'verify_peer_name'  => false,
+                'allow_self_signed' => true,
+            ]
+        ];
+        $mail->setFrom('assistenza@gestionefamiglia.it', 'Gestione Famiglia');
+        $mail->addAddress($s['email']);
+        $mail->isHTML(false);
+        $mail->Subject = 'Tagliando in scadenza';
+        $mail->Body    = sprintf("Il tagliando '%s' per il mezzo '%s' è in scadenza il %s o a %d km.",
+            $s['nome_tagliando'],
+            $s['nome_mezzo'],
+            $s['next_date'],
+            $s['next_km']
+        );
+        $mail->send();
+    } catch (Exception $e) {
+        // Silenzia eventuali errori di invio
+    }
+}
+?>

--- a/lib/mezzi_tagliandi.php
+++ b/lib/mezzi_tagliandi.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Calcola le prossime scadenze dei tagliandi per i mezzi attivi.
+ *
+ * @param mysqli    $conn        Connessione al database
+ * @param int|null  $idFamiglia  (opzionale) Limita ai mezzi della famiglia indicata
+ * @return array                 Elenco con informazioni sulle scadenze
+ */
+function get_tagliandi_scadenze(mysqli $conn, ?int $idFamiglia = null): array {
+    $sql = "SELECT m.id_mezzo, m.nome_mezzo, m.data_immatricolazione, m.id_utente, u.email,
+                   mt.id_tagliando, mt.nome_tagliando, mt.mesi_da_immatricolazione,
+                   mt.massimo_km_tagliando, mt.frequenza_mesi, mt.frequenza_km
+            FROM mezzi m
+            JOIN mezzi_tagliandi mt ON mt.id_mezzo = m.id_mezzo
+            JOIN utenti u ON u.id = m.id_utente
+            WHERE m.attivo = 1";
+    if ($idFamiglia !== null) {
+        $sql .= " AND m.id_famiglia = ?";
+        $stmt = $conn->prepare($sql);
+        $stmt->bind_param('i', $idFamiglia);
+    } else {
+        $stmt = $conn->prepare($sql);
+    }
+
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $scadenze = [];
+    while ($row = $res->fetch_assoc()) {
+        // ultimo evento di tagliando
+        $stmtEv = $conn->prepare("SELECT data_evento, km_evento FROM mezzi_eventi WHERE id_mezzo = ? AND id_tipo_evento = 1 ORDER BY data_evento DESC LIMIT 1");
+        $stmtEv->bind_param('i', $row['id_mezzo']);
+        $stmtEv->execute();
+        $ev = $stmtEv->get_result()->fetch_assoc();
+        $stmtEv->close();
+
+        // ultimo chilometraggio registrato
+        $stmtKm = $conn->prepare("SELECT chilometri FROM mezzi_chilometri WHERE id_mezzo = ? ORDER BY data_chilometro DESC LIMIT 1");
+        $stmtKm->bind_param('i', $row['id_mezzo']);
+        $stmtKm->execute();
+        $kmRow = $stmtKm->get_result()->fetch_assoc();
+        $stmtKm->close();
+
+        if ($ev) {
+            $nextDate = date('Y-m-d', strtotime($ev['data_evento'] . " +{$row['frequenza_mesi']} months"));
+            $nextKm = (int)$ev['km_evento'] + (int)$row['frequenza_km'];
+        } else {
+            $nextDate = date('Y-m-d', strtotime($row['data_immatricolazione'] . " +{$row['mesi_da_immatricolazione']} months"));
+            $nextKm = (int)$row['massimo_km_tagliando'];
+        }
+
+        $currentKm = $kmRow['chilometri'] ?? null;
+        $kmRemaining = $currentKm !== null ? $nextKm - (int)$currentKm : null;
+        $daysRemaining = (int) floor((strtotime($nextDate) - time()) / 86400);
+
+        $scadenze[] = [
+            'id_mezzo'       => (int)$row['id_mezzo'],
+            'nome_mezzo'     => $row['nome_mezzo'],
+            'id_tagliando'   => (int)$row['id_tagliando'],
+            'nome_tagliando' => $row['nome_tagliando'],
+            'next_date'      => $nextDate,
+            'next_km'        => $nextKm,
+            'days_remaining' => $daysRemaining,
+            'km_remaining'   => $kmRemaining,
+            'email'          => $row['email'],
+            'id_utente'      => (int)$row['id_utente']
+        ];
+    }
+    $stmt->close();
+    return $scadenze;
+}
+?>

--- a/mezzi.php
+++ b/mezzi.php
@@ -3,6 +3,7 @@
 include 'includes/db.php';
 require_once 'includes/permissions.php';
 require_once 'includes/render_mezzo.php';
+require_once 'lib/mezzi_tagliandi.php';
 if (!has_permission($conn, 'page:mezzi.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
 include 'includes/header.php';
 
@@ -13,6 +14,7 @@ $stmt = $conn->prepare("SELECT * FROM mezzi WHERE id_famiglia = ?");
 $stmt->bind_param('i', $idFamiglia);
 $stmt->execute();
 $res = $stmt->get_result();
+$tagliandi = get_tagliandi_scadenze($conn, $idFamiglia);
 ?>
 <div class="d-flex mb-3 justify-content-between">
   <h4>Mezzi</h4>
@@ -32,5 +34,26 @@ $res = $stmt->get_result();
   <?php render_mezzo($row); ?>
 <?php endwhile; ?>
 </div>
+<?php
+$daysThreshold = 30;
+$kmThreshold = 1000;
+$scadenze = array_filter($tagliandi, function ($t) use ($daysThreshold, $kmThreshold) {
+    return ($t['days_remaining'] !== null && $t['days_remaining'] <= $daysThreshold) ||
+           ($t['km_remaining'] !== null && $t['km_remaining'] <= $kmThreshold);
+});
+if (!empty($scadenze)):
+?>
+<div class="mt-4">
+  <h5>Tagliandi in scadenza</h5>
+  <ul class="list-group list-group-flush bg-dark">
+    <?php foreach ($scadenze as $t): ?>
+    <li class="list-group-item bg-dark text-white d-flex justify-content-between">
+      <span><?= htmlspecialchars($t['nome_mezzo']) ?> - <?= htmlspecialchars($t['nome_tagliando']) ?></span>
+      <span><?= date('d/m/Y', strtotime($t['next_date'])) ?> / <?= number_format($t['next_km'], 0, ',', '.') ?> km</span>
+    </li>
+    <?php endforeach; ?>
+  </ul>
+</div>
+<?php endif; ?>
 <script src="js/mezzi.js"></script>
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- implementata funzione `get_tagliandi_scadenze` per calcolare le prossime scadenze dei tagliandi
- aggiunto script cron che invia email agli utenti quando il tagliando si avvicina
- mostrato widget "Tagliandi in scadenza" nella pagina dei mezzi

## Testing
- `php -l lib/mezzi_tagliandi.php`
- `php -l cron/tagliandi_notifica.php`
- `php -l mezzi.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac5f664d7883318ad637f1f1b59dba