### PR TITLE
Enhance event detail page and shopping list integration

### DIFF
--- a/ajax/cibo_to_lista_spesa.php
+++ b/ajax/cibo_to_lista_spesa.php
@@ -1,0 +1,46 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+include '../includes/permissions.php';
+
+$id_evento = (int)($_POST['id_evento'] ?? 0);
+$famiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+if(!$id_evento || !$famiglia){
+    echo json_encode(['success'=>false,'error'=>'Dati non validi']);
+    exit;
+}
+
+// svuota lista esistente
+$stmt = $conn->prepare('DELETE FROM lista_spesa WHERE id_famiglia = ?');
+$stmt->bind_param('i', $famiglia);
+if(!$stmt->execute()){
+    echo json_encode(['success'=>false]);
+    exit;
+}
+$stmt->close();
+
+// recupera cibo dell'evento
+$stmt = $conn->prepare('SELECT c.piatto, e2c.quantita, c.um FROM eventi_eventi2cibo e2c JOIN eventi_cibo c ON e2c.id_cibo = c.id WHERE e2c.id_evento = ?');
+$stmt->bind_param('i', $id_evento);
+$stmt->execute();
+$res = $stmt->get_result();
+$items = $res->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+if($items){
+    $stmtIns = $conn->prepare('INSERT INTO lista_spesa (id_famiglia, nome, quantita) VALUES (?,?,?)');
+    $stmtIns->bind_param('iss', $famiglia, $nome, $quantita);
+    foreach($items as $it){
+        $nome = $it['piatto'];
+        $quantita = $it['quantita'] !== null ? trim($it['quantita'] . ' ' . $it['um']) : '';
+        if(!$stmtIns->execute()){
+            $stmtIns->close();
+            echo json_encode(['success'=>false]);
+            exit;
+        }
+    }
+    $stmtIns->close();
+}
+
+echo json_encode(['success'=>true]);

--- a/ajax/delete_e2c.php
+++ b/ajax/delete_e2c.php
@@ -1,0 +1,17 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$id_e2c = (int)($_POST['id_e2c'] ?? 0);
+if(!$id_e2c){
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('DELETE FROM eventi_eventi2cibo WHERE id_e2c=?');
+$stmt->bind_param('i', $id_e2c);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);

--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -124,6 +124,15 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
   });
 
+  document.getElementById('ciboToListaBtn')?.addEventListener('click', function(){
+    if(!confirm('Sostituire la lista della spesa con il cibo di questo evento?')) return;
+    const fd = new FormData();
+    fd.append('id_evento', this.dataset.id);
+    fetch('ajax/cibo_to_lista_spesa.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) window.location.href = 'lista_spesa.php'; else alert(res.error||'Errore'); });
+  });
+
   // apertura modal modifica salvadanaio/etichetta
   document.querySelectorAll('#salvList .se-row, #etList .se-row').forEach(li => {
     li.addEventListener('click', () => {
@@ -168,6 +177,16 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const fd = new FormData(this);
     fetch('ajax/update_e2c.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
+  document.getElementById('deleteCiboBtn')?.addEventListener('click', function(){
+    const id = document.getElementById('ciboForm')?.id_e2c.value;
+    if(!id || !confirm('Eliminare questo cibo dall\'evento?')) return;
+    const fd = new FormData();
+    fd.append('id_e2c', id);
+    fetch('ajax/delete_e2c.php', {method:'POST', body:fd})
       .then(r=>r.json())
       .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
   });


### PR DESCRIPTION
## Summary
- Show invitation status counts below event invitation title
- Format event dates as dd/mm/yyyy and hide duplicate end date
- Align food quantities, add delete option, and allow exporting event food to shopping list

## Testing
- `php -l eventi_dettaglio.php`
- `php -l ajax/delete_e2c.php`
- `php -l ajax/cibo_to_lista_spesa.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac66f547848331aef57419da9a04b0