### PR TITLE
Enable editing of mezzo events via modal

### DIFF
--- a/ajax/update_mezzo_evento.php
+++ b/ajax/update_mezzo_evento.php
@@ -1,0 +1,38 @@
+<?php
+include '../includes/session_check.php';
+include '../includes/db.php';
+header('Content-Type: application/json');
+
+$idUtente = $_SESSION['utente_id'] ?? ($_SESSION['id_utente'] ?? 0);
+$idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
+
+$idMezzo = (int)($_POST['id_mezzo'] ?? 0);
+$idEvento = (int)($_POST['id_evento'] ?? 0);
+$idTipo = (int)($_POST['id_tipo_evento'] ?? 0);
+$dataEvento = $_POST['data_evento'] ?? '';
+$kmEvento = (int)($_POST['km_evento'] ?? 0);
+$note = $_POST['note'] ?? '';
+
+$stmt = $conn->prepare("SELECT id_utente FROM mezzi WHERE id_mezzo=? AND id_famiglia=?");
+$stmt->bind_param('ii', $idMezzo, $idFamiglia);
+$stmt->execute();
+$res = $stmt->get_result();
+$row = $res->fetch_assoc();
+$stmt->close();
+
+if (!$row || (int)$row['id_utente'] !== $idUtente) {
+    echo json_encode(['success' => false, 'error' => 'Operazione non autorizzata']);
+    exit;
+}
+
+if ($idEvento > 0) {
+    $stmt = $conn->prepare("UPDATE mezzi_eventi SET id_tipo_evento=?, data_evento=?, km_evento=?, note=? WHERE id_evento=? AND id_mezzo=?");
+    $stmt->bind_param('isissi', $idTipo, $dataEvento, $kmEvento, $note, $idEvento, $idMezzo);
+} else {
+    $stmt = $conn->prepare("INSERT INTO mezzi_eventi (id_mezzo, id_tipo_evento, data_evento, km_evento, note) VALUES (?,?,?,?,?)");
+    $stmt->bind_param('iisis', $idMezzo, $idTipo, $dataEvento, $kmEvento, $note);
+}
+$ok = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $ok]);

--- a/js/mezzo_dettaglio.js
+++ b/js/mezzo_dettaglio.js
@@ -32,9 +32,15 @@ document.getElementById('chilometroForm')?.addEventListener('submit', function(e
     .then(res=>{ if(res.success) location.reload(); });
 });
 
-function openEventoModal(){
+function openEventoModal(data){
   const form = document.getElementById('eventoForm');
-  form?.reset();
+  if(!form) return;
+  form.reset();
+  form.id_evento.value = data && data.id ? data.id : '';
+  form.id_tipo_evento.value = data && data.id_tipo_evento ? data.id_tipo_evento : form.id_tipo_evento.value;
+  form.data_evento.value = data && data.data_evento ? data.data_evento : '';
+  form.km_evento.value = data && data.km_evento ? data.km_evento : '';
+  form.note.value = data && data.note ? data.note : '';
   new bootstrap.Modal(document.getElementById('eventoModal')).show();
 }
 
@@ -42,7 +48,7 @@ document.getElementById('eventoForm')?.addEventListener('submit', function(e){
   e.preventDefault();
   const fd = new FormData(this);
   fd.append('id_mezzo', mezzoData.id);
-  fetch('ajax/add_mezzo_evento.php', {method:'POST', body:fd})
+  fetch('ajax/update_mezzo_evento.php', {method:'POST', body:fd})
     .then(r=>r.json())
     .then(res=>{ if(res.success) location.reload(); });
 });
@@ -53,6 +59,20 @@ function editChilometro(el){
 
 document.querySelectorAll('#chilometriList li').forEach(li=>{
   li.addEventListener('click', ()=>editChilometro(li));
+});
+
+function editEvento(el){
+  openEventoModal({
+    id: el.dataset.id,
+    id_tipo_evento: el.dataset.tipo,
+    data_evento: el.dataset.data,
+    km_evento: el.dataset.km,
+    note: el.dataset.note
+  });
+}
+
+document.querySelectorAll('#eventiList .mezzo-card').forEach(div=>{
+  div.addEventListener('click', ()=>editEvento(div));
 });
 
 function deleteChilometro(ev, id){

--- a/mezzo_dettaglio.php
+++ b/mezzo_dettaglio.php
@@ -52,7 +52,7 @@ if ($id > 0) {
     }
     $stmtKm->close();
 
-    $stmtEv = $conn->prepare("SELECT me.id_evento, me.data_evento, me.km_evento, me.note, mt.tipo_evento FROM mezzi_eventi me JOIN mezzi_eventi_tipi mt ON mt.id_tipo_evento = me.id_tipo_evento WHERE me.id_mezzo = ? ORDER BY me.data_evento DESC");
+    $stmtEv = $conn->prepare("SELECT me.id_evento, me.id_tipo_evento, me.data_evento, me.km_evento, me.note, mt.tipo_evento FROM mezzi_eventi me JOIN mezzi_eventi_tipi mt ON mt.id_tipo_evento = me.id_tipo_evento WHERE me.id_mezzo = ? ORDER BY me.data_evento DESC");
     $stmtEv->bind_param('i', $id);
     $stmtEv->execute();
     $resEv = $stmtEv->get_result();
@@ -117,7 +117,12 @@ if ($id > 0): ?>
   </div>
   <div id="eventiList">
     <?php foreach ($eventi as $row): ?>
-      <div class="mezzo-card movement d-flex justify-content-between align-items-start text-white">
+      <div class="mezzo-card movement d-flex justify-content-between align-items-start text-white"
+           data-id="<?= (int)$row['id_evento'] ?>"
+           data-tipo="<?= (int)$row['id_tipo_evento'] ?>"
+           data-data="<?= htmlspecialchars($row['data_evento']) ?>"
+           data-km="<?= (int)$row['km_evento'] ?>"
+           data-note="<?= htmlspecialchars($row['note'], ENT_QUOTES) ?>">
         <div class="flex-grow-1">
           <div class="fw-semibold"><?= htmlspecialchars($row['tipo_evento']) ?></div>
           <?php if (!empty($row['note'])): ?>
@@ -202,6 +207,7 @@ if ($id > 0): ?>
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
+        <input type="hidden" name="id_evento" id="id_evento">
         <div class="mb-3">
           <label class="form-label">Tipo evento</label>
           <select name="id_tipo_evento" class="form-select bg-secondary text-white">


### PR DESCRIPTION
## Summary
- allow clicking on a vehicle event to open a modal pre-filled for editing
- add client-side logic to populate event modal and submit changes via AJAX
- provide `update_mezzo_evento.php` endpoint to insert or update vehicle events

## Testing
- `php -l mezzo_dettaglio.php`
- `php -l ajax/update_mezzo_evento.php`
- `node --check js/mezzo_dettaglio.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac7e2413c083318204c09f0b826181