### PR TITLE
Add query management interface

### DIFF
--- a/includes/render_query.php
+++ b/includes/render_query.php
@@ -1,0 +1,20 @@
+<?php
+function render_query(array $row) {
+    $isArchived = (int)($row['archiviato'] ?? 0) === 1;
+    $classes = 'query-card d-flex justify-content-between align-items-center text-white text-decoration-none border-bottom py-2';
+    if ($isArchived) {
+        $classes .= ' archiviato';
+    }
+    $search = strtolower(($row['descrizione'] ?? '') . ' ' . ($row['stringa_da_completare'] ?? ''));
+    $searchAttr = htmlspecialchars($search, ENT_QUOTES);
+    $url = 'query_dettaglio.php?id=' . (int)$row['id_dato_remoto'];
+    echo '<div class="' . $classes . '" data-search="' . $searchAttr . '">';
+    echo '  <div class="flex-grow-1" onclick="window.location.href=\'' . $url . '\'">';
+    echo '    <div class="fw-semibold">' . htmlspecialchars($row['descrizione'] ?? '') . '</div>';
+    echo '  </div>';
+    echo '  <div class="ms-2 text-nowrap">';
+    echo '    <button type="button" class="btn btn-sm btn-outline-light run-query" data-id="' . (int)$row['id_dato_remoto'] . '" onclick="event.stopPropagation();">Esegui</button>';
+    echo '  </div>';
+    echo '</div>';
+}
+?>

--- a/js/query.js
+++ b/js/query.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const search = document.getElementById('search');
+  const showArchived = document.getElementById('showArchived');
+  const cards = Array.from(document.querySelectorAll('.query-card'));
+
+  function filter() {
+    const q = search.value.trim().toLowerCase();
+    cards.forEach(card => {
+      const text = card.dataset.search || '';
+      const isArchived = card.classList.contains('archiviato');
+      const match = text.includes(q);
+      const visible = match && (!isArchived || showArchived.checked || q !== '');
+      if (visible) {
+        card.style.removeProperty('display');
+      } else {
+        card.style.setProperty('display', 'none', 'important');
+      }
+    });
+  }
+
+  search.addEventListener('input', filter);
+  showArchived.addEventListener('input', filter);
+  filter();
+
+  document.getElementById('queryList').addEventListener('click', e => {
+    const btn = e.target.closest('.run-query');
+    if (btn) {
+      const id = btn.dataset.id;
+      btn.disabled = true;
+      fetch('query_execute.php?id=' + encodeURIComponent(id))
+        .then(r => r.json())
+        .then(data => {
+          alert(JSON.stringify(data, null, 2));
+        })
+        .catch(err => alert('Errore: ' + err))
+        .finally(() => { btn.disabled = false; });
+    }
+  });
+});

--- a/query.php
+++ b/query.php
@@ -1,0 +1,27 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+require_once 'includes/render_query.php';
+include 'includes/header.php';
+
+$stmt = $conn->prepare('SELECT * FROM dati_remoti');
+$stmt->execute();
+$res = $stmt->get_result();
+?>
+<div class="d-flex mb-3 justify-content-between">
+  <h4>Query</h4><a href="query_dettaglio.php" class="btn btn-outline-light btn-sm">Aggiungi nuovo</a>
+</div>
+<div class="d-flex mb-3 align-items-center">
+  <input type="text" id="search" class="form-control bg-dark text-white border-secondary me-2" placeholder="Cerca">
+  <div class="form-check form-switch text-nowrap">
+    <input class="form-check-input" type="checkbox" id="showArchived">
+    <label class="form-check-label" for="showArchived">Mostra archiviati</label>
+  </div>
+</div>
+<div id="queryList">
+<?php while ($row = $res->fetch_assoc()): ?>
+  <?php render_query($row); ?>
+<?php endwhile; ?>
+</div>
+<script src="js/query.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/query_dettaglio.php
+++ b/query_dettaglio.php
@@ -1,0 +1,90 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$data = [
+    'descrizione' => '',
+    'stringa_da_completare' => '',
+    'parametri' => '',
+    'archiviato' => 0,
+    'id_dato_remoto' => 0
+];
+
+if ($id > 0) {
+    $stmt = $conn->prepare('SELECT * FROM dati_remoti WHERE id_dato_remoto = ?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($res && $res->num_rows > 0) {
+        $data = $res->fetch_assoc();
+    } else {
+        include 'includes/header.php';
+        echo '<p class="text-danger">Record non trovato.</p>';
+        include 'includes/footer.php';
+        exit;
+    }
+    $stmt->close();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id_dato_remoto = isset($_POST['id_dato_remoto']) ? (int)$_POST['id_dato_remoto'] : 0;
+    if (isset($_POST['delete']) && $id_dato_remoto > 0) {
+        $stmt = $conn->prepare('DELETE FROM dati_remoti WHERE id_dato_remoto = ?');
+        $stmt->bind_param('i', $id_dato_remoto);
+        $stmt->execute();
+        $stmt->close();
+        header('Location: query.php');
+        exit;
+    }
+    $descrizione = $_POST['descrizione'] ?? '';
+    $stringa = $_POST['stringa_da_completare'] ?? '';
+    $parametri = $_POST['parametri'] ?? '';
+    $archiviato = isset($_POST['archiviato']) ? 1 : 0;
+    if ($id_dato_remoto > 0) {
+        $stmt = $conn->prepare('UPDATE dati_remoti SET descrizione=?, stringa_da_completare=?, parametri=?, archiviato=? WHERE id_dato_remoto=?');
+        $stmt->bind_param('sssii', $descrizione, $stringa, $parametri, $archiviato, $id_dato_remoto);
+        $stmt->execute();
+        $stmt->close();
+    } else {
+        $stmt = $conn->prepare('INSERT INTO dati_remoti (descrizione, stringa_da_completare, parametri, archiviato) VALUES (?,?,?,?)');
+        $stmt->bind_param('sssi', $descrizione, $stringa, $parametri, $archiviato);
+        $stmt->execute();
+        $stmt->close();
+    }
+    header('Location: query.php');
+    exit;
+}
+
+include 'includes/header.php';
+?>
+<div class="container text-white">
+  <a href="javascript:history.back()" class="btn btn-outline-light mb-3">← Indietro</a>
+  <h4 class="mb-4">Dettaglio Query</h4>
+</div>
+<form method="post" class="bg-dark text-white p-3 rounded">
+  <div class="mb-3">
+    <label class="form-label">Descrizione</label>
+    <input type="text" name="descrizione" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['descrizione']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Stringa da completare</label>
+    <textarea name="stringa_da_completare" class="form-control bg-dark text-white border-secondary" rows="3"><?= htmlspecialchars($data['stringa_da_completare']) ?></textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Parametri (JSON)</label>
+    <textarea name="parametri" class="form-control bg-dark text-white border-secondary" rows="3"><?= htmlspecialchars($data['parametri']) ?></textarea>
+  </div>
+  <div class="form-check form-switch mb-3">
+    <input class="form-check-input" type="checkbox" id="archiviato" name="archiviato" <?= ($data['archiviato'] ?? 0) ? 'checked' : '' ?>>
+    <label class="form-check-label" for="archiviato">Archiviato</label>
+  </div>
+  <?php if ($data['id_dato_remoto']): ?>
+    <input type="hidden" name="id_dato_remoto" value="<?= (int)$data['id_dato_remoto'] ?>">
+  <?php endif; ?>
+  <button type="submit" class="btn btn-primary w-100">Salva</button>
+  <?php if ($data['id_dato_remoto']): ?>
+    <button type="submit" name="delete" value="1" class="btn btn-danger w-100 mt-3" onclick="return confirm('Eliminare definitivamente?');">Elimina</button>
+  <?php endif; ?>
+</form>
+<?php include 'includes/footer.php'; ?>

--- a/query_execute.php
+++ b/query_execute.php
@@ -1,0 +1,44 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+require_once 'includes/utility.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+header('Content-Type: application/json');
+
+if ($id <= 0) {
+    echo json_encode(['error' => 'ID mancante']);
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT stringa_da_completare, parametri FROM dati_remoti WHERE id_dato_remoto = ?');
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$res = $stmt->get_result();
+$row = $res->fetch_assoc();
+$stmt->close();
+
+if (!$row) {
+    echo json_encode(['error' => 'Record non trovato']);
+    exit;
+}
+
+$SQLinv = $row['stringa_da_completare'] ?? '';
+$parametri = json_decode($row['parametri'] ?? '', true);
+if (is_array($parametri)) {
+    foreach ($parametri as $chiave => $valore) {
+        $SQLinv = str_replace('[[' . $chiave . ']]', $valore, $SQLinv);
+    }
+}
+
+$token = Encrypt(microtime(true) . rand(1000, 9999), 'test');
+$SQLen = Encrypt(htmlspecialchars_decode($SQLinv), 'test');
+$url = 'https://new.cosulich.it/approvazione_fatture/user_get_inaz_json.php?action=execute_query&token=' . $token . '&SQL=' . $SQLen;
+$response = @file_get_contents($url);
+$risposta = json_decode($response, true);
+
+echo json_encode([
+    'query' => $SQLinv,
+    'risposta' => $risposta,
+    'url' => $url
+]);

--- a/storia.php
+++ b/storia.php
@@ -42,6 +42,9 @@ var aziende_chiavi = JSON.parse('<?= json_encode($aziende_chiavi, JSON_HEX_TAG |
     <li class="nav-item">
         <a class="nav-link" id="nav-aziende" data-quale="aziende" href="#">Aziende</a>
     </li>
+    <li class="nav-item">
+        <a class="nav-link" href="query.php">Query</a>
+    </li>
 </ul>
 <div class="row g-2 mb-3">
     <div class="col-12 col-md-4">


### PR DESCRIPTION
## Summary
- link query management from history page
- list, search, run and edit remote queries with archive filtering
- execute remote queries by replacing parameters and calling external endpoint

## Testing
- `php -l storia.php query.php query_dettaglio.php query_execute.php includes/render_query.php`

------
https://chatgpt.com/codex/tasks/task_e_68aee1be02988331a6fc3b88d130e2c3