### PR TITLE
Replace undefined CurrentPage() reference in query_execute

### DIFF
--- a/query_execute.php
+++ b/query_execute.php
@@ -65,7 +65,7 @@ foreach($risultati as $ris)
 {
 	foreach($ris as $chiave => $valore)
 	{
-		if(($chiave!="ANNO" && $chiave!="MESE") || CurrentPage()->id_dato_remoto->CurrentValue!=10)
+                if(($chiave!="ANNO" && $chiave!="MESE") || $id != 10)
 		{
 			echo $chiave.": ".$valore."<br>";
 		}


### PR DESCRIPTION
## Summary
- avoid fatal error in query_execute.php by using `$id` parameter instead of undefined `CurrentPage()`

## Testing
- `php -l query_execute.php`


------
https://chatgpt.com/codex/tasks/task_e_68aee9a37b2c833181bbf084cb8fda39