### PR TITLE
Redirect to film detail after import

### DIFF
--- a/ajax/film_import.php
+++ b/ajax/film_import.php
@@ -5,9 +5,9 @@ include '../includes/db.php';
 header('Content-Type: application/json');
 $input = json_decode(file_get_contents('php://input'), true);
 $tmdbId = (int)($input['tmdb_id'] ?? 0);
-$dataVisto = $input['data_visto'] ?: null;
-$voto = $input['voto'] !== '' ? (float)$input['voto'] : null;
-$commento = trim($input['commento'] ?? '');
+$dataVisto = isset($input['data_visto']) && $input['data_visto'] !== '' ? $input['data_visto'] : null;
+$voto = isset($input['voto']) && $input['voto'] !== '' ? (float)$input['voto'] : null;
+$commento = isset($input['commento']) ? trim($input['commento']) : '';
 
 if (!$tmdbId) {
     echo json_encode(['success' => false, 'error' => 'ID mancante']);

--- a/js/film_aggiungi.js
+++ b/js/film_aggiungi.js
@@ -22,26 +22,18 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   function importMovie(movie) {
-    const data_visto = prompt('Data visto (YYYY-MM-DD)', '');
-    const voto = prompt('Voto (1-10, es 8.5)', '');
-    const commento = prompt('Commento', '');
     fetch('ajax/film_import.php', {
       method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({
-        tmdb_id: movie.id,
-        data_visto,
-        voto,
-        commento
-      })
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tmdb_id: movie.id })
     })
-    .then(r => r.json())
-    .then(res => {
-      if (res.success) {
-        alert('Film importato');
-      } else {
-        alert(res.error || 'Errore');
-      }
-    });
+      .then(r => r.json())
+      .then(res => {
+        if (res.success && res.id_film) {
+          window.location.href = `film_dettaglio.php?id=${res.id_film}`;
+        } else {
+          alert(res.error || 'Errore');
+        }
+      });
   }
 });


### PR DESCRIPTION
## Summary
- Redirect to `film_dettaglio.php` after importing a movie so users can immediately edit details
- Allow `ajax/film_import.php` to handle optional date, rating, and comment fields

## Testing
- `php -l ajax/film_import.php`
- `node --check js/film_aggiungi.js`


------
https://chatgpt.com/codex/tasks/task_e_68af4c3c9f408331b976f3c4dc039b62