### PR TITLE
Add film groups and comment modals

### DIFF
--- a/ajax/add_film_commento.php
+++ b/ajax/add_film_commento.php
@@ -1,0 +1,18 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:add_film_commento', 'insert')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$idFilm = (int)($_POST['id_film'] ?? 0);
+$commento = trim($_POST['commento'] ?? '');
+$idUtente = $_SESSION['utente_id'] ?? 0;
+if (!$idFilm || $commento === '' || !$idUtente) { echo json_encode(['success'=>false,'error'=>'Dati non validi']); exit; }
+$stmt = $conn->prepare('INSERT INTO film_commenti (id_film, id_utente, commento) VALUES (?,?,?)');
+$stmt->bind_param('iis', $idFilm, $idUtente, $commento);
+if ($stmt->execute()) {
+    echo json_encode(['success'=>true, 'id'=>$conn->insert_id]);
+} else {
+    echo json_encode(['success'=>false,'error'=>'Errore durante l\'inserimento']);
+}
+?>

--- a/ajax/delete_film_commento.php
+++ b/ajax/delete_film_commento.php
@@ -1,0 +1,17 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:delete_film_commento', 'delete')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$id = (int)($_POST['id'] ?? 0);
+$idUtente = $_SESSION['utente_id'] ?? 0;
+if (!$id || !$idUtente) { echo json_encode(['success'=>false,'error'=>'Dati non validi']); exit; }
+$stmt = $conn->prepare('DELETE FROM film_commenti WHERE id=? AND id_utente=?');
+$stmt->bind_param('ii', $id, $idUtente);
+if ($stmt->execute() && $stmt->affected_rows > 0) {
+    echo json_encode(['success'=>true]);
+} else {
+    echo json_encode(['success'=>false,'error'=>'Errore durante l\'eliminazione']);
+}
+?>

--- a/ajax/update_film_commento.php
+++ b/ajax/update_film_commento.php
@@ -1,0 +1,18 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:update_film_commento', 'update')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$id = (int)($_POST['id'] ?? 0);
+$commento = trim($_POST['commento'] ?? '');
+$idUtente = $_SESSION['utente_id'] ?? 0;
+if (!$id || $commento === '' || !$idUtente) { echo json_encode(['success'=>false,'error'=>'Dati non validi']); exit; }
+$stmt = $conn->prepare('UPDATE film_commenti SET commento=? WHERE id=? AND id_utente=?');
+$stmt->bind_param('sii', $commento, $id, $idUtente);
+if ($stmt->execute() && $stmt->affected_rows > 0) {
+    echo json_encode(['success'=>true]);
+} else {
+    echo json_encode(['success'=>false,'error'=>'Errore durante l\'aggiornamento']);
+}
+?>

--- a/js/film_dettaglio.js
+++ b/js/film_dettaglio.js
@@ -1,0 +1,46 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const list = document.getElementById('commentiList');
+  const form = document.getElementById('commentoForm');
+  const modalEl = document.getElementById('commentoModal');
+  const deleteBtn = document.getElementById('deleteCommentoBtn');
+  const addBtn = document.getElementById('addCommentoBtn');
+
+  addBtn?.addEventListener('click', () => {
+    form.reset();
+    form.id.value = '';
+    deleteBtn.classList.add('d-none');
+    modalEl.querySelector('.modal-title').textContent = 'Nuovo commento';
+    new bootstrap.Modal(modalEl).show();
+  });
+
+  list?.addEventListener('click', e => {
+    const row = e.target.closest('.commento-row');
+    if (row && row.dataset.utente == UTENTE_ID) {
+      form.commento.value = row.dataset.commento;
+      form.id.value = row.dataset.id;
+      deleteBtn.classList.remove('d-none');
+      modalEl.querySelector('.modal-title').textContent = 'Modifica commento';
+      new bootstrap.Modal(modalEl).show();
+    }
+  });
+
+  form?.addEventListener('submit', e => {
+    e.preventDefault();
+    const fd = new FormData(form);
+    fd.append('id_film', FILM_ID);
+    const url = fd.get('id') ? 'ajax/update_film_commento.php' : 'ajax/add_film_commento.php';
+    fetch(url, {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+
+  deleteBtn?.addEventListener('click', () => {
+    const id = form.id.value;
+    if(!id || !confirm('Eliminare questo commento?')) return;
+    const fd = new FormData();
+    fd.append('id', id);
+    fetch('ajax/delete_film_commento.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
+  });
+});

--- a/sql/add_film_gruppi.sql
+++ b/sql/add_film_gruppi.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `film_gruppi` (
+  `id_gruppo` INT NOT NULL AUTO_INCREMENT,
+  `nome` VARCHAR(100) NOT NULL,
+  `inserito_il` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `aggiornato_il` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id_gruppo`),
+  UNIQUE KEY `uq_film_gruppi_nome` (`nome`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `film`
+  ADD COLUMN `id_gruppo` INT DEFAULT NULL AFTER `lingua_originale`,
+  ADD KEY `idx_film_gruppo` (`id_gruppo`),
+  ADD CONSTRAINT `fk_film_gruppo` FOREIGN KEY (`id_gruppo`) REFERENCES `film_gruppi`(`id_gruppo`) ON DELETE SET NULL;

--- a/sql/film.sql
+++ b/sql/film.sql
@@ -1,3 +1,12 @@
+CREATE TABLE `film_gruppi` (
+  `id_gruppo` INT NOT NULL AUTO_INCREMENT,
+  `nome` VARCHAR(100) NOT NULL,
+  `inserito_il` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `aggiornato_il` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id_gruppo`),
+  UNIQUE KEY `uq_film_gruppi_nome` (`nome`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE `film` (
   `id_film` INT NOT NULL AUTO_INCREMENT,
   `tmdb_id` INT NOT NULL,
@@ -8,10 +17,13 @@ CREATE TABLE `film` (
   `trama` TEXT,
   `poster_url` VARCHAR(255) DEFAULT NULL,
   `lingua_originale` VARCHAR(10) DEFAULT NULL,
+  `id_gruppo` INT DEFAULT NULL,
   `inserito_il` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `aggiornato_il` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id_film`),
-  UNIQUE KEY `uq_film_tmdb` (`tmdb_id`)
+  UNIQUE KEY `uq_film_tmdb` (`tmdb_id`),
+  KEY `idx_film_gruppo` (`id_gruppo`),
+  CONSTRAINT `fk_film_gruppo` FOREIGN KEY (`id_gruppo`) REFERENCES `film_gruppi`(`id_gruppo`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `film_generi` (


### PR DESCRIPTION
## Summary
- Allow assigning films to global groups or trilogies
- Replace inline comments with modal-based add/edit/delete interface
- Add SQL migration and DB schema updates for film groups

## Testing
- `php -l film_dettaglio.php`
- `php -l ajax/add_film_commento.php`
- `php -l ajax/update_film_commento.php`
- `php -l ajax/delete_film_commento.php`


------
https://chatgpt.com/codex/tasks/task_e_68af58b066708331a46dc0bf201954fd