### PR TITLE
Display film duration and average rating on film list

### DIFF
--- a/includes/render_film.php
+++ b/includes/render_film.php
@@ -16,6 +16,12 @@ function render_film(array $row) {
     if (!empty($row['voto'])) {
         echo '<div class="small">Voto: ' . htmlspecialchars($row['voto']) . '</div>';
     }
+    if (!empty($row['voto_medio'])) {
+        echo '<div class="small">Voto medio: ' . htmlspecialchars($row['voto_medio']) . '</div>';
+    }
+    if (!empty($row['durata'])) {
+        echo '<div class="small">Durata: ' . (int)$row['durata'] . ' min</div>';
+    }
     if (!empty($row['data_visto'])) {
         echo '<div class="small">Visto il: ' . htmlspecialchars($row['data_visto']) . '</div>';
     }


### PR DESCRIPTION
## Summary
- Show each film's average rating and runtime in the film listing.

## Testing
- `php -l includes/render_film.php`
- `php -l film.php`


------
https://chatgpt.com/codex/tasks/task_e_68af61263800833184dfaf174b494ee1