### PR TITLE
Add modal filter interface for films

### DIFF
--- a/film.php
+++ b/film.php
@@ -6,45 +6,113 @@ include 'includes/header.php';
 
 $idUtente = $_SESSION['utente_id'] ?? 0;
 
-// Fetch films for current user with genres and group name
+// Fetch films for current user with genres, group and lists
 $stmt = $conn->prepare(
-    "SELECT f.*, fu.data_visto, fu.voto, fg.nome AS gruppo, GROUP_CONCAT(f2g.id_genere) AS generi " .
+    "SELECT f.*, fu.data_visto, fu.voto, fg.nome AS gruppo, " .
+    "GROUP_CONCAT(DISTINCT f2g.id_genere) AS generi, " .
+    "GROUP_CONCAT(DISTINCT f2l.id_lista) AS liste " .
     "FROM film f " .
     "JOIN film_utenti fu ON f.id_film = fu.id_film " .
     "LEFT JOIN film2generi f2g ON f.id_film = f2g.id_film " .
     "LEFT JOIN film_gruppi fg ON f.id_gruppo = fg.id_gruppo " .
+    "LEFT JOIN film2liste f2l ON f.id_film = f2l.id_film " .
+    "LEFT JOIN film_liste l ON f2l.id_lista = l.id_lista AND l.id_utente = ? " .
     "WHERE fu.id_utente = ? " .
     "GROUP BY f.id_film, fu.data_visto, fu.voto, fg.nome"
 );
-$stmt->bind_param('i', $idUtente);
+$stmt->bind_param('ii', $idUtente, $idUtente);
 $stmt->execute();
 $res = $stmt->get_result();
 
 $yearsRes = $conn->query("SELECT DISTINCT anno FROM film ORDER BY anno DESC");
 $generiRes = $conn->query("SELECT id_genere, nome FROM film_generi ORDER BY nome");
+$gruppiRes = $conn->query("SELECT id_gruppo, nome FROM film_gruppi ORDER BY nome");
+$stmtListe = $conn->prepare("SELECT id_lista, nome FROM film_liste WHERE id_utente=? ORDER BY nome");
+$stmtListe->bind_param('i', $idUtente);
+$stmtListe->execute();
+$listeRes = $stmtListe->get_result();
 ?>
 <div class="d-flex mb-3 justify-content-between">
   <h4>Film</h4><a href="film_aggiungi.php" class="btn btn-outline-light btn-sm">Aggiungi</a>
 </div>
 <div class="row mb-3 g-2">
-  <div class="col-sm">
+  <div class="col">
     <input type="text" id="search" class="form-control bg-dark text-white border-secondary" placeholder="Cerca">
   </div>
-  <div class="col-sm-3">
-    <select id="filterAnno" class="form-select bg-dark text-white border-secondary">
-      <option value="">Tutti gli anni</option>
-      <?php while($y = $yearsRes->fetch_assoc()): ?>
-      <option value="<?= (int)$y['anno'] ?>"><?= (int)$y['anno'] ?></option>
-      <?php endwhile; ?>
-    </select>
+  <div class="col-auto">
+    <button type="button" class="btn btn-outline-light" data-bs-toggle="modal" data-bs-target="#filtersModal">
+      <i class="bi bi-funnel"></i>
+    </button>
   </div>
-  <div class="col-sm-3">
-    <select id="filterGenere" class="form-select bg-dark text-white border-secondary">
-      <option value="">Tutti i generi</option>
-      <?php while($g = $generiRes->fetch_assoc()): ?>
-      <option value="<?= (int)$g['id_genere'] ?>"><?= htmlspecialchars($g['nome']) ?></option>
-      <?php endwhile; ?>
-    </select>
+</div>
+
+<div class="modal fade" id="filtersModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content bg-dark text-white">
+      <div class="modal-header">
+        <h5 class="modal-title">Filtri</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Chiudi"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="filterAnno" class="form-label">Anno</label>
+          <select id="filterAnno" class="form-select bg-dark text-white border-secondary">
+            <option value="">Tutti gli anni</option>
+            <?php while($y = $yearsRes->fetch_assoc()): ?>
+            <option value="<?= (int)$y['anno'] ?>"><?= (int)$y['anno'] ?></option>
+            <?php endwhile; ?>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label for="filterGenere" class="form-label">Genere</label>
+          <select id="filterGenere" class="form-select bg-dark text-white border-secondary">
+            <option value="">Tutti i generi</option>
+            <?php while($g = $generiRes->fetch_assoc()): ?>
+            <option value="<?= (int)$g['id_genere'] ?>"><?= htmlspecialchars($g['nome']) ?></option>
+            <?php endwhile; ?>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label for="filterRegista" class="form-label">Regista</label>
+          <input type="text" id="filterRegista" class="form-control bg-dark text-white border-secondary">
+        </div>
+        <div class="mb-3">
+          <label for="filterGruppo" class="form-label">Gruppo</label>
+          <select id="filterGruppo" class="form-select bg-dark text-white border-secondary">
+            <option value="">Tutti i gruppi</option>
+            <?php while($gr = $gruppiRes->fetch_assoc()): ?>
+            <option value="<?= (int)$gr['id_gruppo'] ?>"><?= htmlspecialchars($gr['nome']) ?></option>
+            <?php endwhile; ?>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label for="filterLista" class="form-label">Lista</label>
+          <select id="filterLista" class="form-select bg-dark text-white border-secondary">
+            <option value="">Tutte le liste</option>
+            <?php while($l = $listeRes->fetch_assoc()): ?>
+            <option value="<?= (int)$l['id_lista'] ?>"><?= htmlspecialchars($l['nome']) ?></option>
+            <?php endwhile; ?>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Data visione</label>
+          <div class="d-flex gap-2">
+            <input type="date" id="filterDataDa" class="form-control bg-dark text-white border-secondary" placeholder="Da">
+            <input type="date" id="filterDataA" class="form-control bg-dark text-white border-secondary" placeholder="A">
+          </div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Durata (min)</label>
+          <div class="d-flex gap-2">
+            <input type="number" id="filterDurataDa" class="form-control bg-dark text-white border-secondary" placeholder="Da">
+            <input type="number" id="filterDurataA" class="form-control bg-dark text-white border-secondary" placeholder="A">
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Chiudi</button>
+      </div>
+    </div>
   </div>
 </div>
 <div id="filmList">

--- a/includes/render_film.php
+++ b/includes/render_film.php
@@ -4,8 +4,14 @@ function render_film(array $row) {
     $searchAttr = htmlspecialchars($search, ENT_QUOTES);
     $anno = (int)($row['anno'] ?? 0);
     $generi = htmlspecialchars($row['generi'] ?? '', ENT_QUOTES);
+    $regista = strtolower($row['regista'] ?? '');
+    $registaAttr = htmlspecialchars($regista, ENT_QUOTES);
+    $gruppoId = (int)($row['id_gruppo'] ?? 0);
+    $listeAttr = htmlspecialchars($row['liste'] ?? '', ENT_QUOTES);
+    $visto = htmlspecialchars($row['data_visto'] ?? '', ENT_QUOTES);
+    $durata = (int)($row['durata'] ?? 0);
     $url = 'film_dettaglio.php?id=' . (int)($row['id_film'] ?? 0);
-    echo '<div class="film-card movement d-flex justify-content-between align-items-start text-white text-decoration-none mb-2" data-search="' . $searchAttr . '" data-anno="' . $anno . '" data-generi="' . $generi . '" onclick="window.location.href=\'' . $url . '\'">';
+    echo '<div class="film-card movement d-flex justify-content-between align-items-start text-white text-decoration-none mb-2" data-search="' . $searchAttr . '" data-anno="' . $anno . '" data-generi="' . $generi . '" data-regista="' . $registaAttr . '" data-gruppo="' . $gruppoId . '" data-liste="' . $listeAttr . '" data-visto="' . $visto . '" data-durata="' . $durata . '" onclick="window.location.href=\'' . $url . '\'">';
     if (!empty($row['poster_url'])) {
         echo '<img src="' . htmlspecialchars($row['poster_url']) . '" alt="" class="me-3" style="height:75px;">';
     }

--- a/js/film.js
+++ b/js/film.js
@@ -2,19 +2,44 @@ document.addEventListener('DOMContentLoaded', () => {
   const search = document.getElementById('search');
   const filterAnno = document.getElementById('filterAnno');
   const filterGenere = document.getElementById('filterGenere');
+  const filterRegista = document.getElementById('filterRegista');
+  const filterGruppo = document.getElementById('filterGruppo');
+  const filterLista = document.getElementById('filterLista');
+  const filterDataDa = document.getElementById('filterDataDa');
+  const filterDataA = document.getElementById('filterDataA');
+  const filterDurataDa = document.getElementById('filterDurataDa');
+  const filterDurataA = document.getElementById('filterDurataA');
   const cards = Array.from(document.querySelectorAll('.film-card'));
 
   function filter() {
     const q = search.value.trim().toLowerCase();
     const anno = filterAnno.value;
     const genere = filterGenere.value;
+    const regista = filterRegista.value.trim().toLowerCase();
+    const gruppo = filterGruppo.value;
+    const lista = filterLista.value;
+    const dataDa = filterDataDa.value;
+    const dataA = filterDataA.value;
+    const durataDa = parseInt(filterDurataDa.value || '0', 10);
+    const durataA = parseInt(filterDurataA.value || '0', 10);
+
     cards.forEach(card => {
       const text = (card.dataset.search || '');
       const matchSearch = text.includes(q);
       const matchAnno = !anno || card.dataset.anno === anno;
       const genres = (card.dataset.generi || '').split(',');
       const matchGenere = !genere || genres.includes(genere);
-      const visible = matchSearch && matchAnno && matchGenere;
+      const matchRegista = !regista || (card.dataset.regista || '').includes(regista);
+      const matchGruppo = !gruppo || card.dataset.gruppo === gruppo;
+      const liste = (card.dataset.liste || '').split(',');
+      const matchLista = !lista || liste.includes(lista);
+      const visto = card.dataset.visto || '';
+      const matchDataDa = !dataDa || (visto && visto >= dataDa);
+      const matchDataA = !dataA || (visto && visto <= dataA);
+      const durata = parseInt(card.dataset.durata || '0', 10);
+      const matchDurataDa = !filterDurataDa.value || durata >= durataDa;
+      const matchDurataA = !filterDurataA.value || durata <= durataA;
+      const visible = matchSearch && matchAnno && matchGenere && matchRegista && matchGruppo && matchLista && matchDataDa && matchDataA && matchDurataDa && matchDurataA;
       if (visible) {
         card.style.removeProperty('display');
       } else {
@@ -23,8 +48,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  search.addEventListener('input', filter);
-  filterAnno.addEventListener('input', filter);
-  filterGenere.addEventListener('input', filter);
+  [search, filterAnno, filterGenere, filterRegista, filterGruppo, filterLista, filterDataDa, filterDataA, filterDurataDa, filterDurataA].forEach(el => {
+    if (el) el.addEventListener('input', filter);
+  });
   filter();
 });


### PR DESCRIPTION
## Summary
- Fetch film groups and lists and expose metadata for filtering
- Replace inline filters with a modal containing advanced options
- Expand client-side filtering to support year, genre, director, group, list, view date range and duration

## Testing
- `php -l film.php`
- `php -l includes/render_film.php`
- `node --check js/film.js`


------
https://chatgpt.com/codex/tasks/task_e_68af63859ad88331b61e7ee41094d5d5