### PR TITLE
Allow independent receipt uploads

### DIFF
--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -1756,7 +1756,8 @@ ALTER TABLE `movimenti_revolut`
   ADD PRIMARY KEY (`id_movimento_revolut`),
   ADD KEY `idx_revolut_id_gruppo` (`id_gruppo_transazione`),
   ADD KEY `idx_revolut_id_etichetta` (`id_etichetta`),
-  ADD KEY `fk_revolut_salvadanaio` (`id_salvadanaio`);
+  ADD KEY `fk_revolut_salvadanaio` (`id_salvadanaio`),
+  ADD KEY `idx_revolut_id_caricamento` (`id_caricamento`);
 
 --
 -- Indici per le tabelle `movimenti_revolut2salvadanaio_importazione`
@@ -2494,7 +2495,8 @@ ALTER TABLE `mezzi_eventi`
 ALTER TABLE `movimenti_revolut`
   ADD CONSTRAINT `fk_revolut_etichetta` FOREIGN KEY (`id_etichetta`) REFERENCES `bilancio_etichette` (`id_etichetta`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_revolut_gruppo` FOREIGN KEY (`id_gruppo_transazione`) REFERENCES `bilancio_gruppi_transazione` (`id_gruppo_transazione`) ON DELETE SET NULL,
-  ADD CONSTRAINT `fk_revolut_salvadanaio` FOREIGN KEY (`id_salvadanaio`) REFERENCES `salvadanai` (`id_salvadanaio`) ON DELETE SET NULL;
+  ADD CONSTRAINT `fk_revolut_salvadanaio` FOREIGN KEY (`id_salvadanaio`) REFERENCES `salvadanai` (`id_salvadanaio`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_revolut_caricamento` FOREIGN KEY (`id_caricamento`) REFERENCES `ocr_caricamenti` (`id_caricamento`) ON DELETE SET NULL;
 
 --
 -- Limiti per la tabella `userlevel_permissions`

--- a/upload.php
+++ b/upload.php
@@ -1,0 +1,30 @@
+<?php
+include 'includes/session_check.php';
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <title>Carica scontrino</title>
+</head>
+<body>
+<form action="ajax/save_caricamento.php" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="id_supermercato" value="0">
+    <div>
+        <label>File scontrino: <input type="file" name="nome_file" required></label>
+    </div>
+    <div>
+        <label>Data scontrino: <input type="date" name="data_scontrino"></label>
+    </div>
+    <div>
+        <label>Totale scontrino: <input type="number" step="0.01" name="totale_scontrino"></label>
+    </div>
+    <div>
+        <label>Descrizione: <input type="text" name="descrizione"></label>
+    </div>
+    <div>
+        <button type="submit">Carica</button>
+    </div>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Permit saving receipts without specifying a movement in `ajax/save_caricamento.php`
- Add simple `upload.php` form for standalone receipt capture
- Index and FK for `id_caricamento` in `movimenti_revolut` schema

## Testing
- `php -l ajax/save_caricamento.php`
- `php -l upload.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac59e0545c83318ecf54a16dc453b4