### PR TITLE
Add upload page to utility menu and modal

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -149,7 +149,8 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
                       has_permission($conn, 'page:eventi.php', 'view') ||
                       has_permission($conn, 'page:lista_spesa.php', 'view') ||
                       has_permission($conn, 'page:storia.php', 'view') ||
-                      has_permission($conn, 'page:film.php', 'view');
+                      has_permission($conn, 'page:film.php', 'view') ||
+                      has_permission($conn, 'page:upload.php', 'view');
         if ($showUtility):
       ?>
       <li class="mb-3">
@@ -175,6 +176,9 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
             <?php endif; ?>
             <?php if (has_permission($conn, 'page:film.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/film.php"><i class="bi bi-film me-2 text-white"></i>Film</a></li>
+            <?php endif; ?>
+            <?php if (has_permission($conn, 'page:upload.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/upload.php"><i class="bi bi-cloud-upload me-2 text-white"></i>Upload</a></li>
             <?php endif; ?>
             <?php if (has_permission($conn, 'table:turni_sync_google_log', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/table_manager.php?table=turni_sync_google_log"><i class="bi bi-journal-text me-2 text-white"></i>Log sincronizzazione turni</a></li>

--- a/index.php
+++ b/index.php
@@ -173,7 +173,12 @@ if (has_permission($conn, 'page:index.php-movimenti', 'view')): ?>
           <a href="film.php" class="btn btn-outline-light w-100 text-start d-flex align-items-center">
             <i class="bi bi-film me-2"></i>Film
           </a>
-          <?php endif; ?> 
+          <?php endif; ?>
+          <?php if (has_permission($conn, 'page:upload.php', 'view')): ?>
+          <a href="upload.php" class="btn btn-outline-light w-100 text-start d-flex align-items-center">
+            <i class="bi bi-cloud-upload me-2"></i>Upload
+          </a>
+          <?php endif; ?>
           <?php if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == 1 && has_permission($conn, 'page:etichette_lista.php', 'view')): ?>
           <a href="etichette_lista.php" class="btn btn-outline-light w-100 text-start d-flex align-items-center">
             <i class="bi bi-tags me-2"></i>Etichette


### PR DESCRIPTION
## Summary
- Include `upload.php` in the Utility dropdown with permission checks.
- Add an Upload link to the "Altre funzioni" modal on the home page.

## Testing
- `php -l includes/header.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1e5dc75608331988e5ccfe052e8e4