### PR TITLE
Enable associating existing receipts to movements

### DIFF
--- a/ajax/associate_caricamento.php
+++ b/ajax/associate_caricamento.php
@@ -1,0 +1,27 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+$idMovimento = intval($input['id_movimento'] ?? 0);
+$src = $input['src'] ?? '';
+$idCaricamento = intval($input['id_caricamento'] ?? 0);
+
+$allowedSources = ['movimenti_revolut','bilancio_entrate','bilancio_uscite'];
+if (!$idMovimento || !$idCaricamento || !in_array($src, $allowedSources, true)) {
+    echo json_encode(['success' => false, 'error' => 'Parametri non validi']);
+    exit;
+}
+
+$idFields = [
+    'movimenti_revolut' => 'id_movimento_revolut',
+    'bilancio_entrate' => 'id_entrata',
+    'bilancio_uscite' => 'id_uscita',
+];
+$stmt = $conn->prepare("UPDATE $src SET id_caricamento=? WHERE {$idFields[$src]}=?");
+$stmt->bind_param('ii', $idCaricamento, $idMovimento);
+$stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => true]);

--- a/ajax/list_caricamenti.php
+++ b/ajax/list_caricamenti.php
@@ -1,0 +1,25 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$idUtente = $_SESSION['utente_id'];
+
+$sql = "SELECT id_caricamento, nome_file, data_scontrino, totale_scontrino, descrizione
+        FROM ocr_caricamenti c
+        WHERE id_utente = ?
+          AND id_caricamento NOT IN (
+            SELECT id_caricamento FROM bilancio_entrate WHERE id_caricamento IS NOT NULL
+            UNION
+            SELECT id_caricamento FROM bilancio_uscite WHERE id_caricamento IS NOT NULL
+            UNION
+            SELECT id_caricamento FROM movimenti_revolut WHERE id_caricamento IS NOT NULL
+          )
+        ORDER BY data_caricamento DESC";
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('i', $idUtente);
+$stmt->execute();
+$result = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+echo json_encode($result);


### PR DESCRIPTION
## Summary
- Let movement pages choose from unlinked receipts or upload new ones
- Add AJAX endpoints to list and associate receipt uploads
- Update movement upload UI with receipt column and modal

## Testing
- `php -l ajax/list_caricamenti.php`
- `php -l ajax/associate_caricamento.php`
- `php -l dettaglio.php`
- `php -l upload_movimenti.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1e72f4f948331ad1eb439bc067a27