### PR TITLE
Add vacation planning section with calendar integration

### DIFF
--- a/ajax/turni_get.php
+++ b/ajax/turni_get.php
@@ -64,9 +64,26 @@ while ($row = $evRes->fetch_assoc()) {
         'colore' => $row['colore'],
         'colore_testo' => $row['colore_testo'],
         'data_evento' => $row['data_evento'],
-        'data_fine' => $row['data_fine']
+        'data_fine' => $row['data_fine'],
+        'link' => 'eventi_dettaglio.php?id=' . (int)$row['id']
     ];
 }
 $evStmt->close();
+
+// Viaggi pianificati/prenotati
+$tripRes = $conn->query("SELECT titolo, data_inizio, data_fine FROM v_eventi_viaggi WHERE data_inizio <= '$end' AND COALESCE(data_fine, data_inizio) >= '$start'");
+if ($tripRes) {
+    while ($row = $tripRes->fetch_assoc()) {
+        $eventi[] = [
+            'id' => 0,
+            'titolo' => $row['titolo'],
+            'colore' => '#0dcaf0',
+            'colore_testo' => '#000000',
+            'data_evento' => $row['data_inizio'],
+            'data_fine' => $row['data_fine'],
+            'link' => null
+        ];
+    }
+}
 
 echo json_encode(['turni' => $turni, 'eventi' => $eventi]);

--- a/ajax/update_mezzo.php
+++ b/ajax/update_mezzo.php
@@ -9,6 +9,7 @@ $idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
 $id = (int)($_POST['id_mezzo'] ?? 0);
 $nome = $_POST['nome_mezzo'] ?? '';
 $data = $_POST['data_immatricolazione'] ?? '';
+$consumo = $_POST['consumo_litri_100km'] !== '' ? (float)$_POST['consumo_litri_100km'] : null;
 $attivo = isset($_POST['attivo']) ? 1 : 0;
 
 $stmt = $conn->prepare("SELECT id_utente FROM mezzi WHERE id_mezzo=? AND id_famiglia=?");
@@ -23,8 +24,8 @@ if (!$row || (int)$row['id_utente'] !== $idUtente) {
     exit;
 }
 
-$stmt = $conn->prepare("UPDATE mezzi SET nome_mezzo=?, data_immatricolazione=?, attivo=? WHERE id_mezzo=? AND id_famiglia=?");
-$stmt->bind_param('ssiii', $nome, $data, $attivo, $id, $idFamiglia);
+$stmt = $conn->prepare("UPDATE mezzi SET nome_mezzo=?, data_immatricolazione=?, consumo_litri_100km=?, attivo=? WHERE id_mezzo=? AND id_famiglia=?");
+$stmt->bind_param('ssdiii', $nome, $data, $consumo, $attivo, $id, $idFamiglia);
 $ok = $stmt->execute();
 $stmt->close();
 

--- a/js/mezzo_dettaglio.js
+++ b/js/mezzo_dettaglio.js
@@ -2,6 +2,7 @@ function openMezzoModal() {
   const form = document.getElementById('mezzoForm');
   form.nome_mezzo.value = mezzoData.nome_mezzo || '';
   form.data_immatricolazione.value = mezzoData.data_immatricolazione || '';
+  form.consumo_litri_100km.value = mezzoData.consumo_litri_100km || '';
   form.attivo.checked = mezzoData.attivo == 1;
   new bootstrap.Modal(document.getElementById('editMezzoModal')).show();
 }

--- a/js/turni.js
+++ b/js/turni.js
@@ -103,7 +103,11 @@ document.addEventListener('DOMContentLoaded', () => {
         evento.className='turno event';
         evento.style.background=ev.colore || '#6c757d';
         evento.style.color=ev.colore_testo || '#ffffff';
-        evento.innerHTML=`<a href="eventi_dettaglio.php?id=${ev.id}" class="text-decoration-none">${ev.titolo}</a>`;
+        if(ev.link){
+          evento.innerHTML=`<a href="${ev.link}" class="text-decoration-none">${ev.titolo}</a>`;
+        }else{
+          evento.textContent=ev.titolo;
+        }
         items.push({time:ev.data_evento.slice(11,19), el:evento});
       });
       items.sort((a,b)=>a.time.localeCompare(b.time));
@@ -134,7 +138,11 @@ document.addEventListener('DOMContentLoaded', () => {
           turno.style.background=ev.colore || '#6c757d';
           turno.style.color=ev.colore_testo;
           const tCol=ev.colore_testo||'#ffffff';
-          turno.innerHTML=`<a href="eventi_dettaglio.php?id=${ev.id}" class="text-decoration-none" style="color:${tCol}">${ev.titolo}</a>`;
+          if(ev.link){
+            turno.innerHTML=`<a href="${ev.link}" class="text-decoration-none" style="color:${tCol}">${ev.titolo}</a>`;
+          }else{
+            turno.textContent=ev.titolo;
+          }
           info.cell.querySelector('.turni-container').appendChild(turno);
         }
         return;
@@ -156,7 +164,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const tCol=ev.colore_testo||'#ffffff';
         bar.style.left=(startIdx/7*100)+'%';
         bar.style.width=(spanDays/7*100)+'%';
-        bar.innerHTML=`<a href="eventi_dettaglio.php?id=${ev.id}" style="color:${tCol}">${ev.titolo}</a>`;
+        if(ev.link){
+          bar.innerHTML=`<a href="${ev.link}" style="color:${tCol}">${ev.titolo}</a>`;
+        }else{
+          bar.textContent=ev.titolo;
+        }
         rowEl.appendChild(bar);
         rowEl.classList.add('multi-events');
         segStart.setDate(segEnd.getDate()+1);

--- a/mezzo_dettaglio.php
+++ b/mezzo_dettaglio.php
@@ -10,9 +10,10 @@ $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $id === 0) {
     $nome_mezzo = $_POST['nome_mezzo'] ?? '';
     $data_immatricolazione = $_POST['data_immatricolazione'] ?? '';
+    $consumo = $_POST['consumo_litri_100km'] !== '' ? (float)$_POST['consumo_litri_100km'] : null;
     $attivo = isset($_POST['attivo']) ? 1 : 0;
-    $stmt = $conn->prepare("INSERT INTO mezzi (id_utente, id_famiglia, nome_mezzo, data_immatricolazione, attivo) VALUES (?,?,?,?,?)");
-    $stmt->bind_param('iissi', $idUtente, $idFamiglia, $nome_mezzo, $data_immatricolazione, $attivo);
+    $stmt = $conn->prepare("INSERT INTO mezzi (id_utente, id_famiglia, nome_mezzo, data_immatricolazione, consumo_litri_100km, attivo) VALUES (?,?,?,?,?,?)");
+    $stmt->bind_param('iissdi', $idUtente, $idFamiglia, $nome_mezzo, $data_immatricolazione, $consumo, $attivo);
     $stmt->execute();
     $stmt->close();
     header('Location: mezzi.php');
@@ -21,6 +22,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $id === 0) {
 $data = [
     'nome_mezzo' => '',
     'data_immatricolazione' => '',
+    'consumo_litri_100km' => null,
     'attivo' => 1,
     'id_mezzo' => 0,
     'id_utente' => $idUtente
@@ -160,6 +162,10 @@ if ($id > 0): ?>
           <label class="form-label">Data immatricolazione</label>
           <input type="date" name="data_immatricolazione" class="form-control bg-secondary text-white">
         </div>
+        <div class="mb-3">
+          <label class="form-label">Consumo (L/100km)</label>
+          <input type="number" step="0.1" name="consumo_litri_100km" class="form-control bg-secondary text-white">
+        </div>
         <div class="form-check form-switch mb-3">
           <input class="form-check-input" type="checkbox" name="attivo" id="mezzoAttivo">
           <label class="form-check-label" for="mezzoAttivo">Attivo</label>
@@ -241,6 +247,7 @@ const mezzoData = {
   id: <?= (int)$data['id_mezzo'] ?>,
   nome_mezzo: <?= json_encode($data['nome_mezzo']) ?>,
   data_immatricolazione: <?= json_encode($data['data_immatricolazione']) ?>,
+  consumo_litri_100km: <?= json_encode($data['consumo_litri_100km']) ?>,
   attivo: <?= (int)$data['attivo'] ?>
 };
 </script>
@@ -259,6 +266,10 @@ const mezzoData = {
   <div class="mb-3">
     <label class="form-label">Data immatricolazione</label>
     <input type="date" name="data_immatricolazione" class="form-control bg-dark text-white border-secondary">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Consumo (L/100km)</label>
+    <input type="number" step="0.1" name="consumo_litri_100km" class="form-control bg-dark text-white border-secondary">
   </div>
   <div class="form-check form-switch mb-3">
     <input class="form-check-input" type="checkbox" id="attivo" name="attivo" checked>

--- a/sql/add_consumo_litri_100km_to_mezzi.sql
+++ b/sql/add_consumo_litri_100km_to_mezzi.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mezzi
+  ADD COLUMN consumo_litri_100km DECIMAL(5,2) DEFAULT NULL;

--- a/sql/vacanze.sql
+++ b/sql/vacanze.sql
@@ -1,0 +1,156 @@
+CREATE TABLE viaggi_luoghi (
+  id_luogo INT AUTO_INCREMENT PRIMARY KEY,
+  nome VARCHAR(100) NOT NULL,
+  citta VARCHAR(100),
+  regione VARCHAR(100),
+  paese VARCHAR(100),
+  lat DECIMAL(9,6),
+  lng DECIMAL(9,6),
+  url_maps VARCHAR(255),
+  sito_web VARCHAR(255),
+  note_apertura TEXT,
+  note TEXT,
+  creato_il DATETIME DEFAULT CURRENT_TIMESTAMP,
+  aggiornato_il DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE viaggi (
+  id_viaggio INT AUTO_INCREMENT PRIMARY KEY,
+  titolo VARCHAR(150) NOT NULL,
+  id_luogo INT,
+  data_inizio DATE,
+  data_fine DATE,
+  notti INT,
+  persone INT,
+  stato ENUM('idea','shortlist','pianificato','prenotato','fatto','scartato') DEFAULT 'idea',
+  priorita TINYINT,
+  visibilita ENUM('private','shared','public') DEFAULT 'private',
+  token_condivisione CHAR(22),
+  note TEXT,
+  meteo_previsto_json JSON,
+  meteo_aggiornato_il DATETIME,
+  creato_il DATETIME DEFAULT CURRENT_TIMESTAMP,
+  aggiornato_il DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (id_luogo) REFERENCES viaggi_luoghi(id_luogo)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE viaggi_tratte (
+  id_tratta INT AUTO_INCREMENT PRIMARY KEY,
+  id_viaggio INT NOT NULL,
+  gruppo_alternativa VARCHAR(40),
+  tipo_tratta ENUM('auto','aereo','traghetto','treno') NOT NULL,
+  descrizione TEXT,
+  origine_testo VARCHAR(255),
+  origine_lat DECIMAL(9,6),
+  origine_lng DECIMAL(9,6),
+  destinazione_testo VARCHAR(255),
+  destinazione_lat DECIMAL(9,6),
+  destinazione_lng DECIMAL(9,6),
+  distanza_km DECIMAL(8,2),
+  durata_ore DECIMAL(5,2),
+  consumo_litri_100km DECIMAL(5,2),
+  prezzo_carburante_eur_litro DECIMAL(5,3),
+  pedaggi_eur DECIMAL(10,2),
+  costo_traghetto_eur DECIMAL(10,2),
+  costo_volo_eur DECIMAL(10,2),
+  costo_noleggio_eur DECIMAL(10,2),
+  altri_costi_eur DECIMAL(10,2),
+  note TEXT,
+  FOREIGN KEY (id_viaggio) REFERENCES viaggi(id_viaggio)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE viaggi_alloggi (
+  id_alloggio INT AUTO_INCREMENT PRIMARY KEY,
+  id_viaggio INT NOT NULL,
+  gruppo_alternativa VARCHAR(40),
+  giorno_indice INT,
+  nome_alloggio VARCHAR(255),
+  indirizzo VARCHAR(255),
+  lat DECIMAL(9,6),
+  lng DECIMAL(9,6),
+  data_checkin DATE,
+  data_checkout DATE,
+  costo_notte_eur DECIMAL(10,2),
+  note TEXT,
+  FOREIGN KEY (id_viaggio) REFERENCES viaggi(id_viaggio)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE viaggi_etichette (
+  id_etichetta INT AUTO_INCREMENT PRIMARY KEY,
+  nome VARCHAR(100) UNIQUE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE viaggi2etichette (
+  id_viaggio INT NOT NULL,
+  id_etichetta INT NOT NULL,
+  PRIMARY KEY (id_viaggio, id_etichetta),
+  FOREIGN KEY (id_viaggio) REFERENCES viaggi(id_viaggio) ON DELETE CASCADE,
+  FOREIGN KEY (id_etichetta) REFERENCES viaggi_etichette(id_etichetta) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE viaggi_checklist (
+  id_checklist INT AUTO_INCREMENT PRIMARY KEY,
+  id_viaggio INT NOT NULL,
+  voce VARCHAR(255) NOT NULL,
+  completata TINYINT(1) DEFAULT 0,
+  FOREIGN KEY (id_viaggio) REFERENCES viaggi(id_viaggio) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE viaggi_feedback (
+  id_feedback INT AUTO_INCREMENT PRIMARY KEY,
+  id_viaggio INT NOT NULL,
+  id_utente INT,
+  voto TINYINT,
+  commento TEXT,
+  creato_il DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (id_viaggio) REFERENCES viaggi(id_viaggio) ON DELETE CASCADE,
+  FOREIGN KEY (id_utente) REFERENCES utenti(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE viaggi2caricamenti (
+  id_viaggio INT NOT NULL,
+  id_caricamento INT NOT NULL,
+  PRIMARY KEY (id_viaggio, id_caricamento),
+  FOREIGN KEY (id_viaggio) REFERENCES viaggi(id_viaggio) ON DELETE CASCADE,
+  FOREIGN KEY (id_caricamento) REFERENCES ocr_caricamenti(id_caricamento)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE VIEW v_totali_alternative AS
+SELECT
+  vt.id_viaggio,
+  vt.gruppo_alternativa,
+  SUM(
+    (COALESCE(vt.distanza_km,0) * COALESCE(vt.consumo_litri_100km,0) / 100) * COALESCE(vt.prezzo_carburante_eur_litro,0)
+    + COALESCE(vt.pedaggi_eur,0)
+    + COALESCE(vt.costo_traghetto_eur,0)
+    + COALESCE(vt.costo_volo_eur,0)
+    + COALESCE(vt.costo_noleggio_eur,0)
+    + COALESCE(vt.altri_costi_eur,0)
+  ) AS totale_trasporti,
+  (
+    SELECT COALESCE(SUM(DATEDIFF(va.data_checkout, va.data_checkin) * COALESCE(va.costo_notte_eur,0)),0)
+    FROM viaggi_alloggi va
+    WHERE va.id_viaggio = vt.id_viaggio AND va.gruppo_alternativa = vt.gruppo_alternativa
+  ) AS totale_alloggi,
+  (
+    SUM(
+      (COALESCE(vt.distanza_km,0) * COALESCE(vt.consumo_litri_100km,0) / 100) * COALESCE(vt.prezzo_carburante_eur_litro,0)
+      + COALESCE(vt.pedaggi_eur,0)
+      + COALESCE(vt.costo_traghetto_eur,0)
+      + COALESCE(vt.costo_volo_eur,0)
+      + COALESCE(vt.costo_noleggio_eur,0)
+      + COALESCE(vt.altri_costi_eur,0)
+    )
+    + (
+      SELECT COALESCE(SUM(DATEDIFF(va.data_checkout, va.data_checkin) * COALESCE(va.costo_notte_eur,0)),0)
+      FROM viaggi_alloggi va
+      WHERE va.id_viaggio = vt.id_viaggio AND va.gruppo_alternativa = vt.gruppo_alternativa
+    )
+  ) AS totale_viaggio
+FROM viaggi_tratte vt
+GROUP BY vt.id_viaggio, vt.gruppo_alternativa;
+
+CREATE VIEW v_eventi_viaggi AS
+SELECT v.titolo, v.data_inizio, v.data_fine
+FROM viaggi v
+WHERE v.stato IN ('pianificato','prenotato');

--- a/vacanze.php
+++ b/vacanze.php
@@ -1,0 +1,59 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+include 'includes/header.php';
+
+$stato = $_GET['stato'] ?? '';
+$budget = $_GET['budget_max'] ?? '';
+$query = "SELECT v.*, t.min_totale FROM viaggi v LEFT JOIN (SELECT id_viaggio, MIN(totale_viaggio) AS min_totale FROM v_totali_alternative GROUP BY id_viaggio) t ON v.id_viaggio=t.id_viaggio WHERE 1=1";
+$params = [];
+$types = '';
+if ($stato !== '') { $query .= " AND v.stato = ?"; $types .= 's'; $params[] = $stato; }
+if ($budget !== '') { $query .= " AND (t.min_totale IS NULL OR t.min_totale <= ?)"; $types .= 'd'; $params[] = $budget; }
+$query .= " ORDER BY v.data_inizio DESC";
+$stmt = $conn->prepare($query);
+if ($types) { $stmt->bind_param($types, ...$params); }
+$stmt->execute();
+$res = $stmt->get_result();
+?>
+<div class="container text-white">
+  <div class="d-flex mb-3 justify-content-between">
+    <h4>Vacanze</h4>
+    <a href="vacanze_modifica.php" class="btn btn-outline-light btn-sm">Nuovo</a>
+  </div>
+  <form class="mb-3" method="get">
+    <div class="row g-2">
+      <div class="col">
+        <select name="stato" class="form-select bg-dark text-white border-secondary">
+          <option value="">Stato</option>
+          <?php foreach(['idea','shortlist','pianificato','prenotato','fatto','scartato'] as $s): ?>
+            <option value="<?= $s ?>" <?= $stato===$s?'selected':'' ?>><?= ucfirst($s) ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="col">
+        <input type="number" step="0.01" name="budget_max" value="<?= htmlspecialchars($budget) ?>" class="form-control bg-dark text-white border-secondary" placeholder="Budget max €">
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary w-100">Filtra</button>
+      </div>
+    </div>
+    <!-- Filtri aggiuntivi: regione, durata, etichette -->
+  </form>
+  <div class="row row-cols-1 g-3">
+    <?php while($row = $res->fetch_assoc()): ?>
+    <div class="col">
+      <div class="card bg-dark text-white">
+        <div class="card-body">
+          <h5 class="card-title"><a href="vacanze_view.php?id=<?= (int)$row['id_viaggio'] ?>" class="text-white text-decoration-none"><?= htmlspecialchars($row['titolo']) ?></a></h5>
+          <p class="card-text small mb-1"><?= htmlspecialchars($row['data_inizio']) ?> - <?= htmlspecialchars($row['data_fine']) ?></p>
+          <?php if(isset($row['min_totale'])): ?>
+          <p class="card-text">Miglior totale: €<?= number_format($row['min_totale'],2,',','.') ?></p>
+          <?php endif; ?>
+        </div>
+      </div>
+    </div>
+    <?php endwhile; ?>
+  </div>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/vacanze_modifica.php
+++ b/vacanze_modifica.php
@@ -1,0 +1,71 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+include 'includes/header.php';
+
+// Default carburante modificabili qui
+$DEFAULT_CONSUMO = 7.0; // L/100km
+$DEFAULT_PREZZO = 1.8; // €/L
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id = (int)($_POST['id_viaggio'] ?? 0);
+    $titolo = $_POST['titolo'] ?? '';
+    $data_inizio = $_POST['data_inizio'] ?? null;
+    $data_fine = $_POST['data_fine'] ?? null;
+    $stato = $_POST['stato'] ?? 'idea';
+    if ($id > 0) {
+        $stmt = $conn->prepare('UPDATE viaggi SET titolo=?, data_inizio=?, data_fine=?, stato=? WHERE id_viaggio=?');
+        $stmt->bind_param('ssssi', $titolo, $data_inizio, $data_fine, $stato, $id);
+    } else {
+        $stmt = $conn->prepare('INSERT INTO viaggi (titolo, data_inizio, data_fine, stato) VALUES (?,?,?,?)');
+        $stmt->bind_param('ssss', $titolo, $data_inizio, $data_fine, $stato);
+    }
+    $stmt->execute();
+    $id = $id ?: $stmt->insert_id;
+    header('Location: vacanze_view.php?id=' . $id);
+    exit;
+}
+
+$data = ['titolo' => '', 'data_inizio' => '', 'data_fine' => '', 'stato' => 'idea'];
+if ($id > 0) {
+    $stmt = $conn->prepare('SELECT * FROM viaggi WHERE id_viaggio=?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($res && $res->num_rows > 0) {
+        $data = $res->fetch_assoc();
+    }
+}
+?>
+<div class="container text-white">
+  <a href="javascript:history.back()" class="btn btn-outline-light mb-3">← Indietro</a>
+  <h4 class="mb-3"><?= $id > 0 ? 'Modifica viaggio' : 'Nuovo viaggio' ?></h4>
+  <form method="post" class="bg-dark p-3 rounded">
+    <input type="hidden" name="id_viaggio" value="<?= (int)$id ?>">
+    <div class="mb-3">
+      <label class="form-label">Titolo</label>
+      <input type="text" name="titolo" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['titolo']) ?>" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Data inizio</label>
+      <input type="date" name="data_inizio" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['data_inizio']) ?>">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Data fine</label>
+      <input type="date" name="data_fine" class="form-control bg-dark text-white border-secondary" value="<?= htmlspecialchars($data['data_fine']) ?>">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Stato</label>
+      <select name="stato" class="form-select bg-dark text-white border-secondary">
+        <?php foreach(['idea','shortlist','pianificato','prenotato','fatto','scartato'] as $s): ?>
+        <option value="<?= $s ?>" <?= $data['stato']===$s?'selected':'' ?>><?= ucfirst($s) ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <button class="btn btn-primary w-100">Salva</button>
+  </form>
+  <p class="mt-4 small">Modificare i valori predefiniti di consumo (<?= $DEFAULT_CONSUMO ?> L/100km) e prezzo carburante (<?= $DEFAULT_PREZZO ?> €/L) modificando le variabili all'inizio di questo file.</p>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/vacanze_share.php
+++ b/vacanze_share.php
@@ -1,0 +1,35 @@
+<?php
+include 'includes/db.php';
+include 'includes/header.php';
+
+$token = $_GET['t'] ?? '';
+$stmt = $conn->prepare('SELECT * FROM viaggi WHERE token_condivisione=? AND visibilita="shared"');
+$stmt->bind_param('s', $token);
+$stmt->execute();
+$res = $stmt->get_result();
+$viaggio = $res->fetch_assoc();
+if (!$viaggio) {
+    echo '<p class="text-danger">Viaggio non trovato</p>';
+    include 'includes/footer.php';
+    exit;
+}
+$id = $viaggio['id_viaggio'];
+$totStmt = $conn->prepare('SELECT * FROM v_totali_alternative WHERE id_viaggio=?');
+$totStmt->bind_param('i', $id);
+$totStmt->execute();
+$totRes = $totStmt->get_result();
+$totali = [];
+while ($row = $totRes->fetch_assoc()) { $totali[$row['gruppo_alternativa']] = $row; }
+?>
+<div class="container text-white">
+  <h4 class="mb-3"><?= htmlspecialchars($viaggio['titolo']) ?></h4>
+  <?php foreach ($totali as $grp => $t): ?>
+    <div class="mb-3">
+      <h6><?= htmlspecialchars($grp) ?></h6>
+      <div class="small">Trasporti: €<?= number_format($t['totale_trasporti'], 2, ',', '.') ?></div>
+      <div class="small">Alloggi: €<?= number_format($t['totale_alloggi'], 2, ',', '.') ?></div>
+      <div class="fw-bold">Totale: €<?= number_format($t['totale_viaggio'], 2, ',', '.') ?></div>
+    </div>
+  <?php endforeach; ?>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/vacanze_view.php
+++ b/vacanze_view.php
@@ -1,0 +1,62 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+include 'includes/header.php';
+
+$id = (int)($_GET['id'] ?? 0);
+$stmt = $conn->prepare('SELECT * FROM viaggi WHERE id_viaggio=?');
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$res = $stmt->get_result();
+$viaggio = $res->fetch_assoc();
+if (!$viaggio) {
+    echo '<p class="text-danger">Viaggio non trovato</p>';
+    include 'includes/footer.php';
+    exit;
+}
+
+$totStmt = $conn->prepare('SELECT * FROM v_totali_alternative WHERE id_viaggio=?');
+$totStmt->bind_param('i', $id);
+$totStmt->execute();
+$totRes = $totStmt->get_result();
+$totali = [];
+while ($row = $totRes->fetch_assoc()) { $totali[$row['gruppo_alternativa']] = $row; }
+?>
+<div class="container text-white">
+  <a href="vacanze.php" class="btn btn-outline-light mb-3">← Indietro</a>
+  <h4 class="mb-3"><?= htmlspecialchars($viaggio['titolo']) ?>
+    <a href="vacanze_modifica.php?id=<?= $id ?>" class="text-white ms-2"><i class="bi bi-pencil"></i></a>
+  </h4>
+  <ul class="nav nav-tabs" id="vacTabs" role="tablist">
+    <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabAlt">Alternative</button></li>
+    <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabCheck">Checklist</button></li>
+    <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabFeed">Feedback</button></li>
+    <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabDoc">Documenti</button></li>
+  </ul>
+  <div class="tab-content border border-top-0 p-3">
+    <div class="tab-pane fade show active" id="tabAlt">
+      <?php if (empty($totali)): ?>
+        <p class="text-muted">Nessuna alternativa.</p>
+      <?php else: ?>
+        <?php foreach ($totali as $grp => $t): ?>
+          <div class="mb-3">
+            <h6><?= htmlspecialchars($grp) ?></h6>
+            <div class="small">Trasporti: €<?= number_format($t['totale_trasporti'], 2, ',', '.') ?></div>
+            <div class="small">Alloggi: €<?= number_format($t['totale_alloggi'], 2, ',', '.') ?></div>
+            <div class="fw-bold">Totale: €<?= number_format($t['totale_viaggio'], 2, ',', '.') ?></div>
+          </div>
+        <?php endforeach; ?>
+      <?php endif; ?>
+    </div>
+    <div class="tab-pane fade" id="tabCheck">
+      <p class="text-muted">Checklist in arrivo.</p>
+    </div>
+    <div class="tab-pane fade" id="tabFeed">
+      <p class="text-muted">Feedback non disponibili.</p>
+    </div>
+    <div class="tab-pane fade" id="tabDoc">
+      <p class="text-muted">Nessun documento allegato.</p>
+    </div>
+  </div>
+</div>
+<?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add database tables and views for trip planning and cost estimation
- extend vehicle records with fuel consumption field and editing UI
- introduce mobile-first vacation pages and expose trips in calendar

## Testing
- `php -l vacanze.php`
- `php -l vacanze_modifica.php`
- `php -l vacanze_view.php`
- `php -l vacanze_share.php`
- `php -l mezzo_dettaglio.php`
- `php -l ajax/update_mezzo.php`
- `php -l ajax/turni_get.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1e975dc48833187feb32b853cae2d