### PR TITLE
Add Vacanze to utility menu and Altro modal

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -150,6 +150,7 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
                       has_permission($conn, 'page:lista_spesa.php', 'view') ||
                       has_permission($conn, 'page:storia.php', 'view') ||
                       has_permission($conn, 'page:film.php', 'view') ||
+                      has_permission($conn, 'page:vacanze.php', 'view') ||
                       has_permission($conn, 'page:upload.php', 'view');
         if ($showUtility):
       ?>
@@ -176,6 +177,9 @@ $conn->set_charset('utf8mb4'); // IMPORTANTISSIMO
             <?php endif; ?>
             <?php if (has_permission($conn, 'page:film.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/film.php"><i class="bi bi-film me-2 text-white"></i>Film</a></li>
+            <?php endif; ?>
+            <?php if (has_permission($conn, 'page:vacanze.php', 'view')): ?>
+            <li><a class="dropdown-item text-white" href="/Gestionale25/vacanze.php"><i class="bi bi-airplane me-2 text-white"></i>Vacanze</a></li>
             <?php endif; ?>
             <?php if (has_permission($conn, 'page:upload.php', 'view')): ?>
             <li><a class="dropdown-item text-white" href="/Gestionale25/upload.php"><i class="bi bi-cloud-upload me-2 text-white"></i>Upload</a></li>

--- a/index.php
+++ b/index.php
@@ -174,6 +174,11 @@ if (has_permission($conn, 'page:index.php-movimenti', 'view')): ?>
             <i class="bi bi-film me-2"></i>Film
           </a>
           <?php endif; ?>
+          <?php if (has_permission($conn, 'page:vacanze.php', 'view')): ?>
+          <a href="vacanze.php" class="btn btn-outline-light w-100 text-start d-flex align-items-center">
+            <i class="bi bi-airplane me-2"></i>Vacanze
+          </a>
+          <?php endif; ?>
           <?php if (has_permission($conn, 'page:upload.php', 'view')): ?>
           <a href="upload.php" class="btn btn-outline-light w-100 text-start d-flex align-items-center">
             <i class="bi bi-cloud-upload me-2"></i>Upload


### PR DESCRIPTION
## Summary
- Expose Vacanze page in the Utility dropdown
- Add Vacanze option to the "Altro" modal on the dashboard

## Testing
- `php -l index.php includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b209c632e48331b9045c25bb8d8c6e