### PR TITLE
Add interactive vacation checklist page

### DIFF
--- a/ajax/add_viaggi_checklist_message.php
+++ b/ajax/add_viaggi_checklist_message.php
@@ -1,0 +1,15 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:add_viaggi_checklist_message', 'insert')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$idChecklist = (int)($_POST['id_checklist'] ?? 0);
+$messaggio = trim($_POST['messaggio'] ?? '');
+$idUtente = $_SESSION['id'] ?? 0;
+if (!$idChecklist || $messaggio === '' || !$idUtente) { echo json_encode(['success'=>false,'error'=>'Dati non validi']); exit; }
+$stmt = $conn->prepare('INSERT INTO viaggi_checklist_messaggi (id_checklist, id_utente, messaggio) VALUES (?,?,?)');
+$stmt->bind_param('iis', $idChecklist, $idUtente, $messaggio);
+$ok = $stmt->execute();
+echo json_encode(['success'=>$ok]);
+?>

--- a/ajax/get_viaggi_checklist_messages.php
+++ b/ajax/get_viaggi_checklist_messages.php
@@ -1,0 +1,18 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:get_viaggi_checklist_messages', 'view')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$id = (int)($_GET['id_checklist'] ?? 0);
+if (!$id) { echo json_encode(['success'=>false,'error'=>'ID mancante']); exit; }
+$stmt = $conn->prepare('SELECT vcm.id_messaggio, vcm.messaggio, vcm.creato_il, u.username FROM viaggi_checklist_messaggi vcm LEFT JOIN utenti u ON vcm.id_utente=u.id WHERE vcm.id_checklist=? ORDER BY vcm.creato_il');
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$res = $stmt->get_result();
+$messages = [];
+while ($r = $res->fetch_assoc()) {
+    $messages[] = ['id'=>$r['id_messaggio'], 'messaggio'=>$r['messaggio'], 'username'=>$r['username'], 'creato_il'=>$r['creato_il']];
+}
+echo json_encode(['success'=>true,'messages'=>$messages]);
+?>

--- a/ajax/update_viaggi_checklist.php
+++ b/ajax/update_viaggi_checklist.php
@@ -1,0 +1,28 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:update_viaggi_checklist', 'update')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$id = (int)($_POST['id'] ?? 0);
+if (!$id) { echo json_encode(['success'=>false,'error'=>'ID mancante']); exit; }
+if (isset($_POST['completata'])) {
+    $completata = $_POST['completata'] == '1' ? 1 : 0;
+    $stmt = $conn->prepare('UPDATE viaggi_checklist SET completata=? WHERE id_checklist=?');
+    $stmt->bind_param('ii', $completata, $id);
+} elseif (isset($_POST['id_utente'])) {
+    if ($_POST['id_utente'] === '') {
+        $stmt = $conn->prepare('UPDATE viaggi_checklist SET id_utente=NULL WHERE id_checklist=?');
+        $stmt->bind_param('i', $id);
+    } else {
+        $idUtente = (int)$_POST['id_utente'];
+        $stmt = $conn->prepare('UPDATE viaggi_checklist SET id_utente=? WHERE id_checklist=?');
+        $stmt->bind_param('ii', $idUtente, $id);
+    }
+} else {
+    echo json_encode(['success'=>false,'error'=>'Dati non validi']);
+    exit;
+}
+$ok = $stmt->execute();
+echo json_encode(['success'=>$ok]);
+?>

--- a/js/vacanze_checklist.js
+++ b/js/vacanze_checklist.js
@@ -1,0 +1,73 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.checklist-checkbox').forEach(chk => {
+    chk.addEventListener('change', e => {
+      const id = chk.dataset.id;
+      const fd = new FormData();
+      fd.append('id', id);
+      fd.append('completata', chk.checked ? 1 : 0);
+      fetch('ajax/update_viaggi_checklist.php', { method:'POST', body:fd })
+        .then(r => r.json())
+        .then(res => { if(!res.success){ alert(res.error || 'Errore'); } });
+    });
+  });
+
+  document.querySelectorAll('.checklist-user').forEach(sel => {
+    sel.addEventListener('change', e => {
+      const id = sel.dataset.id;
+      const fd = new FormData();
+      fd.append('id', id);
+      fd.append('id_utente', sel.value);
+      fetch('ajax/update_viaggi_checklist.php', { method:'POST', body:fd })
+        .then(r => r.json())
+        .then(res => { if(!res.success){ alert(res.error || 'Errore'); } });
+    });
+  });
+
+  document.querySelectorAll('.collapse').forEach(col => {
+    col.addEventListener('shown.bs.collapse', () => {
+      const msgBox = col.querySelector('.checklist-chat-messages');
+      const id = msgBox.dataset.id;
+      loadMessages(id);
+    });
+  });
+
+  document.querySelectorAll('.checklist-chat-send').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.dataset.id;
+      const input = document.querySelector('.checklist-chat-input[data-id="'+id+'"]');
+      const text = input.value.trim();
+      if(!text) return;
+      const fd = new FormData();
+      fd.append('id_checklist', id);
+      fd.append('messaggio', text);
+      fetch('ajax/add_viaggi_checklist_message.php', { method:'POST', body:fd })
+        .then(r => r.json())
+        .then(res => {
+          if(res.success){
+            input.value='';
+            loadMessages(id);
+          } else {
+            alert(res.error || 'Errore');
+          }
+        });
+    });
+  });
+
+  function loadMessages(id){
+    fetch('ajax/get_viaggi_checklist_messages.php?id_checklist='+id)
+      .then(r => r.json())
+      .then(res => {
+        if(res.success){
+          const box = document.querySelector('.checklist-chat-messages[data-id="'+id+'"]');
+          if(!box) return;
+          box.innerHTML = '';
+          res.messages.forEach(m => {
+            const div = document.createElement('div');
+            div.className = 'small';
+            div.textContent = m.username + ': ' + m.messaggio;
+            box.appendChild(div);
+          });
+        }
+      });
+  }
+});

--- a/sql/vacanze.sql
+++ b/sql/vacanze.sql
@@ -95,7 +95,19 @@ CREATE TABLE viaggi_checklist (
   id_viaggio INT NOT NULL,
   voce VARCHAR(255) NOT NULL,
   completata TINYINT(1) DEFAULT 0,
-  FOREIGN KEY (id_viaggio) REFERENCES viaggi(id_viaggio) ON DELETE CASCADE
+  id_utente INT,
+  FOREIGN KEY (id_viaggio) REFERENCES viaggi(id_viaggio) ON DELETE CASCADE,
+  FOREIGN KEY (id_utente) REFERENCES utenti(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE viaggi_checklist_messaggi (
+  id_messaggio INT AUTO_INCREMENT PRIMARY KEY,
+  id_checklist INT NOT NULL,
+  id_utente INT NOT NULL,
+  messaggio TEXT NOT NULL,
+  creato_il DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (id_checklist) REFERENCES viaggi_checklist(id_checklist) ON DELETE CASCADE,
+  FOREIGN KEY (id_utente) REFERENCES utenti(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE viaggi_feedback (

--- a/vacanze_checklist.php
+++ b/vacanze_checklist.php
@@ -1,0 +1,70 @@
+<?php include 'includes/session_check.php'; ?>
+<?php
+include 'includes/db.php';
+include 'includes/header.php';
+
+$id = (int)($_GET['id'] ?? 0);
+$stmt = $conn->prepare('SELECT titolo FROM viaggi WHERE id_viaggio=?');
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$viaggio = $stmt->get_result()->fetch_assoc();
+if (!$viaggio) {
+    echo '<p class="text-danger">Viaggio non trovato</p>';
+    include 'includes/footer.php';
+    exit;
+}
+
+$chkStmt = $conn->prepare('SELECT vc.id_checklist, vc.voce, vc.completata, vc.id_utente, u.username FROM viaggi_checklist vc LEFT JOIN utenti u ON vc.id_utente=u.id WHERE vc.id_viaggio=? ORDER BY vc.id_checklist');
+$chkStmt->bind_param('i', $id);
+$chkStmt->execute();
+$chkRes = $chkStmt->get_result();
+
+$userRes = $conn->query('SELECT id, username FROM utenti ORDER BY username');
+$users = $userRes ? $userRes->fetch_all(MYSQLI_ASSOC) : [];
+?>
+<div class="container text-white">
+  <a href="vacanze_view.php?id=<?= $id ?>" class="btn btn-outline-light mb-3">← Indietro</a>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="vacanze.php">Vacanze</a></li>
+      <li class="breadcrumb-item"><a href="vacanze_view.php?id=<?= $id ?>"><?= htmlspecialchars($viaggio['titolo']) ?></a></li>
+      <li class="breadcrumb-item active" aria-current="page">Checklist</li>
+    </ol>
+  </nav>
+  <div class="d-flex justify-content-between mb-3">
+    <h4 class="m-0">Checklist</h4>
+    <a class="btn btn-sm btn-outline-light" href="table_manager.php?table=viaggi_checklist&id_viaggio=<?= $id ?>">Aggiungi</a>
+  </div>
+  <?php if ($chkRes->num_rows === 0): ?>
+    <p class="text-muted">Nessuna voce.</p>
+  <?php else: ?>
+    <ul class="list-group list-group-flush" id="checklistList">
+      <?php while ($row = $chkRes->fetch_assoc()): ?>
+        <li class="list-group-item bg-dark text-white">
+          <div class="d-flex justify-content-between align-items-center">
+            <div>
+              <input type="checkbox" class="form-check-input me-2 checklist-checkbox" data-id="<?= $row['id_checklist'] ?>" <?= $row['completata'] ? 'checked' : '' ?>>
+              <?= htmlspecialchars($row['voce']) ?>
+              <select class="form-select form-select-sm d-inline-block w-auto ms-2 checklist-user" data-id="<?= $row['id_checklist'] ?>">
+                <option value="">--</option>
+                <?php foreach ($users as $u): ?>
+                  <option value="<?= $u['id'] ?>" <?= ($row['id_utente'] == $u['id']) ? 'selected' : '' ?>><?= htmlspecialchars($u['username']) ?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <button class="btn btn-sm btn-outline-light" data-bs-toggle="collapse" data-bs-target="#chat<?= $row['id_checklist'] ?>">Chat</button>
+          </div>
+          <div class="collapse mt-2" id="chat<?= $row['id_checklist'] ?>">
+            <div class="checklist-chat-messages mb-2" data-id="<?= $row['id_checklist'] ?>"></div>
+            <div class="input-group input-group-sm">
+              <input type="text" class="form-control bg-dark text-white checklist-chat-input" data-id="<?= $row['id_checklist'] ?>" placeholder="Messaggio">
+              <button class="btn btn-outline-light checklist-chat-send" data-id="<?= $row['id_checklist'] ?>">Invia</button>
+            </div>
+          </div>
+        </li>
+      <?php endwhile; ?>
+    </ul>
+  <?php endif; ?>
+</div>
+<script src="js/vacanze_checklist.js"></script>
+<?php include 'includes/footer.php'; ?>

--- a/vacanze_view.php
+++ b/vacanze_view.php
@@ -37,6 +37,12 @@ $chkStmt = $conn->prepare('SELECT id_checklist, voce, completata FROM viaggi_che
 $chkStmt->bind_param('i', $id);
 $chkStmt->execute();
 $chkRes = $chkStmt->get_result();
+$chkRows = $chkRes->fetch_all(MYSQLI_ASSOC);
+$totChecklist = count($chkRows);
+$totChecklistDone = 0;
+foreach ($chkRows as $r) {
+    if (!empty($r['completata'])) { $totChecklistDone++; }
+}
 
 // Feedback
 $fbStmt = $conn->prepare('SELECT vf.id_feedback, vf.voto, vf.commento, u.username FROM viaggi_feedback vf LEFT JOIN utenti u ON vf.id_utente=u.id WHERE vf.id_viaggio=? ORDER BY vf.id_feedback');
@@ -74,12 +80,11 @@ $docRes = $docStmt->get_result();
               <div class="p-2 border rounded h-100">
                 <h6 class="mb-1"><?= htmlspecialchars($grp) ?></h6>
                 <?php foreach (($tratte[$grp] ?? []) as $tr): ?>
-                  <div class="small text-muted">
-                    <?= htmlspecialchars(ucfirst($tr['tipo_tratta'])) ?>
-                    <?php if ($tr['origine_testo'] || $tr['destinazione_testo']): ?>:
+                  <?php if ($tr['origine_testo'] || $tr['destinazione_testo']): ?>
+                    <div class="small text-muted">
                       <?= htmlspecialchars($tr['origine_testo'] ?? '') ?> → <?= htmlspecialchars($tr['destinazione_testo'] ?? '') ?>
-                    <?php endif; ?>
-                  </div>
+                    </div>
+                  <?php endif; ?>
                 <?php endforeach; ?>
                 <div class="small">Trasporti: €<?= number_format($t['totale_trasporti'], 2, ',', '.') ?></div>
                 <div class="small">Alloggi: €<?= number_format($t['totale_alloggi'], 2, ',', '.') ?></div>
@@ -97,19 +102,15 @@ $docRes = $docStmt->get_result();
       <h5 class="m-0">Checklist</h5>
       <a href="table_manager.php?table=viaggi_checklist&id_viaggio=<?= $id ?>" class="btn btn-sm btn-outline-light">Aggiungi</a>
     </div>
-    <?php if ($chkRes->num_rows === 0): ?>
+    <?php if ($totChecklist === 0): ?>
       <p class="text-muted">Nessuna voce.</p>
     <?php else: ?>
-      <ul class="list-group list-group-flush">
-        <?php while ($row = $chkRes->fetch_assoc()): ?>
-          <li class="list-group-item bg-dark text-white p-0">
-            <a href="table_manager.php?table=viaggi_checklist&search=<?= (int)$row['id_checklist'] ?>&id_viaggio=<?= $id ?>" class="d-flex justify-content-between align-items-center text-white text-decoration-none p-2">
-              <span><?= htmlspecialchars($row['voce']) ?></span>
-              <?php if ($row['completata']): ?><i class="bi bi-check2"></i><?php endif; ?>
-            </a>
-          </li>
-        <?php endwhile; ?>
-      </ul>
+      <a href="vacanze_checklist.php?id=<?= $id ?>" class="text-decoration-none text-white">
+        <div class="p-2 border rounded">
+          <div class="small">Voci totali: <?= $totChecklist ?></div>
+          <div class="small">Completate: <?= $totChecklistDone ?></div>
+        </div>
+      </a>
     <?php endif; ?>
   </div>
 


### PR DESCRIPTION
## Summary
- Hide transport type in vacation view
- Show checklist summary and link to detailed view
- Provide checklist page with completion toggle, assignee selection and per-item chat

## Testing
- `php -l vacanze_view.php`
- `php -l vacanze_checklist.php`
- `php -l ajax/update_viaggi_checklist.php`
- `php -l ajax/get_viaggi_checklist_messages.php`
- `php -l ajax/add_viaggi_checklist_message.php`


------
https://chatgpt.com/codex/tasks/task_e_68b29dfa55348331b6388f16c9975efe