### PR TITLE
Add async loading flag for Google Maps API

### DIFF
--- a/vacanze_tratte_dettaglio.php
+++ b/vacanze_tratte_dettaglio.php
@@ -198,5 +198,5 @@ function calculateDistance() {
 }
 window.initAutocomplete = initAutocomplete;
 </script>
-<script src="https://maps.googleapis.com/maps/api/js?key=<?= $config['GOOGLE_MAPS_API'] ?>&libraries=places&callback=initAutocomplete" async defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<?= $config['GOOGLE_MAPS_API'] ?>&libraries=places&callback=initAutocomplete&loading=async" async defer></script>
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- load Google Maps JavaScript API using `loading=async` to avoid console warning and improve performance

## Testing
- `php -l vacanze_tratte_dettaglio.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2a03b39f88331974fe343a1d7740c