### PR TITLE
Improve vacation document and checklist handling

### DIFF
--- a/ajax/add_viaggi_checklist.php
+++ b/ajax/add_viaggi_checklist.php
@@ -1,0 +1,23 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:add_viaggi_checklist', 'insert')) {
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Accesso negato']);
+    exit;
+}
+$idViaggio = (int)($_POST['id_viaggio'] ?? 0);
+$voce = trim($_POST['voce'] ?? '');
+$idUtente = ($_POST['id_utente'] === '' ? null : (int)($_POST['id_utente'] ?? 0));
+if(!$idViaggio || $voce === ''){
+    echo json_encode(['success'=>false,'error'=>'Dati non validi']);
+    exit;
+}
+$stmt = $conn->prepare('INSERT INTO viaggi_checklist (id_viaggio, voce, id_utente) VALUES (?,?,?)');
+$stmt->bind_param('isi', $idViaggio, $voce, $idUtente);
+$ok = $stmt->execute();
+$stmt->close();
+echo json_encode(['success'=>$ok]);
+?>

--- a/ajax/add_viaggi_documento.php
+++ b/ajax/add_viaggi_documento.php
@@ -1,0 +1,43 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:add_viaggi_documento', 'insert')) {
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Accesso negato']);
+    exit;
+}
+$idViaggio = (int)($_POST['id_viaggio'] ?? 0);
+if (!$idViaggio || empty($_FILES['file']['name'])) {
+    echo json_encode(['success'=>false,'error'=>'Dati mancanti']);
+    exit;
+}
+$uploadDir = __DIR__ . '/../files/vacanze/';
+if (!is_dir($uploadDir)) {
+    mkdir($uploadDir, 0777, true);
+}
+$nomeFile = basename($_FILES['file']['name']);
+$target = $uploadDir . $nomeFile;
+if (!move_uploaded_file($_FILES['file']['tmp_name'], $target)) {
+    echo json_encode(['success'=>false,'error'=>'Upload fallito']);
+    exit;
+}
+$idUtente = $_SESSION['id'] ?? 0;
+$ip = $_SERVER['REMOTE_ADDR'] ?? '';
+$idSupermercato = 0;
+$dataScontrino = null;
+$totale = 0;
+$jsonLinee = '[]';
+$descrizione = null;
+$stmt = $conn->prepare('INSERT INTO ocr_caricamenti (id_utente, id_supermercato, nome_file, data_scontrino, totale_scontrino, indirizzo_ip, JSON_linee, descrizione) VALUES (?,?,?,?,?,?,?,?)');
+$stmt->bind_param('iissdsss', $idUtente, $idSupermercato, $nomeFile, $dataScontrino, $totale, $ip, $jsonLinee, $descrizione);
+$stmt->execute();
+$idCaricamento = $stmt->insert_id;
+$stmt->close();
+$stmt = $conn->prepare('INSERT INTO viaggi2caricamenti (id_viaggio, id_caricamento) VALUES (?,?)');
+$stmt->bind_param('ii', $idViaggio, $idCaricamento);
+$ok = $stmt->execute();
+$stmt->close();
+echo json_encode(['success'=>$ok]);
+?>

--- a/js/vacanze_checklist.js
+++ b/js/vacanze_checklist.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.checklist-checkbox').forEach(chk => {
-    chk.addEventListener('change', e => {
+    chk.addEventListener('change', () => {
       const id = chk.dataset.id;
       const fd = new FormData();
       fd.append('id', id);
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.querySelectorAll('.checklist-user').forEach(sel => {
-    sel.addEventListener('change', e => {
+    sel.addEventListener('change', () => {
       const id = sel.dataset.id;
       const fd = new FormData();
       fd.append('id', id);
@@ -23,49 +23,77 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  document.querySelectorAll('.collapse').forEach(col => {
-    col.addEventListener('shown.bs.collapse', () => {
-      const msgBox = col.querySelector('.checklist-chat-messages');
-      const id = msgBox.dataset.id;
-      loadMessages(id);
-    });
-  });
-
-  document.querySelectorAll('.checklist-chat-send').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const id = btn.dataset.id;
-      const input = document.querySelector('.checklist-chat-input[data-id="'+id+'"]');
-      const text = input.value.trim();
-      if(!text) return;
-      const fd = new FormData();
-      fd.append('id_checklist', id);
-      fd.append('messaggio', text);
-      fetch('ajax/add_viaggi_checklist_message.php', { method:'POST', body:fd })
+  const addBtn = document.getElementById('addChecklistBtn');
+  const addModalEl = document.getElementById('addChecklistModal');
+  const addForm = document.getElementById('addChecklistForm');
+  const addModal = addModalEl ? new bootstrap.Modal(addModalEl) : null;
+  if(addBtn && addModal){
+    addBtn.addEventListener('click', () => addModal.show());
+  }
+  if(addForm){
+    addForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const fd = new FormData(addForm);
+      fd.append('id_viaggio', viaggioId);
+      fetch('ajax/add_viaggi_checklist.php', { method:'POST', body:fd })
         .then(r => r.json())
         .then(res => {
           if(res.success){
-            input.value='';
-            loadMessages(id);
+            window.location.reload();
           } else {
             alert(res.error || 'Errore');
           }
         });
     });
+  }
+
+  let currentChecklist = null;
+  const chatModalEl = document.getElementById('chatModal');
+  const chatModal = chatModalEl ? new bootstrap.Modal(chatModalEl) : null;
+  const chatMessages = document.getElementById('chatMessages');
+  const chatInput = document.getElementById('chatInput');
+  const chatSend = document.getElementById('chatSend');
+
+  document.querySelectorAll('.checklist-chat-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      currentChecklist = btn.dataset.id;
+      chatInput.value = '';
+      loadMessages(currentChecklist);
+      chatModal.show();
+    });
   });
+
+  if(chatSend){
+    chatSend.addEventListener('click', () => {
+      const text = chatInput.value.trim();
+      if(!text || !currentChecklist) return;
+      const fd = new FormData();
+      fd.append('id_checklist', currentChecklist);
+      fd.append('messaggio', text);
+      fetch('ajax/add_viaggi_checklist_message.php', { method:'POST', body:fd })
+        .then(r => r.json())
+        .then(res => {
+          if(res.success){
+            chatInput.value='';
+            loadMessages(currentChecklist);
+          } else {
+            alert(res.error || 'Errore');
+          }
+        });
+    });
+  }
 
   function loadMessages(id){
     fetch('ajax/get_viaggi_checklist_messages.php?id_checklist='+id)
       .then(r => r.json())
       .then(res => {
-        if(res.success){
-          const box = document.querySelector('.checklist-chat-messages[data-id="'+id+'"]');
-          if(!box) return;
-          box.innerHTML = '';
+        if(res.success && chatMessages){
+          chatMessages.innerHTML = '';
           res.messages.forEach(m => {
             const div = document.createElement('div');
             div.className = 'small';
             div.textContent = m.username + ': ' + m.messaggio;
-            box.appendChild(div);
+            chatMessages.appendChild(div);
           });
         }
       });

--- a/js/vacanze_view.js
+++ b/js/vacanze_view.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('docForm');
+  if(form){
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const fd = new FormData(form);
+      fd.append('id_viaggio', viaggioId);
+      fetch('ajax/add_viaggi_documento.php', { method: 'POST', body: fd })
+        .then(r => r.json())
+        .then(res => {
+          if(res.success){
+            window.location.reload();
+          } else {
+            alert(res.error || 'Errore');
+          }
+        });
+    });
+  }
+});

--- a/vacanze_checklist.php
+++ b/vacanze_checklist.php
@@ -33,7 +33,7 @@ $users = $userRes ? $userRes->fetch_all(MYSQLI_ASSOC) : [];
   </nav>
   <div class="d-flex justify-content-between mb-3">
     <h4 class="m-0">Checklist</h4>
-    <a class="btn btn-sm btn-outline-light" href="table_manager.php?table=viaggi_checklist&id_viaggio=<?= $id ?>">Aggiungi</a>
+    <button class="btn btn-sm btn-outline-light" id="addChecklistBtn">Aggiungi</button>
   </div>
   <?php if ($chkRes->num_rows === 0): ?>
     <p class="text-muted">Nessuna voce.</p>
@@ -52,19 +52,61 @@ $users = $userRes ? $userRes->fetch_all(MYSQLI_ASSOC) : [];
                 <?php endforeach; ?>
               </select>
             </div>
-            <button class="btn btn-sm btn-outline-light" data-bs-toggle="collapse" data-bs-target="#chat<?= $row['id_checklist'] ?>">Chat</button>
-          </div>
-          <div class="collapse mt-2" id="chat<?= $row['id_checklist'] ?>">
-            <div class="checklist-chat-messages mb-2" data-id="<?= $row['id_checklist'] ?>"></div>
-            <div class="input-group input-group-sm">
-              <input type="text" class="form-control bg-dark text-white checklist-chat-input" data-id="<?= $row['id_checklist'] ?>" placeholder="Messaggio">
-              <button class="btn btn-outline-light checklist-chat-send" data-id="<?= $row['id_checklist'] ?>">Invia</button>
-            </div>
+            <button class="btn btn-sm btn-outline-light checklist-chat-btn" data-id="<?= $row['id_checklist'] ?>">Chat</button>
           </div>
         </li>
       <?php endwhile; ?>
     </ul>
   <?php endif; ?>
 </div>
+<div class="modal fade" id="addChecklistModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content" id="addChecklistForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Nuova voce</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Voce</label>
+          <input type="text" name="voce" class="form-control" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Assegna a</label>
+          <select name="id_utente" class="form-select">
+            <option value="">--</option>
+            <?php foreach ($users as $u): ?>
+              <option value="<?= $u['id'] ?>"><?= htmlspecialchars($u['username']) ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+        <button type="submit" class="btn btn-primary">Salva</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="modal fade" id="chatModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content bg-dark text-white">
+      <div class="modal-header">
+        <h5 class="modal-title">Chat</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div id="chatMessages" class="mb-3" style="max-height:300px;overflow-y:auto;"></div>
+        <div class="input-group">
+          <input type="text" id="chatInput" class="form-control bg-dark text-white" placeholder="Messaggio">
+          <button class="btn btn-outline-light" id="chatSend">Invia</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>const viaggioId = <?= $id ?>;</script>
 <script src="js/vacanze_checklist.js"></script>
 <?php include 'includes/footer.php'; ?>

--- a/vacanze_view.php
+++ b/vacanze_view.php
@@ -99,12 +99,9 @@ $docRes = $docStmt->get_result();
   </div>
 
   <div class="mb-4">
-    <div class="d-flex justify-content-between mb-3">
-      <h5 class="m-0">Checklist</h5>
-      <a href="table_manager.php?table=viaggi_checklist&id_viaggio=<?= $id ?>" class="btn btn-sm btn-outline-light">Aggiungi</a>
-    </div>
+    <h5 class="mb-3">Checklist</h5>
     <?php if ($totChecklist === 0): ?>
-      <p class="text-muted">Nessuna voce.</p>
+      <a href="vacanze_checklist.php?id=<?= $id ?>" class="btn btn-sm btn-outline-light">Nuova checklist</a>
     <?php else: ?>
       <a href="vacanze_checklist.php?id=<?= $id ?>" class="text-decoration-none text-white">
         <div class="p-2 border rounded">
@@ -116,20 +113,15 @@ $docRes = $docStmt->get_result();
   </div>
 
   <div class="mb-4">
-    <div class="d-flex justify-content-between mb-3">
-      <h5 class="m-0">Feedback</h5>
-      <a href="table_manager.php?table=viaggi_feedback&id_viaggio=<?= $id ?>" class="btn btn-sm btn-outline-light">Aggiungi</a>
-    </div>
+    <h5 class="mb-3">Feedback</h5>
     <?php if ($fbRes->num_rows === 0): ?>
       <p class="text-muted">Nessun feedback.</p>
     <?php else: ?>
       <ul class="list-group list-group-flush">
         <?php while ($row = $fbRes->fetch_assoc()): ?>
-          <li class="list-group-item bg-dark text-white p-0">
-            <a href="table_manager.php?table=viaggi_feedback&search=<?= (int)$row['id_feedback'] ?>&id_viaggio=<?= $id ?>" class="text-white text-decoration-none d-block p-2">
-              <div><strong><?= htmlspecialchars($row['username'] ?? 'Anonimo') ?></strong> - voto <?= (int)$row['voto'] ?></div>
-              <?php if ($row['commento']): ?><div class="small"><?= htmlspecialchars($row['commento']) ?></div><?php endif; ?>
-            </a>
+          <li class="list-group-item bg-dark text-white">
+            <div><strong><?= htmlspecialchars($row['username'] ?? 'Anonimo') ?></strong> - voto <?= (int)$row['voto'] ?></div>
+            <?php if ($row['commento']): ?><div class="small"><?= htmlspecialchars($row['commento']) ?></div><?php endif; ?>
           </li>
         <?php endwhile; ?>
       </ul>
@@ -137,23 +129,49 @@ $docRes = $docStmt->get_result();
   </div>
 
   <div class="mb-4">
-    <div class="d-flex justify-content-between mb-3">
+    <div class="d-flex justify-content-between mb-3 align-items-center">
       <h5 class="m-0">Documenti</h5>
-      <a href="table_manager.php?table=viaggi2caricamenti&id_viaggio=<?= $id ?>" class="btn btn-sm btn-outline-light">Aggiungi</a>
+      <button class="btn btn-sm btn-outline-light" data-bs-toggle="modal" data-bs-target="#docModal">Aggiungi</button>
     </div>
     <?php if ($docRes->num_rows === 0): ?>
       <p class="text-muted">Nessun documento allegato.</p>
     <?php else: ?>
-      <ul class="list-group list-group-flush">
+      <div class="row row-cols-1 row-cols-md-2 g-3">
         <?php while ($row = $docRes->fetch_assoc()): ?>
-          <li class="list-group-item bg-dark text-white p-0">
-            <a href="table_manager.php?table=viaggi2caricamenti&search=<?= (int)$row['id_caricamento'] ?>&id_viaggio=<?= $id ?>" class="text-white text-decoration-none d-block p-2">
-              <?= htmlspecialchars($row['nome_file']) ?>
-            </a>
-          </li>
+          <div class="col">
+            <div class="card bg-dark text-white h-100">
+              <div class="card-body d-flex flex-column">
+                <p class="card-text flex-grow-1 mb-2"><?= htmlspecialchars($row['nome_file']) ?></p>
+                <a href="files/vacanze/<?= urlencode($row['nome_file']) ?>" class="btn btn-sm btn-outline-light mt-auto" target="_blank">Apri</a>
+              </div>
+            </div>
+          </div>
         <?php endwhile; ?>
-      </ul>
+      </div>
     <?php endif; ?>
   </div>
+
+  <div class="modal fade" id="docModal" tabindex="-1">
+    <div class="modal-dialog">
+      <form class="modal-content" id="docForm" enctype="multipart/form-data">
+        <div class="modal-header">
+          <h5 class="modal-title">Carica documento</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <input type="file" name="file" class="form-control" required>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+          <button type="submit" class="btn btn-primary">Carica</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script>const viaggioId = <?= $id ?>;</script>
+  <script src="js/vacanze_view.js"></script>
 </div>
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Display checklist summary with option to start a new list and make feedback read-only
- Add document cards with upload modal and new checklist/chat modals

## Testing
- `php -l vacanze_view.php`
- `php -l vacanze_checklist.php`
- `php -l ajax/add_viaggi_documento.php`
- `php -l ajax/add_viaggi_checklist.php`
- `node --check js/vacanze_view.js`
- `node --check js/vacanze_checklist.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2aaa149f88331af0c9fe753afe671