### PR TITLE
Add manage holidays button and secure list detail redirect

### DIFF
--- a/vacanze_lista.php
+++ b/vacanze_lista.php
@@ -61,7 +61,10 @@ $nottiRes = $conn->query("SELECT DISTINCT notti FROM viaggi WHERE notti IS NOT N
     <input type="hidden" name="prezzo_min" value="<?= htmlspecialchars($prezzoMin) ?>">
     <input type="hidden" name="prezzo_max" value="<?= htmlspecialchars($prezzoMax) ?>">
   </form>
-  <div class="d-flex justify-content-end mb-3">
+  <div class="d-flex justify-content-end mb-3 gap-2">
+    <?php if (has_permission($conn, 'page:vacanze.php', 'view')): ?>
+    <a href="vacanze.php" class="btn btn-outline-light">Gestisci vacanze</a>
+    <?php endif; ?>
     <button class="btn btn-outline-light" data-bs-toggle="modal" data-bs-target="#filtersModal"><i class="bi bi-sliders"></i> Filtri</button>
   </div>
   <div class="row g-3">

--- a/vacanze_lista_dettaglio.php
+++ b/vacanze_lista_dettaglio.php
@@ -1,3 +1,4 @@
+<?php include 'includes/session_check.php'; ?>
 <?php
 $id = (int)($_GET['id'] ?? 0);
 header('Location: vacanze_view.php?id=' . $id);


### PR DESCRIPTION
## Summary
- show a "Gestisci vacanze" button next to the filters when user has permission
- ensure list detail page requires session and forwards to vacation view

## Testing
- `php -l vacanze_lista.php`
- `php -l vacanze_lista_dettaglio.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2bab044388331a015ab324dd8c315