### PR TITLE
Display two vacations per row on desktop

### DIFF
--- a/vacanze_lista.php
+++ b/vacanze_lista.php
@@ -69,7 +69,7 @@ $nottiRes = $conn->query("SELECT DISTINCT notti FROM viaggi WHERE notti IS NOT N
   </div>
   <div class="row g-3">
     <?php while($row = $res->fetch_assoc()): ?>
-    <div class="col-12">
+    <div class="col-12 col-md-6">
       <a href="vacanze_lista_dettaglio.php?id=<?= (int)$row['id_viaggio'] ?>" class="text-decoration-none text-dark">
         <div class="card">
           <?php if ($row['foto_url']): ?>


### PR DESCRIPTION
## Summary
- show two vacation cards per row on desktop while keeping single column on mobile

## Testing
- `php -l vacanze_lista.php`

------
https://chatgpt.com/codex/tasks/task_e_68b2fa6b06248331a59e6de6a5e1f0d9