### PR TITLE
Fix carousel image height in vacation detail page

### DIFF
--- a/vacanze_lista_dettaglio.php
+++ b/vacanze_lista_dettaglio.php
@@ -55,7 +55,7 @@ $docRes = $docStmt->get_result();
     <div class="carousel-inner">
       <?php $i=0; while($f = $fotoRes->fetch_assoc()): $url = 'https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photoreference=' . urlencode($f['photo_reference']) . '&key=' . ($config['GOOGLE_PLACES_FOTO_API'] ?? ''); ?>
       <div class="carousel-item <?= $i===0?'active':'' ?>">
-        <img src="<?= htmlspecialchars($url) ?>" class="d-block w-100" alt="">
+        <img src="<?= htmlspecialchars($url) ?>" class="d-block w-100" alt="" style="height:522px;object-fit:cover;">
       </div>
       <?php $i++; endwhile; ?>
     </div>


### PR DESCRIPTION
## Summary
- Ensure carousel photos maintain a consistent 522px height

## Testing
- `php -l vacanze_lista_dettaglio.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2fadf0d3883318e8bf745c11250d5