### PR TITLE
Allow duplicating vacation routes and lodgings

### DIFF
--- a/js/vacanze_tratte.js
+++ b/js/vacanze_tratte.js
@@ -16,4 +16,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
   }
+
+  document.querySelectorAll('.duplicate').forEach(el => {
+    el.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      const href = el.getAttribute('data-href');
+      if (href) window.location.href = href;
+    });
+  });
 });

--- a/vacanze_alloggi_dettaglio.php
+++ b/vacanze_alloggi_dettaglio.php
@@ -6,6 +6,7 @@ include 'includes/header.php';
 $id = (int)($_GET['id'] ?? 0);
 $alt = (int)($_GET['alt'] ?? 0);
 $id_alloggio = (int)($_GET['id_alloggio'] ?? 0);
+$duplica = isset($_GET['duplica']);
 
 // Recupera info viaggio per breadcrumb
 $stmt = $conn->prepare('SELECT titolo FROM viaggi WHERE id_viaggio=?');
@@ -72,6 +73,9 @@ if ($id_alloggio) {
         exit;
     }
     $alt = (int)$alloggio['id_viaggio_alternativa'];
+    if ($duplica) {
+        $id_alloggio = 0;
+    }
 }
 
 $altStmt = $conn->prepare('SELECT id_viaggio_alternativa, breve_descrizione FROM viaggi_alternative WHERE id_viaggio=? ORDER BY id_viaggio_alternativa');
@@ -84,7 +88,7 @@ $alt_desc = $alternative[$alt] ?? '';
 ?>
 <div class="container text-white">
   <a href="vacanze_tratte.php?id=<?= $id ?>&alt=<?= $alt ?>" class="btn btn-outline-light mb-3">← Indietro</a>
-  <h4 class="mb-3"><?= $id_alloggio ? 'Modifica' : 'Nuovo' ?> alloggio</h4>
+  <h4 class="mb-3"><?= $duplica ? 'Duplica' : ($id_alloggio ? 'Modifica' : 'Nuovo') ?> alloggio</h4>
   <form method="post">
     <input type="hidden" name="id_alloggio" value="<?= (int)$id_alloggio ?>">
     <div class="mb-3">
@@ -126,7 +130,7 @@ $alt_desc = $alternative[$alt] ?? '';
     </div>
     <div class="d-flex justify-content-between mt-3">
       <button type="submit" class="btn btn-primary">Salva</button>
-      <?php if ($id_alloggio): ?>
+      <?php if ($id_alloggio && !$duplica): ?>
         <button type="submit" name="delete" value="1" class="btn btn-danger">Elimina</button>
       <?php endif; ?>
     </div>

--- a/vacanze_tratte.php
+++ b/vacanze_tratte.php
@@ -66,7 +66,7 @@ $allRes = $allStmt->get_result();
               <div><?= htmlspecialchars($row['descrizione'] ?: $row['tipo_tratta']) ?></div>
               <div class="small text-muted"><?= ucfirst($row['tipo_tratta']) ?></div>
             </div>
-            <div>€<?= number_format($row['totale'], 2, ',', '.') ?> <i class="bi bi-pencil ms-2"></i></div>
+            <div>€<?= number_format($row['totale'], 2, ',', '.') ?> <i class="bi bi-pencil ms-2"></i><i class="bi bi-files ms-2 text-info duplicate" data-href="vacanze_tratte_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>&id_tratta=<?= (int)$row['id_tratta'] ?>&duplica=1"></i></div>
           </div>
         </a>
       <?php endwhile; ?>
@@ -86,7 +86,7 @@ $allRes = $allStmt->get_result();
         <a href="vacanze_alloggi_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>&id_alloggio=<?= (int)$row['id_alloggio'] ?>" class="list-group-item list-group-item-action bg-dark text-white">
           <div class="d-flex justify-content-between">
             <span><?= htmlspecialchars($row['nome_alloggio'] ?: 'Alloggio') ?></span>
-            <span>€<?= number_format($row['totale'], 2, ',', '.') ?> <i class="bi bi-pencil"></i></span>
+            <span>€<?= number_format($row['totale'], 2, ',', '.') ?> <i class="bi bi-pencil"></i><i class="bi bi-files ms-2 text-info duplicate" data-href="vacanze_alloggi_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>&id_alloggio=<?= (int)$row['id_alloggio'] ?>&duplica=1"></i></span>
           </div>
         </a>
       <?php endwhile; ?>

--- a/vacanze_tratte_dettaglio.php
+++ b/vacanze_tratte_dettaglio.php
@@ -6,6 +6,7 @@ include 'includes/header.php';
 $id = (int)($_GET['id'] ?? 0);
 $alt = (int)($_GET['alt'] ?? 0);
 $id_tratta = (int)($_GET['id_tratta'] ?? 0);
+$duplica = isset($_GET['duplica']);
 
 // Recupera info viaggio per breadcrumb
 $stmt = $conn->prepare('SELECT titolo FROM viaggi WHERE id_viaggio=?');
@@ -90,6 +91,9 @@ if ($id_tratta) {
         exit;
     }
     $alt = (int)$tratta['id_viaggio_alternativa'];
+    if ($duplica) {
+        $id_tratta = 0;
+    }
 }
 
 $altStmt = $conn->prepare('SELECT id_viaggio_alternativa, breve_descrizione FROM viaggi_alternative WHERE id_viaggio=? ORDER BY id_viaggio_alternativa');
@@ -102,7 +106,7 @@ $alt_desc = $alternative[$alt] ?? '';
 ?>
 <div class="container text-white">
   <a href="vacanze_tratte.php?id=<?= $id ?>&alt=<?= $alt ?>" class="btn btn-outline-light mb-3">← Indietro</a>
-  <h4 class="mb-3"><?= $id_tratta ? 'Modifica' : 'Nuova' ?> tratta</h4>
+  <h4 class="mb-3"><?= $duplica ? 'Duplica' : ($id_tratta ? 'Modifica' : 'Nuova') ?> tratta</h4>
   <form method="post">
     <input type="hidden" name="id_tratta" value="<?= (int)$id_tratta ?>">
     <div class="mb-3">
@@ -190,7 +194,7 @@ $alt_desc = $alternative[$alt] ?? '';
     </div>
     <div class="d-flex justify-content-between mt-3">
       <button type="submit" class="btn btn-primary">Salva</button>
-      <?php if ($id_tratta): ?>
+      <?php if ($id_tratta && !$duplica): ?>
         <button type="submit" name="delete" value="1" class="btn btn-danger">Elimina</button>
       <?php endif; ?>
     </div>


### PR DESCRIPTION
## Summary
- Add duplicate icons for routes and lodgings in vacation itinerary page
- Support duplication of existing records on detail pages via `duplica` parameter
- Handle duplicate icon clicks in JavaScript

## Testing
- `php -l vacanze_tratte.php`
- `php -l vacanze_tratte_dettaglio.php`
- `php -l vacanze_alloggi_dettaglio.php`
- `node --check js/vacanze_tratte.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2ffd7781083319fbcb33cce3ced51