### PR TITLE
Show alternative details inline

### DIFF
--- a/js/vacanze_lista_dettaglio.js
+++ b/js/vacanze_lista_dettaglio.js
@@ -1,0 +1,65 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const altCards = document.querySelectorAll('.alt-card');
+  const detailDiv = document.getElementById('altDettagli');
+
+  const escapeHtml = str => str ? str.replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m])) : '';
+
+  function renderDetails(data){
+    let html = '';
+    html += `<h5 class="mb-3">${escapeHtml(data.breve_descrizione)}</h5>`;
+    html += '<h6>Tratte</h6>';
+    if(data.tratte.length === 0){
+      html += '<p class="text-muted">Nessuna tratta.</p>';
+    } else {
+      html += '<ul class="list-group mb-3">';
+      data.tratte.forEach(t => {
+        const titolo = escapeHtml(t.descrizione || t.tipo_tratta);
+        let route = '';
+        if(t.origine_testo || t.destinazione_testo){
+          route = `<div class="small text-muted">${escapeHtml(t.origine_testo || '')} → ${escapeHtml(t.destinazione_testo || '')}</div>`;
+        }
+        html += `<li class="list-group-item d-flex justify-content-between"><div><div>${titolo}</div>${route}</div><div>€${t.totale}</div></li>`;
+      });
+      html += '</ul>';
+    }
+    html += '<h6>Alloggi</h6>';
+    if(data.alloggi.length === 0){
+      html += '<p class="text-muted">Nessun alloggio.</p>';
+    } else {
+      html += '<ul class="list-group mb-3">';
+      data.alloggi.forEach(a => {
+        html += `<li class="list-group-item d-flex justify-content-between"><span>${escapeHtml(a.nome_alloggio || 'Alloggio')}</span><span>€${a.totale}</span></li>`;
+      });
+      html += '</ul>';
+    }
+    html += `<div class="small">Trasporti: €${data.totale_trasporti}</div>`;
+    html += `<div class="small">Alloggi: €${data.totale_alloggi}</div>`;
+    html += `<div class="fw-bold">Totale: €${data.totale_viaggio}</div>`;
+    detailDiv.innerHTML = html;
+  }
+
+  function loadAlt(altId, el){
+    fetch(`ajax/get_viaggi_alternativa.php?id_viaggio=${viaggioId}&id_alternativa=${altId}`)
+      .then(r => r.json())
+      .then(res => {
+        if(res.success){
+          renderDetails(res);
+          altCards.forEach(card => card.querySelector('.card').classList.remove('border-primary'));
+          if(el){ el.querySelector('.card').classList.add('border-primary'); }
+        } else {
+          detailDiv.innerHTML = `<p class="text-danger">${escapeHtml(res.error || 'Errore')}</p>`;
+        }
+      });
+  }
+
+  altCards.forEach(card => {
+    card.addEventListener('click', e => {
+      e.preventDefault();
+      loadAlt(card.dataset.alt, card);
+    });
+  });
+
+  if(altCards.length > 0){
+    loadAlt(altCards[0].dataset.alt, altCards[0]);
+  }
+});

--- a/vacanze_lista_dettaglio.php
+++ b/vacanze_lista_dettaglio.php
@@ -86,7 +86,7 @@ $docRes = $docStmt->get_result();
     <div class="row row-cols-1 row-cols-md-2 g-3">
       <?php while($alt = $altRes->fetch_assoc()): ?>
       <div class="col">
-        <a href="vacanze_tratte.php?id=<?= $id ?>&alt=<?= (int)$alt['id_viaggio_alternativa'] ?>" class="text-decoration-none text-dark">
+        <a href="#" data-alt="<?= (int)$alt['id_viaggio_alternativa'] ?>" class="text-decoration-none text-dark alt-card">
           <div class="card">
             <div class="card-body d-flex justify-content-between">
               <div><?= htmlspecialchars($alt['breve_descrizione']) ?></div>
@@ -99,6 +99,8 @@ $docRes = $docStmt->get_result();
     </div>
     <?php endif; ?>
   </div>
+
+  <div id="altDettagli" class="mb-4"></div>
 
   <ul class="nav nav-tabs nav-fill" id="detailTabs" role="tablist">
     <li class="nav-item" role="presentation">
@@ -135,6 +137,8 @@ $docRes = $docStmt->get_result();
       <?php endif; ?>
     </div>
   </div>
+  <script>const viaggioId = <?= $id ?>;</script>
+  <script src="js/vacanze_lista_dettaglio.js"></script>
 </div>
 <?php include 'includes/footer.php'; ?>
 


### PR DESCRIPTION
## Summary
- Display alternative details inline on `vacanze_lista_dettaglio.php` and update when clicking different alternatives
- Add JavaScript loader to fetch and render routes and accommodations for selected alternative
- Provide backend endpoint to supply alternative data via JSON

## Testing
- `php -l vacanze_lista_dettaglio.php`
- `php -l ajax/get_viaggi_alternativa.php`
- `node --check js/vacanze_lista_dettaglio.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3011c2b2c83318e81482c6943edd1