### PR TITLE
Hide Gestisci vacanze button without insert permission

### DIFF
--- a/vacanze_lista.php
+++ b/vacanze_lista.php
@@ -62,7 +62,7 @@ $nottiRes = $conn->query("SELECT DISTINCT notti FROM viaggi WHERE notti IS NOT N
     <input type="hidden" name="prezzo_max" value="<?= htmlspecialchars($prezzoMax) ?>">
   </form>
   <div class="d-flex justify-content-end mb-3 gap-2">
-    <?php if (has_permission($conn, 'page:vacanze.php', 'view')): ?>
+    <?php if (has_permission($conn, 'page:vacanze.php', 'insert')): ?>
     <a href="vacanze.php" class="btn btn-outline-light">Gestisci vacanze</a>
     <?php endif; ?>
     <button class="btn btn-outline-light" data-bs-toggle="modal" data-bs-target="#filtersModal"><i class="bi bi-sliders"></i> Filtri</button>


### PR DESCRIPTION
## Summary
- Show "Gestisci vacanze" button in the vacation list only when the user has insert rights for `vacanze.php`

## Testing
- `php -l vacanze_lista.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3031f23d08331935a9c40d986d7ba