### PR TITLE
Add community feedback section

### DIFF
--- a/ajax/add_viaggi_feedback.php
+++ b/ajax/add_viaggi_feedback.php
@@ -1,0 +1,25 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'ajax:add_viaggi_feedback', 'insert')) {
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Accesso negato']);
+    exit;
+}
+$idViaggio = (int)($_POST['id_viaggio'] ?? 0);
+$voto = (($_POST['voto'] ?? '') === '' ? null : (int)$_POST['voto']);
+$commento = trim($_POST['commento'] ?? '');
+$idUtente = $_SESSION['utente_id'] ?? 0;
+if(!$idViaggio || (!$commento && $voto === null) || !$idUtente){
+    echo json_encode(['success'=>false,'error'=>'Dati non validi']);
+    exit;
+}
+$stmt = $conn->prepare('INSERT INTO viaggi_feedback (id_viaggio, id_utente, voto, commento) VALUES (?,?,?,?)');
+$stmt->bind_param('iiis', $idViaggio, $idUtente, $voto, $commento);
+$ok = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success'=>$ok]);
+?>

--- a/js/vacanze_lista_dettaglio.js
+++ b/js/vacanze_lista_dettaglio.js
@@ -1,0 +1,37 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const reviewForm = document.getElementById('reviewForm');
+  if (reviewForm) {
+    reviewForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const fd = new FormData(reviewForm);
+      fd.append('id_viaggio', viaggioId);
+      fetch('ajax/add_viaggi_feedback.php', { method: 'POST', body: fd })
+        .then(r => r.json())
+        .then(res => {
+          if (res.success) {
+            window.location.reload();
+          } else {
+            alert(res.error || 'Errore');
+          }
+        });
+    });
+  }
+
+  const askForm = document.getElementById('askForm');
+  if (askForm) {
+    askForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const fd = new FormData(askForm);
+      fd.append('id_viaggio', viaggioId);
+      fetch('ajax/add_viaggi_feedback.php', { method: 'POST', body: fd })
+        .then(r => r.json())
+        .then(res => {
+          if (res.success) {
+            window.location.reload();
+          } else {
+            alert(res.error || 'Errore');
+          }
+        });
+    });
+  }
+});

--- a/vacanze.php
+++ b/vacanze.php
@@ -8,7 +8,7 @@ $budget = $_GET['budget_max'] ?? '';
 $query = "SELECT v.*, t.min_totale, a.num_alternative, f.media_voto, f.num_feedback FROM viaggi v "
   . "LEFT JOIN (SELECT id_viaggio, MIN(totale_viaggio) AS min_totale FROM v_totali_alternative GROUP BY id_viaggio) t ON v.id_viaggio=t.id_viaggio "
   . "LEFT JOIN (SELECT id_viaggio, COUNT(*) AS num_alternative FROM viaggi_alternative GROUP BY id_viaggio) a ON v.id_viaggio=a.id_viaggio "
-  . "LEFT JOIN (SELECT id_viaggio, AVG(voto) AS media_voto, COUNT(*) AS num_feedback FROM viaggi_feedback GROUP BY id_viaggio) f ON v.id_viaggio=f.id_viaggio WHERE 1=1";
+  . "LEFT JOIN (SELECT id_viaggio, AVG(voto) AS media_voto, COUNT(voto) AS num_feedback FROM viaggi_feedback GROUP BY id_viaggio) f ON v.id_viaggio=f.id_viaggio WHERE 1=1";
 $params = [];
 $types = '';
 if ($stato !== '') { $query .= " AND v.stato = ?"; $types .= 's'; $params[] = $stato; }

--- a/vacanze_lista_dettaglio.php
+++ b/vacanze_lista_dettaglio.php
@@ -26,7 +26,7 @@ $altStmt->bind_param('i', $id);
 $altStmt->execute();
 $altRes = $altStmt->get_result();
 
-$fbStmt = $conn->prepare('SELECT AVG(voto) AS media, COUNT(*) AS num FROM viaggi_feedback WHERE id_viaggio=?');
+$fbStmt = $conn->prepare('SELECT AVG(voto) AS media, COUNT(voto) AS num FROM viaggi_feedback WHERE id_viaggio=?');
 $fbStmt->bind_param('i', $id);
 $fbStmt->execute();
 $fbStats = $fbStmt->get_result()->fetch_assoc();
@@ -77,6 +77,15 @@ $docRes = $docStmt->get_result();
   <?php else: ?>
   <p><a href="vacanze_lista_dettaglio_feedback.php?id=<?= $id ?>" class="text-decoration-none">Nessuna recensione</a></p>
   <?php endif; ?>
+
+  <div class="mb-4">
+    <div class="mb-3">
+      <button class="btn btn-outline-secondary w-100 text-start" data-bs-toggle="modal" data-bs-target="#askModal">Chiedi alla community</button>
+    </div>
+    <div>
+      <button class="btn btn-primary w-100" data-bs-toggle="modal" data-bs-target="#reviewModal">Scrivi una recensione</button>
+    </div>
+  </div>
 
   <div class="mb-4">
     <h5 class="mb-3">Alternative</h5>
@@ -135,6 +144,52 @@ $docRes = $docStmt->get_result();
       <?php endif; ?>
     </div>
   </div>
+
+  <div class="modal fade" id="askModal" tabindex="-1">
+    <div class="modal-dialog">
+      <form class="modal-content" id="askForm">
+        <div class="modal-header">
+          <h5 class="modal-title">Chiedi alla community</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <textarea class="form-control" name="commento" rows="3" required></textarea>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+          <button type="submit" class="btn btn-primary">Invia</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="modal fade" id="reviewModal" tabindex="-1">
+    <div class="modal-dialog">
+      <form class="modal-content" id="reviewForm">
+        <div class="modal-header">
+          <h5 class="modal-title">Scrivi una recensione</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Voto (0-10)</label>
+            <input type="number" name="voto" class="form-control" min="0" max="10" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Commento</label>
+            <textarea class="form-control" name="commento" rows="3"></textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+          <button type="submit" class="btn btn-primary">Salva</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script>const viaggioId = <?= $id ?>;</script>
+  <script src="js/vacanze_lista_dettaglio.js"></script>
 </div>
 <?php include 'includes/footer.php'; ?>
 

--- a/vacanze_lista_dettaglio_feedback.php
+++ b/vacanze_lista_dettaglio_feedback.php
@@ -5,7 +5,7 @@ include 'includes/header.php';
 
 $id = (int)($_GET['id'] ?? 0);
 
-$statStmt = $conn->prepare('SELECT AVG(voto) AS media, COUNT(*) AS num FROM viaggi_feedback WHERE id_viaggio=?');
+$statStmt = $conn->prepare('SELECT AVG(voto) AS media, COUNT(voto) AS num FROM viaggi_feedback WHERE id_viaggio=?');
 $statStmt->bind_param('i', $id);
 $statStmt->execute();
 $stats = $statStmt->get_result()->fetch_assoc();
@@ -33,7 +33,9 @@ $fbRes = $fbStmt->get_result();
           <small class="text-muted"><?= htmlspecialchars(date('d/m/Y', strtotime($row['creato_il']))) ?></small>
           <?php if ($row['commento']): ?><div><?= htmlspecialchars($row['commento']) ?></div><?php endif; ?>
         </div>
+        <?php if ($row['voto'] !== null): ?>
         <div class="ms-3 fw-bold align-self-center"><?= (int)$row['voto'] ?></div>
+        <?php endif; ?>
       </li>
       <?php endwhile; ?>
     </ul>

--- a/vacanze_view.php
+++ b/vacanze_view.php
@@ -128,7 +128,7 @@ $docRes = $docStmt->get_result();
       <ul class="list-group list-group-flush">
         <?php while ($row = $fbRes->fetch_assoc()): ?>
           <li class="list-group-item bg-dark text-white">
-            <div><strong><?= htmlspecialchars($row['username'] ?? 'Anonimo') ?></strong> - voto <?= (int)$row['voto'] ?></div>
+            <div><strong><?= htmlspecialchars($row['username'] ?? 'Anonimo') ?></strong><?= $row['voto'] !== null ? ' - voto ' . (int)$row['voto'] : '' ?></div>
             <?php if ($row['commento']): ?><div class="small"><?= htmlspecialchars($row['commento']) ?></div><?php endif; ?>
           </li>
         <?php endwhile; ?>


### PR DESCRIPTION
## Summary
- allow visitors to submit reviews or questions from the trip detail page with dedicated modals
- add AJAX endpoint and client script to store feedback with optional rating
- ensure rating statistics ignore entries without a vote and display votes only when available

## Testing
- `php -l vacanze_lista_dettaglio.php`
- `php -l vacanze_lista_dettaglio_feedback.php`
- `php -l vacanze.php`
- `php -l vacanze_view.php`
- `php -l ajax/add_viaggi_feedback.php`
- `node -e "require('fs').readFileSync('js/vacanze_lista_dettaglio.js');"`


------
https://chatgpt.com/codex/tasks/task_e_68b302e588c08331894b34240df807be