### PR TITLE
Limit vacation route changes to authorized users

### DIFF
--- a/vacanze_tratte.php
+++ b/vacanze_tratte.php
@@ -42,6 +42,12 @@ $allStmt->bind_param('ii', $id, $alt);
 $allStmt->execute();
 $allRes = $allStmt->get_result();
 $alloggi = $allRes->fetch_all(MYSQLI_ASSOC);
+
+$canEditAlt = has_permission($conn, 'ajax:update_viaggi_alternativa', 'update');
+$canInsertTratta = has_permission($conn, 'table:viaggi_tratte', 'insert');
+$canUpdateTratta = has_permission($conn, 'table:viaggi_tratte', 'update');
+$canInsertAlloggio = has_permission($conn, 'table:viaggi_alloggi', 'insert');
+$canUpdateAlloggio = has_permission($conn, 'table:viaggi_alloggi', 'update');
 ?>
 <div class="container text-white">
   <a href="vacanze_view.php?id=<?= $id ?>" class="btn btn-outline-light mb-3">← Indietro</a>
@@ -53,8 +59,14 @@ $alloggi = $allRes->fetch_all(MYSQLI_ASSOC);
     </ol>
   </nav>
   <div class="d-flex justify-content-between mb-3">
-      <h4 class="m-0">Tratte - <?= htmlspecialchars($alt_desc) ?> <a href="#" class="text-white ms-2" data-bs-toggle="modal" data-bs-target="#altEditModal"><i class="bi bi-pencil"></i></a></h4>
+      <h4 class="m-0">Tratte - <?= htmlspecialchars($alt_desc) ?>
+        <?php if ($canEditAlt): ?>
+          <a href="#" class="text-white ms-2" data-bs-toggle="modal" data-bs-target="#altEditModal"><i class="bi bi-pencil"></i></a>
+        <?php endif; ?>
+      </h4>
+      <?php if ($canInsertTratta): ?>
       <a class="btn btn-sm btn-outline-light" href="vacanze_tratte_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>">Aggiungi</a>
+      <?php endif; ?>
   </div>
 
   <?php if (empty($tratte)): ?>
@@ -62,22 +74,35 @@ $alloggi = $allRes->fetch_all(MYSQLI_ASSOC);
   <?php else: ?>
     <div class="list-group">
         <?php foreach ($tratte as $row): ?>
+          <?php if ($canUpdateTratta): ?>
           <a href="vacanze_tratte_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>&id_tratta=<?= (int)$row['id_tratta'] ?>" class="list-group-item list-group-item-action bg-dark text-white">
+          <?php else: ?>
+          <div class="list-group-item bg-dark text-white">
+          <?php endif; ?>
           <div class="d-flex justify-content-between">
             <div>
               <div><?= htmlspecialchars($row['descrizione'] ?: $row['tipo_tratta']) ?></div>
               <div class="small text-muted"><?= ucfirst($row['tipo_tratta']) ?></div>
             </div>
-            <div>€<?= number_format($row['totale'], 2, ',', '.') ?> <i class="bi bi-pencil ms-2"></i><i class="bi bi-files ms-2 text-info duplicate" data-href="vacanze_tratte_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>&id_tratta=<?= (int)$row['id_tratta'] ?>&duplica=1"></i></div>
+            <div>€<?= number_format($row['totale'], 2, ',', '.') ?>
+              <?php if ($canUpdateTratta): ?><i class="bi bi-pencil ms-2"></i><?php endif; ?>
+              <?php if ($canInsertTratta): ?><i class="bi bi-files ms-2 text-info duplicate" data-href="vacanze_tratte_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>&id_tratta=<?= (int)$row['id_tratta'] ?>&duplica=1"></i><?php endif; ?>
+            </div>
           </div>
-        </a>
+          <?php if ($canUpdateTratta): ?>
+          </a>
+          <?php else: ?>
+          </div>
+          <?php endif; ?>
       <?php endforeach; ?>
     </div>
   <?php endif; ?>
 
   <div class="d-flex justify-content-between mb-3 mt-4">
       <h4 class="m-0">Alloggi</h4>
+      <?php if ($canInsertAlloggio): ?>
       <a class="btn btn-sm btn-outline-light" href="vacanze_alloggi_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>">Aggiungi</a>
+      <?php endif; ?>
   </div>
 
   <?php if (empty($alloggi)): ?>
@@ -85,12 +110,23 @@ $alloggi = $allRes->fetch_all(MYSQLI_ASSOC);
   <?php else: ?>
     <div class="list-group">
       <?php foreach ($alloggi as $row): ?>
+        <?php if ($canUpdateAlloggio): ?>
         <a href="vacanze_alloggi_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>&id_alloggio=<?= (int)$row['id_alloggio'] ?>" class="list-group-item list-group-item-action bg-dark text-white">
+        <?php else: ?>
+        <div class="list-group-item bg-dark text-white">
+        <?php endif; ?>
           <div class="d-flex justify-content-between">
             <span><?= htmlspecialchars($row['nome_alloggio'] ?: 'Alloggio') ?></span>
-            <span>€<?= number_format($row['totale'], 2, ',', '.') ?> <i class="bi bi-pencil"></i><i class="bi bi-files ms-2 text-info duplicate" data-href="vacanze_alloggi_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>&id_alloggio=<?= (int)$row['id_alloggio'] ?>&duplica=1"></i></span>
+            <span>€<?= number_format($row['totale'], 2, ',', '.') ?>
+              <?php if ($canUpdateAlloggio): ?><i class="bi bi-pencil"></i><?php endif; ?>
+              <?php if ($canInsertAlloggio): ?><i class="bi bi-files ms-2 text-info duplicate" data-href="vacanze_alloggi_dettaglio.php?id=<?= $id ?>&alt=<?= $alt ?>&id_alloggio=<?= (int)$row['id_alloggio'] ?>&duplica=1"></i><?php endif; ?>
+            </span>
           </div>
+        <?php if ($canUpdateAlloggio): ?>
         </a>
+        <?php else: ?>
+        </div>
+        <?php endif; ?>
       <?php endforeach; ?>
     </div>
   <?php endif; ?>
@@ -98,6 +134,7 @@ $alloggi = $allRes->fetch_all(MYSQLI_ASSOC);
   <h4 class="mb-3 mt-4">Mappa</h4>
   <div id="map" style="height:500px"></div>
 
+  <?php if ($canEditAlt): ?>
   <div class="modal fade" id="altEditModal" tabindex="-1">
     <div class="modal-dialog">
       <form class="modal-content" id="altEditForm">
@@ -118,6 +155,7 @@ $alloggi = $allRes->fetch_all(MYSQLI_ASSOC);
       </form>
     </div>
   </div>
+  <?php endif; ?>
 
   <script>
     const altId = <?= $alt ?>;


### PR DESCRIPTION
## Summary
- restrict access to route and lodging add/edit features in `vacanze_tratte.php` based on permissions
- hide alternative edit modal and controls when user lacks rights

## Testing
- `php -l vacanze_tratte.php`


------
https://chatgpt.com/codex/tasks/task_e_68b303858e1483319e39b56cce47da5a