### PR TITLE
Fix vacation pages redirects by moving header includes

### DIFF
--- a/vacanze_alloggi_dettaglio.php
+++ b/vacanze_alloggi_dettaglio.php
@@ -1,7 +1,6 @@
 <?php include 'includes/session_check.php'; ?>
 <?php
 include 'includes/db.php';
-include 'includes/header.php';
 
 $id = (int)($_GET['id'] ?? 0);
 $alt = (int)($_GET['alt'] ?? 0);
@@ -14,6 +13,7 @@ $stmt->bind_param('i', $id);
 $stmt->execute();
 $viaggio = $stmt->get_result()->fetch_assoc();
 if (!$viaggio) {
+    include 'includes/header.php';
     echo '<p class="text-danger">Viaggio non trovato</p>';
     include 'includes/footer.php';
     exit;
@@ -47,7 +47,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     header('Location: vacanze_tratte.php?id=' . $id . '&alt=' . $id_alt);
     exit;
-}
 
 $alloggio = [
     'id_viaggio_alternativa' => $alt,
@@ -86,6 +85,7 @@ $alternative = [];
 while ($row = $altRes->fetch_assoc()) { $alternative[$row['id_viaggio_alternativa']] = $row['breve_descrizione']; }
 $alt_desc = $alternative[$alt] ?? '';
 ?>
+<?php include 'includes/header.php'; ?>
 <div class="container text-white">
   <a href="vacanze_tratte.php?id=<?= $id ?>&alt=<?= $alt ?>" class="btn btn-outline-light mb-3">← Indietro</a>
   <h4 class="mb-3"><?= $duplica ? 'Duplica' : ($id_alloggio ? 'Modifica' : 'Nuovo') ?> alloggio</h4>

--- a/vacanze_luogo_modifica.php
+++ b/vacanze_luogo_modifica.php
@@ -1,7 +1,6 @@
 <?php include 'includes/session_check.php'; ?>
 <?php
 include 'includes/db.php';
-include 'includes/header.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
@@ -69,6 +68,7 @@ if ($id > 0) {
     $foto_esistenti = $pf->get_result()->fetch_all(MYSQLI_ASSOC);
 }
 ?>
+<?php include 'includes/header.php'; ?>
 <div class="container text-white">
   <a href="javascript:history.back()" class="btn btn-outline-light mb-3">← Indietro</a>
   <nav aria-label="breadcrumb">

--- a/vacanze_modifica.php
+++ b/vacanze_modifica.php
@@ -1,7 +1,6 @@
 <?php include 'includes/session_check.php'; ?>
 <?php
 include 'includes/db.php';
-include 'includes/header.php';
 
 // Default carburante modificabili qui
 $DEFAULT_CONSUMO = 7.0; // L/100km
@@ -87,6 +86,7 @@ if ($id > 0) {
     }
 }
 ?>
+<?php include 'includes/header.php'; ?>
 <div class="container text-white">
   <a href="javascript:history.back()" class="btn btn-outline-light mb-3">← Indietro</a>
   <nav aria-label="breadcrumb">

--- a/vacanze_tratte_dettaglio.php
+++ b/vacanze_tratte_dettaglio.php
@@ -1,7 +1,6 @@
 <?php include 'includes/session_check.php'; ?>
 <?php
 include 'includes/db.php';
-include 'includes/header.php';
 
 $id = (int)($_GET['id'] ?? 0);
 $alt = (int)($_GET['alt'] ?? 0);
@@ -14,6 +13,7 @@ $stmt->bind_param('i', $id);
 $stmt->execute();
 $viaggio = $stmt->get_result()->fetch_assoc();
 if (!$viaggio) {
+    include 'includes/header.php';
     echo '<p class="text-danger">Viaggio non trovato</p>';
     include 'includes/footer.php';
     exit;
@@ -56,7 +56,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     header('Location: vacanze_tratte.php?id=' . $id . '&alt=' . $id_alt);
     exit;
-}
 
 $tratta = [
     'id_viaggio_alternativa' => $alt,
@@ -104,6 +103,7 @@ $alternative = [];
 while ($row = $altRes->fetch_assoc()) { $alternative[$row['id_viaggio_alternativa']] = $row['breve_descrizione']; }
 $alt_desc = $alternative[$alt] ?? '';
 ?>
+<?php include 'includes/header.php'; ?>
 <div class="container text-white">
   <a href="vacanze_tratte.php?id=<?= $id ?>&alt=<?= $alt ?>" class="btn btn-outline-light mb-3">← Indietro</a>
   <h4 class="mb-3"><?= $duplica ? 'Duplica' : ($id_tratta ? 'Modifica' : 'Nuova') ?> tratta</h4>


### PR DESCRIPTION
## Summary
- Defer header inclusion until after POST handling in vacation edit pages
- Add header inclusion in error branches for missing travel records

## Testing
- `php -l vacanze_modifica.php` *(fails: /usr/bin/php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b3079fd76083318e43791ad9920398