### PR TITLE
Enable editing and deleting OCR receipt uploads

### DIFF
--- a/ajax/delete_caricamento.php
+++ b/ajax/delete_caricamento.php
@@ -1,0 +1,45 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+include '../includes/permissions.php';
+
+if (!has_permission($conn, 'table:ocr_caricamenti', 'delete')) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Accesso negato']);
+    exit;
+}
+
+$id = intval($_POST['id'] ?? 0);
+$idUtente = $_SESSION['utente_id'] ?? 0;
+if (!$id) {
+    echo json_encode(['success' => false, 'error' => 'ID mancante']);
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT nome_file FROM ocr_caricamenti WHERE id_caricamento=? AND id_utente=?');
+$stmt->bind_param('ii', $id, $idUtente);
+$stmt->execute();
+$stmt->bind_result($nomeFile);
+if (!$stmt->fetch()) {
+    echo json_encode(['success' => false, 'error' => 'Record non trovato']);
+    $stmt->close();
+    exit;
+}
+$stmt->close();
+
+$conn->begin_transaction();
+try {
+    $stmt = $conn->prepare('DELETE FROM ocr_caricamenti WHERE id_caricamento=? AND id_utente=?');
+    $stmt->bind_param('ii', $id, $idUtente);
+    $stmt->execute();
+    $stmt->close();
+    $conn->commit();
+    if ($nomeFile) {
+        @unlink(__DIR__ . '/../files/scontrini/' . $nomeFile);
+    }
+    echo json_encode(['success' => true]);
+} catch (Exception $e) {
+    $conn->rollback();
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- Allow users to update and remove uploaded receipts
- Add server-side endpoint to delete a receipt and its file

## Testing
- `php -l ocr_caricamenti_scontrini.php`
- `php -l ajax/delete_caricamento.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3399dd12083318ccb779d71cc7842