### PR TITLE
Add description and user tracking for vacation documents

### DIFF
--- a/ajax/add_viaggi_documento.php
+++ b/ajax/add_viaggi_documento.php
@@ -23,13 +23,13 @@ if (!move_uploaded_file($_FILES['file']['tmp_name'], $target)) {
     echo json_encode(['success'=>false,'error'=>'Upload fallito']);
     exit;
 }
-$idUtente = $_SESSION['id'] ?? 0;
+$idUtente = $_SESSION['utente_id'] ?? ($_SESSION['id_utente'] ?? 0);
 $ip = $_SERVER['REMOTE_ADDR'] ?? '';
 $idSupermercato = 0;
 $dataScontrino = null;
 $totale = 0;
 $jsonLinee = '[]';
-$descrizione = null;
+$descrizione = $_POST['descrizione'] ?? null;
 $stmt = $conn->prepare('INSERT INTO ocr_caricamenti (id_utente, id_supermercato, nome_file, data_scontrino, totale_scontrino, indirizzo_ip, JSON_linee, descrizione) VALUES (?,?,?,?,?,?,?,?)');
 $stmt->bind_param('iissdsss', $idUtente, $idSupermercato, $nomeFile, $dataScontrino, $totale, $ip, $jsonLinee, $descrizione);
 $stmt->execute();

--- a/vacanze_view.php
+++ b/vacanze_view.php
@@ -48,7 +48,7 @@ $fbStmt->execute();
 $fbRes = $fbStmt->get_result();
 
 // Documenti
-$docStmt = $conn->prepare('SELECT vc.id_caricamento, oc.nome_file FROM viaggi2caricamenti vc JOIN ocr_caricamenti oc ON vc.id_caricamento=oc.id_caricamento WHERE vc.id_viaggio=? ORDER BY vc.id_caricamento');
+$docStmt = $conn->prepare('SELECT vc.id_caricamento, oc.nome_file, oc.descrizione FROM viaggi2caricamenti vc JOIN ocr_caricamenti oc ON vc.id_caricamento=oc.id_caricamento WHERE vc.id_viaggio=? ORDER BY vc.id_caricamento');
 $docStmt->bind_param('i', $id);
 $docStmt->execute();
 $docRes = $docStmt->get_result();
@@ -166,7 +166,12 @@ $docRes = $docStmt->get_result();
           <div class="col">
             <div class="card bg-dark text-white h-100">
               <div class="card-body d-flex flex-column">
-                <p class="card-text flex-grow-1 mb-2"><?= htmlspecialchars($row['nome_file']) ?></p>
+                <p class="card-text flex-grow-1 mb-2">
+                  <?= htmlspecialchars($row['nome_file']) ?>
+                  <?php if (!empty($row['descrizione'])): ?>
+                    <br><small class="text-muted"><?= htmlspecialchars($row['descrizione']) ?></small>
+                  <?php endif; ?>
+                </p>
                 <a href="files/vacanze/<?= urlencode($row['nome_file']) ?>" class="btn btn-sm btn-outline-light mt-auto" target="_blank">Apri</a>
               </div>
             </div>
@@ -187,6 +192,9 @@ $docRes = $docStmt->get_result();
         <div class="modal-body">
           <div class="mb-3">
             <input type="file" name="file" class="form-control" required>
+          </div>
+          <div class="mb-3">
+            <input type="text" name="descrizione" class="form-control" placeholder="Descrizione">
           </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
## Summary
- allow adding a description when uploading travel documents
- record the uploading user's ID when saving documents
- display document descriptions in the travel detail view

## Testing
- `php -l vacanze_view.php`
- `php -l ajax/add_viaggi_documento.php`


------
https://chatgpt.com/codex/tasks/task_e_68b33c53f59c8331a97db65603a1d8a9