### PR TITLE
Add notes editor to vacation trips

### DIFF
--- a/ajax/update_viaggi_note.php
+++ b/ajax/update_viaggi_note.php
@@ -1,0 +1,14 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+if (!has_permission($conn, 'table:viaggi', 'update')) { http_response_code(403); echo json_encode(['success'=>false,'error'=>'Accesso negato']); exit; }
+$idViaggio = (int)($_POST['id_viaggio'] ?? 0);
+$note = $_POST['note'] ?? '';
+if (!$idViaggio) { echo json_encode(['success'=>false,'error'=>'ID mancante']); exit; }
+$stmt = $conn->prepare('UPDATE viaggi SET note=? WHERE id_viaggio=?');
+$stmt->bind_param('si', $note, $idViaggio);
+$ok = $stmt->execute();
+echo json_encode(['success'=>$ok]);
+?>

--- a/js/vacanze_view.js
+++ b/js/vacanze_view.js
@@ -1,4 +1,25 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const noteForm = document.getElementById('noteForm');
+  if(noteForm){
+    ClassicEditor.create(document.getElementById('noteEditor')).then(editor => {
+      noteForm.addEventListener('submit', e => {
+        e.preventDefault();
+        const fd = new FormData();
+        fd.append('id_viaggio', viaggioId);
+        fd.append('note', editor.getData());
+        fetch('ajax/update_viaggi_note.php', { method: 'POST', body: fd })
+          .then(r => r.json())
+          .then(res => {
+            if(res.success){
+              window.location.reload();
+            } else {
+              alert(res.error || 'Errore');
+            }
+          });
+      });
+    });
+  }
+
   const docForm = document.getElementById('docForm');
   if(docForm){
     docForm.addEventListener('submit', e => {

--- a/vacanze_lista_dettaglio.php
+++ b/vacanze_lista_dettaglio.php
@@ -88,6 +88,15 @@ $docRes = $docStmt->get_result();
   </div>
 
   <div class="mb-4">
+    <h5 class="mb-3">Note</h5>
+    <?php if (trim($viaggio['note'] ?? '') === ''): ?>
+      <p class="text-muted">Nessuna nota.</p>
+    <?php else: ?>
+      <div><?= $viaggio['note'] ?></div>
+    <?php endif; ?>
+  </div>
+
+  <div class="mb-4">
     <h5 class="mb-3">Alternative</h5>
     <?php if ($altRes->num_rows === 0): ?>
       <p class="text-muted">Nessuna alternativa.</p>

--- a/vacanze_view.php
+++ b/vacanze_view.php
@@ -68,6 +68,22 @@ $docRes = $docStmt->get_result();
   </h4>
 
   <div class="mb-4">
+    <h5 class="mb-3">Note</h5>
+    <?php if ($canUpdateViaggio): ?>
+      <form id="noteForm">
+        <textarea id="noteEditor" name="note" class="form-control bg-dark text-white border-secondary mb-2" rows="4"><?= htmlspecialchars($viaggio['note']) ?></textarea>
+        <button type="submit" class="btn btn-primary">Salva</button>
+      </form>
+    <?php else: ?>
+      <?php if (trim($viaggio['note'] ?? '') === ''): ?>
+        <p class="text-muted">Nessuna nota.</p>
+      <?php else: ?>
+        <div><?= $viaggio['note'] ?></div>
+      <?php endif; ?>
+    <?php endif; ?>
+  </div>
+
+  <div class="mb-4">
     <div class="d-flex justify-content-between mb-3 align-items-center">
       <h5 class="m-0">Alternative</h5>
       <?php if ($canAddAlternativa): ?>
@@ -206,6 +222,7 @@ $docRes = $docStmt->get_result();
   </div>
   <?php endif; ?>
 
+  <script src="https://cdn.ckeditor.com/ckeditor5/35.3.0/classic/ckeditor.js"></script>
   <script>const viaggioId = <?= $id ?>;</script>
   <script src="js/vacanze_view.js"></script>
 </div>


### PR DESCRIPTION
## Summary
- add rich text notes section to trip view page
- display saved notes in public trip detail
- allow updating trip notes via new AJAX endpoint

## Testing
- `php -l vacanze_view.php`
- `php -l vacanze_lista_dettaglio.php`
- `php -l ajax/update_viaggi_note.php`


------
https://chatgpt.com/codex/tasks/task_e_68b33d9b9d048331bc6c0480f9ff0a97