### PR TITLE
Gestisci pasti e costi extra nelle alternative vacanze

### DIFF
--- a/ajax/get_viaggi_alternativa.php
+++ b/ajax/get_viaggi_alternativa.php
@@ -8,7 +8,7 @@ $idViaggio = (int)($_GET['id_viaggio'] ?? 0);
 $idAlt = (int)($_GET['id_alternativa'] ?? 0);
 if (!$idViaggio || !$idAlt) { echo json_encode(['success'=>false,'error'=>'Parametri mancanti']); exit; }
 
-$stmt = $conn->prepare('SELECT breve_descrizione, totale_trasporti, totale_alloggi, totale_viaggio FROM v_totali_alternative WHERE id_viaggio=? AND id_viaggio_alternativa=?');
+$stmt = $conn->prepare('SELECT breve_descrizione, totale_trasporti, totale_alloggi, totale_pasti, totale_altri_costi, totale_viaggio FROM v_totali_alternative WHERE id_viaggio=? AND id_viaggio_alternativa=?');
 $stmt->bind_param('ii', $idViaggio, $idAlt);
 $stmt->execute();
 $alt = $stmt->get_result()->fetch_assoc();
@@ -29,7 +29,7 @@ while ($row = $trRes->fetch_assoc()) {
     ];
 }
 
-$allStmt = $conn->prepare('SELECT nome_alloggio, DATEDIFF(data_checkout, data_checkin) * COALESCE(costo_notte_eur,0) AS totale FROM viaggi_alloggi WHERE id_viaggio=? AND id_viaggio_alternativa=? ORDER BY id_alloggio');
+$allStmt = $conn->prepare('SELECT nome_alloggio, data_checkin, data_checkout, DATEDIFF(data_checkout, data_checkin) * COALESCE(costo_notte_eur,0) AS totale FROM viaggi_alloggi WHERE id_viaggio=? AND id_viaggio_alternativa=? ORDER BY id_alloggio');
 $allStmt->bind_param('ii', $idViaggio, $idAlt);
 $allStmt->execute();
 $allRes = $allStmt->get_result();
@@ -37,7 +37,44 @@ $alloggi = [];
 while ($row = $allRes->fetch_assoc()) {
     $alloggi[] = [
         'nome_alloggio' => $row['nome_alloggio'],
+        'data_checkin' => $row['data_checkin'],
+        'data_checkout' => $row['data_checkout'],
         'totale' => number_format($row['totale'], 2, ',', '.')
+    ];
+}
+
+$paStmt = $conn->prepare('SELECT giorno_indice, tipo_pasto, nome_locale, tipologia FROM viaggi_pasti WHERE id_viaggio=? AND id_viaggio_alternativa=? ORDER BY giorno_indice, id_pasto');
+$paStmt->bind_param('ii', $idViaggio, $idAlt);
+$paStmt->execute();
+$paRes = $paStmt->get_result();
+$pasti = [];
+$mealCounts = [
+    'colazione' => ['ristorante' => 0, 'cucinato' => 0],
+    'pranzo'    => ['ristorante' => 0, 'cucinato' => 0],
+    'cena'      => ['ristorante' => 0, 'cucinato' => 0],
+];
+while ($row = $paRes->fetch_assoc()) {
+    $pasti[] = [
+        'giorno_indice' => (int)$row['giorno_indice'],
+        'tipo_pasto' => $row['tipo_pasto'],
+        'nome_locale' => $row['nome_locale'],
+        'tipologia' => $row['tipologia'],
+    ];
+    $tipo = $row['tipo_pasto'];
+    $key = $row['tipologia'] === 'cucinato' ? 'cucinato' : 'ristorante';
+    $mealCounts[$tipo][$key]++;
+}
+
+$coStmt = $conn->prepare('SELECT data, importo_eur, note FROM viaggi_altri_costi WHERE id_viaggio=? AND id_viaggio_alternativa=? ORDER BY data, id_costo');
+$coStmt->bind_param('ii', $idViaggio, $idAlt);
+$coStmt->execute();
+$coRes = $coStmt->get_result();
+$altriCosti = [];
+while ($row = $coRes->fetch_assoc()) {
+    $altriCosti[] = [
+        'data' => $row['data'],
+        'note' => $row['note'],
+        'totale' => number_format($row['importo_eur'], 2, ',', '.')
     ];
 }
 
@@ -46,8 +83,13 @@ echo json_encode([
     'breve_descrizione' => $alt['breve_descrizione'],
     'totale_trasporti' => number_format($alt['totale_trasporti'], 2, ',', '.'),
     'totale_alloggi' => number_format($alt['totale_alloggi'], 2, ',', '.'),
+    'totale_pasti' => number_format($alt['totale_pasti'], 2, ',', '.'),
+    'totale_altri_costi' => number_format($alt['totale_altri_costi'], 2, ',', '.'),
     'totale_viaggio' => number_format($alt['totale_viaggio'], 2, ',', '.'),
     'tratte' => $tratte,
-    'alloggi' => $alloggi
+    'alloggi' => $alloggi,
+    'pasti' => $pasti,
+    'meal_counts' => $mealCounts,
+    'altri_costi' => $altriCosti
 ]);
 ?>

--- a/js/vacanze_lista_dettaglio.js
+++ b/js/vacanze_lista_dettaglio.js
@@ -37,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const altCards = document.querySelectorAll('.alt-card');
   const detailDiv = document.getElementById('altDettagli');
+  const tabDetailDiv = document.getElementById('altTabDettagli');
 
   const escapeMap = {
     '&': '&amp;',
@@ -49,12 +50,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function renderDetails(data){
     let html = '';
+    let detHtml = '';
+
     html += `<h5 class="mb-3">${escapeHtml(data.breve_descrizione)}</h5>`;
     html += '<h6>Tratte</h6>';
+    detHtml += '<h6>Tratte</h6>';
     if(data.tratte.length === 0){
       html += '<p class="text-muted">Nessuna tratta.</p>';
+      detHtml += '<p class="text-muted">Nessuna tratta.</p>';
     } else {
       html += '<ul class="list-group mb-3">';
+      detHtml += '<ul class="list-group list-group-flush mb-3">';
       data.tratte.forEach(t => {
         const titolo = escapeHtml(t.descrizione || t.tipo_tratta);
         let route = '';
@@ -62,23 +68,73 @@ document.addEventListener('DOMContentLoaded', () => {
           route = `<div class="small text-muted">${escapeHtml(t.origine_testo || '')} → ${escapeHtml(t.destinazione_testo || '')}</div>`;
         }
         html += `<li class="list-group-item d-flex justify-content-between"><div><div>${titolo}</div>${route}</div><div>€${t.totale}</div></li>`;
+        detHtml += `<li class="list-group-item d-flex justify-content-between"><div><div>${titolo}</div>${route}</div><div>€${t.totale}</div></li>`;
       });
       html += '</ul>';
+      detHtml += '</ul>';
     }
+
     html += '<h6>Alloggi</h6>';
+    detHtml += '<h6>Alloggi</h6>';
     if(data.alloggi.length === 0){
       html += '<p class="text-muted">Nessun alloggio.</p>';
+      detHtml += '<p class="text-muted">Nessun alloggio.</p>';
     } else {
       html += '<ul class="list-group mb-3">';
+      detHtml += '<ul class="list-group list-group-flush mb-3">';
       data.alloggi.forEach(a => {
+        const dates = (a.data_checkin || a.data_checkout) ? `<div class="small text-muted">${escapeHtml(a.data_checkin || '')} - ${escapeHtml(a.data_checkout || '')}</div>` : '';
         html += `<li class="list-group-item d-flex justify-content-between"><span>${escapeHtml(a.nome_alloggio || 'Alloggio')}</span><span>€${a.totale}</span></li>`;
+        detHtml += `<li class="list-group-item d-flex justify-content-between"><div><div>${escapeHtml(a.nome_alloggio || 'Alloggio')}</div>${dates}</div><div>€${a.totale}</div></li>`;
       });
       html += '</ul>';
+      detHtml += '</ul>';
     }
+
+    html += '<h6>Pasti</h6>';
+    detHtml += '<h6>Pasti</h6>';
+    const mc = data.meal_counts;
+    const totMeals = mc.colazione.ristorante + mc.colazione.cucinato + mc.pranzo.ristorante + mc.pranzo.cucinato + mc.cena.ristorante + mc.cena.cucinato;
+    if(totMeals === 0){
+      html += '<p class="text-muted">Nessun pasto.</p>';
+      detHtml += '<p class="text-muted">Nessun pasto.</p>';
+    } else {
+      html += `<p>Colazioni: Ristorante ${mc.colazione.ristorante}, Preparato ${mc.colazione.cucinato}</p>`;
+      html += `<p>Pranzi: Ristorante ${mc.pranzo.ristorante}, Preparato ${mc.pranzo.cucinato}</p>`;
+      html += `<p>Cene: Ristorante ${mc.cena.ristorante}, Preparato ${mc.cena.cucinato}</p>`;
+      detHtml += '<ul class="list-group list-group-flush mb-3">';
+      data.pasti.forEach(p => {
+        const locale = p.tipologia === 'cucinato' ? 'Preparato' : escapeHtml(p.nome_locale || '');
+        detHtml += `<li class="list-group-item">Giorno ${p.giorno_indice} - ${escapeHtml(p.tipo_pasto)} - ${locale} (${escapeHtml(p.tipologia)})</li>`;
+      });
+      detHtml += '</ul>';
+    }
+
+    html += '<h6>Altri costi</h6>';
+    detHtml += '<h6>Altri costi</h6>';
+    if(data.altri_costi.length === 0){
+      html += '<p class="text-muted">Nessun costo extra.</p>';
+      detHtml += '<p class="text-muted">Nessun costo extra.</p>';
+    } else {
+      html += '<ul class="list-group mb-3">';
+      detHtml += '<ul class="list-group list-group-flush mb-3">';
+      data.altri_costi.forEach(c => {
+        const descr = escapeHtml(c.note || 'Costo');
+        const date = c.data ? `${escapeHtml(c.data)} - ` : '';
+        html += `<li class="list-group-item d-flex justify-content-between"><span>${descr}</span><span>€${c.totale}</span></li>`;
+        detHtml += `<li class="list-group-item d-flex justify-content-between"><span>${date}${descr}</span><span>€${c.totale}</span></li>`;
+      });
+      html += '</ul>';
+      detHtml += '</ul>';
+    }
+
     html += `<div class="small">Trasporti: €${data.totale_trasporti}</div>`;
     html += `<div class="small">Alloggi: €${data.totale_alloggi}</div>`;
+    html += `<div class="small">Pasti: €${data.totale_pasti}</div>`;
+    html += `<div class="small">Altri costi: €${data.totale_altri_costi}</div>`;
     html += `<div class="fw-bold">Totale: €${data.totale_viaggio}</div>`;
     detailDiv.innerHTML = html;
+    tabDetailDiv.innerHTML = detHtml;
   }
 
   function loadAlt(altId, el){


### PR DESCRIPTION
## Summary
- Rimuove le sezioni statiche di alloggi e pasti dalla pagina dettagli viaggio
- Estende l'endpoint `get_viaggi_alternativa` per restituire pasti e costi extra raggruppati
- Aggiorna il rendering lato client per mostrare tratte, alloggi, pasti e costi extra dell'alternativa selezionata

## Testing
- `php -l vacanze_lista_dettaglio.php`
- `php -l ajax/get_viaggi_alternativa.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba7deadde883318b78bdc6917f74bc