### PR TITLE
Allow adding document links for trips

### DIFF
--- a/ajax/add_viaggi_documento.php
+++ b/ajax/add_viaggi_documento.php
@@ -9,19 +9,29 @@ if (!has_permission($conn, 'ajax:add_viaggi_documento', 'insert')) {
     exit;
 }
 $idViaggio = (int)($_POST['id_viaggio'] ?? 0);
-if (!$idViaggio || empty($_FILES['file']['name'])) {
+$link = trim($_POST['link'] ?? '');
+$hasFile = !empty($_FILES['file']['name']);
+if (!$idViaggio || (!$hasFile && $link === '')) {
     echo json_encode(['success'=>false,'error'=>'Dati mancanti']);
     exit;
 }
-$uploadDir = __DIR__ . '/../files/vacanze/';
-if (!is_dir($uploadDir)) {
-    mkdir($uploadDir, 0777, true);
-}
-$nomeFile = basename($_FILES['file']['name']);
-$target = $uploadDir . $nomeFile;
-if (!move_uploaded_file($_FILES['file']['tmp_name'], $target)) {
-    echo json_encode(['success'=>false,'error'=>'Upload fallito']);
-    exit;
+if ($link !== '') {
+    if (!filter_var($link, FILTER_VALIDATE_URL)) {
+        echo json_encode(['success'=>false,'error'=>'Link non valido']);
+        exit;
+    }
+    $nomeFile = $link;
+} else {
+    $uploadDir = __DIR__ . '/../files/vacanze/';
+    if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0777, true);
+    }
+    $nomeFile = basename($_FILES['file']['name']);
+    $target = $uploadDir . $nomeFile;
+    if (!move_uploaded_file($_FILES['file']['tmp_name'], $target)) {
+        echo json_encode(['success'=>false,'error'=>'Upload fallito']);
+        exit;
+    }
 }
 $idUtente = $_SESSION['utente_id'] ?? ($_SESSION['id_utente'] ?? 0);
 $ip = $_SERVER['REMOTE_ADDR'] ?? '';

--- a/vacanze_lista_dettaglio.php
+++ b/vacanze_lista_dettaglio.php
@@ -38,7 +38,7 @@ $chkStmt->bind_param('i', $id);
 $chkStmt->execute();
 $chkRes = $chkStmt->get_result();
 
-$docStmt = $conn->prepare('SELECT oc.nome_file FROM viaggi2caricamenti vc JOIN ocr_caricamenti oc ON vc.id_caricamento=oc.id_caricamento WHERE vc.id_viaggio=? ORDER BY vc.id_caricamento');
+$docStmt = $conn->prepare('SELECT oc.nome_file, oc.descrizione FROM viaggi2caricamenti vc JOIN ocr_caricamenti oc ON vc.id_caricamento=oc.id_caricamento WHERE vc.id_viaggio=? ORDER BY vc.id_caricamento');
 $docStmt->bind_param('i', $id);
 $docStmt->execute();
 $docRes = $docStmt->get_result();
@@ -169,7 +169,12 @@ $docRes = $docStmt->get_result();
       <?php else: ?>
         <ul class="list-group list-group-flush">
         <?php while($doc = $docRes->fetch_assoc()): ?>
-          <li class="list-group-item"><a href="files/vacanze/<?= urlencode($doc['nome_file']) ?>" target="_blank"><?= htmlspecialchars($doc['nome_file']) ?></a></li>
+          <?php $isLink = filter_var($doc['nome_file'], FILTER_VALIDATE_URL); ?>
+          <?php
+            $mainText = $isLink ? ($doc['descrizione'] ?: $doc['nome_file']) : $doc['nome_file'];
+            $href = $isLink ? $doc['nome_file'] : 'files/vacanze/' . urlencode($doc['nome_file']);
+          ?>
+          <li class="list-group-item"><a href="<?= htmlspecialchars($href) ?>" target="_blank"><?= htmlspecialchars($mainText) ?></a></li>
         <?php endwhile; ?>
         </ul>
       <?php endif; ?>

--- a/vacanze_view.php
+++ b/vacanze_view.php
@@ -184,13 +184,18 @@ $docRes = $docStmt->get_result();
           <div class="col">
             <div class="card bg-dark text-white h-100">
               <div class="card-body d-flex flex-column">
+                <?php
+                  $isLink = filter_var($row['nome_file'], FILTER_VALIDATE_URL);
+                  $mainText = $isLink ? ($row['descrizione'] ?: $row['nome_file']) : $row['nome_file'];
+                  $smallText = $isLink ? ($row['descrizione'] ? $row['nome_file'] : '') : ($row['descrizione'] ?: '');
+                ?>
                 <p class="card-text flex-grow-1 mb-2">
-                  <?= htmlspecialchars($row['nome_file']) ?>
-                  <?php if (!empty($row['descrizione'])): ?>
-                    <br><small class="text-muted"><?= htmlspecialchars($row['descrizione']) ?></small>
+                  <?= htmlspecialchars($mainText) ?>
+                  <?php if (!empty($smallText)): ?>
+                    <br><small class="text-muted"><?= htmlspecialchars($smallText) ?></small>
                   <?php endif; ?>
                 </p>
-                <a href="files/vacanze/<?= urlencode($row['nome_file']) ?>" class="btn btn-sm btn-outline-light mt-auto" target="_blank">Apri</a>
+                <a href="<?= $isLink ? htmlspecialchars($row['nome_file']) : 'files/vacanze/' . urlencode($row['nome_file']) ?>" class="btn btn-sm btn-outline-light mt-auto" target="_blank">Apri</a>
               </div>
             </div>
           </div>
@@ -209,10 +214,14 @@ $docRes = $docStmt->get_result();
         </div>
         <div class="modal-body">
           <div class="mb-3">
-            <input type="file" name="file" class="form-control" required>
+            <input type="file" name="file" class="form-control">
+          </div>
+          <div class="mb-3">
+            <input type="url" name="link" class="form-control" placeholder="Link (Drive, ecc.)">
           </div>
           <div class="mb-3">
             <input type="text" name="descrizione" class="form-control" placeholder="Descrizione">
+            <small class="form-text">Inserisci un file oppure un link.</small>
           </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
## Summary
- Permit adding document links (e.g., Drive) in trip management
- Show document links or files in trip details and list views
- Handle link uploads server-side without requiring a file

## Testing
- `php -l vacanze_view.php`
- `php -l vacanze_lista_dettaglio.php`
- `php -l ajax/add_viaggi_documento.php`
- `node --check js/vacanze_view.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68ba7ef01a588331bffb8b87249d378f