### PR TITLE
Add quick description mapping button on movement detail

### DIFF
--- a/ajax/add_descrizione2id.php
+++ b/ajax/add_descrizione2id.php
@@ -1,0 +1,22 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+
+$descrizione = trim($_POST['descrizione'] ?? '');
+$id_gruppo = (int)($_POST['id_gruppo_transazione'] ?? 0);
+$conto = $_POST['conto'] ?? '';
+$id_etichetta = isset($_POST['id_etichetta']) && $_POST['id_etichetta'] !== '' ? (int)$_POST['id_etichetta'] : null;
+$id_metodo = (int)($_POST['id_metodo_pagamento'] ?? 0);
+
+if ($descrizione === '' || !$id_gruppo || $conto === '') {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $conn->prepare('INSERT INTO bilancio_descrizione2id (id_utente, descrizione, id_gruppo_transazione, id_metodo_pagamento, id_etichetta, descrizione_extra, conto) VALUES (?, ?, ?, ?, ?, NULL, ?)');
+$stmt->bind_param('isiiis', $_SESSION['utente_id'], $descrizione, $id_gruppo, $id_metodo, $id_etichetta, $conto);
+$ok = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $ok]);


### PR DESCRIPTION
## Summary
- Add top-right button on movement detail to quickly map descriptions to `bilancio_descrizione2id`
- Provide modal form for description, group, account and optional label
- Introduce AJAX endpoint to insert new mapping

## Testing
- `php -l dettaglio.php`
- `php -l ajax/add_descrizione2id.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba7e53a4208331b804534a6c423fe5