### PR TITLE
Add description field for extra vacation costs

### DIFF
--- a/ajax/get_viaggi_alternativa.php
+++ b/ajax/get_viaggi_alternativa.php
@@ -65,7 +65,7 @@ while ($row = $paRes->fetch_assoc()) {
     $mealCounts[$tipo][$key]++;
 }
 
-$coStmt = $conn->prepare('SELECT data, importo_eur, note FROM viaggi_altri_costi WHERE id_viaggio=? AND id_viaggio_alternativa=? ORDER BY data, id_costo');
+$coStmt = $conn->prepare('SELECT data, importo_eur, descrizione FROM viaggi_altri_costi WHERE id_viaggio=? AND id_viaggio_alternativa=? ORDER BY data, id_costo');
 $coStmt->bind_param('ii', $idViaggio, $idAlt);
 $coStmt->execute();
 $coRes = $coStmt->get_result();
@@ -73,7 +73,7 @@ $altriCosti = [];
 while ($row = $coRes->fetch_assoc()) {
     $altriCosti[] = [
         'data' => $row['data'],
-        'note' => $row['note'],
+        'descrizione' => $row['descrizione'],
         'totale' => number_format($row['importo_eur'], 2, ',', '.')
     ];
 }

--- a/js/vacanze_lista_dettaglio.js
+++ b/js/vacanze_lista_dettaglio.js
@@ -119,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
       html += '<ul class="list-group mb-3">';
       detHtml += '<ul class="list-group list-group-flush mb-3">';
       data.altri_costi.forEach(c => {
-        const descr = escapeHtml(c.note || 'Costo');
+        const descr = escapeHtml(c.descrizione || 'Costo');
         const date = c.data ? `${escapeHtml(c.data)} - ` : '';
         html += `<li class="list-group-item d-flex justify-content-between"><span>${descr}</span><span>€${c.totale}</span></li>`;
         detHtml += `<li class="list-group-item d-flex justify-content-between"><span>${date}${descr}</span><span>€${c.totale}</span></li>`;

--- a/sql/struttura.sql
+++ b/sql/struttura.sql
@@ -2619,6 +2619,10 @@ ALTER TABLE `utenti2salvadanai`
   ADD CONSTRAINT `fk_u2s_salvadanaio` FOREIGN KEY (`id_salvadanaio`) REFERENCES `salvadanai` (`id_salvadanaio`) ON DELETE CASCADE,
   ADD CONSTRAINT `fk_u2s_utente` FOREIGN KEY (`id_utente`) REFERENCES `utenti` (`id`) ON DELETE CASCADE;
 
+-- Modifica tabella `viaggi_altri_costi` per aggiungere descrizione
+ALTER TABLE `viaggi_altri_costi`
+  ADD COLUMN `descrizione` varchar(255) DEFAULT NULL AFTER `importo_eur`;
+
 -- Modifiche per gestione luoghi viaggi
 ALTER TABLE `viaggi_luoghi`
   ADD COLUMN `place_id` varchar(255) DEFAULT NULL;

--- a/vacanze_altri_costi_dettaglio.php
+++ b/vacanze_altri_costi_dettaglio.php
@@ -24,6 +24,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $id_alt = (int)($_POST['id_viaggio_alternativa'] ?? $alt);
     $data = $_POST['data'] ?: null;
     $importo = $_POST['importo_eur'] !== '' ? (float)$_POST['importo_eur'] : null;
+    $descrizione = $_POST['descrizione'] ?? null;
     $note = $_POST['note'] ?? null;
 
     if (isset($_POST['delete']) && $id_costo) {
@@ -31,12 +32,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $del->bind_param('ii', $id_costo, $id);
         $del->execute();
     } elseif ($id_costo) {
-        $upd = $conn->prepare('UPDATE viaggi_altri_costi SET id_viaggio_alternativa=?, data=?, importo_eur=?, note=? WHERE id_costo=? AND id_viaggio=?');
-        $upd->bind_param('isdsii', $id_alt, $data, $importo, $note, $id_costo, $id);
+        $upd = $conn->prepare('UPDATE viaggi_altri_costi SET id_viaggio_alternativa=?, data=?, importo_eur=?, descrizione=?, note=? WHERE id_costo=? AND id_viaggio=?');
+        $upd->bind_param('isdssii', $id_alt, $data, $importo, $descrizione, $note, $id_costo, $id);
         $upd->execute();
     } else {
-        $ins = $conn->prepare('INSERT INTO viaggi_altri_costi (id_viaggio, id_viaggio_alternativa, data, importo_eur, note) VALUES (?,?,?,?,?)');
-        $ins->bind_param('iisds', $id, $id_alt, $data, $importo, $note);
+        $ins = $conn->prepare('INSERT INTO viaggi_altri_costi (id_viaggio, id_viaggio_alternativa, data, importo_eur, descrizione, note) VALUES (?,?,?,?,?,?)');
+        $ins->bind_param('iisdss', $id, $id_alt, $data, $importo, $descrizione, $note);
         $ins->execute();
     }
     header('Location: vacanze_tratte.php?id=' . $id . '&alt=' . $id_alt);
@@ -47,6 +48,7 @@ $costo = [
     'id_viaggio_alternativa' => $alt,
     'data' => '',
     'importo_eur' => '',
+    'descrizione' => '',
     'note' => '',
 ];
 
@@ -95,6 +97,10 @@ $alt_desc = $alternative[$alt] ?? '';
     <div class="mb-3">
       <label class="form-label">Importo €</label>
       <input type="number" step="0.01" class="form-control" name="importo_eur" value="<?= htmlspecialchars($costo['importo_eur']) ?>">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Descrizione</label>
+      <input type="text" class="form-control" name="descrizione" value="<?= htmlspecialchars($costo['descrizione']) ?>">
     </div>
     <div class="mb-3">
       <label class="form-label">Note</label>

--- a/vacanze_tratte.php
+++ b/vacanze_tratte.php
@@ -224,8 +224,8 @@ $canUpdateCosto = has_permission($conn, 'table:viaggi_altri_costi', 'update');
         <?php endif; ?>
           <div class="d-flex justify-content-between">
             <div>
-              <div><?= htmlspecialchars($row['data'] ?? '') ?></div>
-              <?php if (!empty($row['note'])): ?><div class="small text-muted"><?= htmlspecialchars($row['note']) ?></div><?php endif; ?>
+              <div><?= htmlspecialchars($row['descrizione'] ?: 'Costo') ?></div>
+              <?php if (!empty($row['data'])): ?><div class="small text-muted"><?= htmlspecialchars($row['data']) ?></div><?php endif; ?>
             </div>
             <div>€<?= number_format($row['importo_eur'] ?? 0, 2, ',', '.') ?>
               <?php if ($canUpdateCosto): ?><i class="bi bi-pencil ms-2"></i><?php endif; ?>


### PR DESCRIPTION
## Summary
- Allow adding a description for extra vacation costs and store it in the database
- Show cost descriptions in vacation routes and list details while hiding notes
- Update database schema with `descrizione` column for `viaggi_altri_costi`

## Testing
- `php -l vacanze_altri_costi_dettaglio.php`
- `php -l vacanze_tratte.php`
- `php -l ajax/get_viaggi_alternativa.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba89aaaab88331b3fdecbc49beccf8