### PR TITLE
Add deletion option for travel alternative in vacation routes

### DIFF
--- a/ajax/delete_viaggi_alternativa.php
+++ b/ajax/delete_viaggi_alternativa.php
@@ -1,0 +1,77 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+
+if (!has_permission($conn, 'ajax:delete_viaggi_alternativa', 'delete')) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Accesso negato']);
+    exit;
+}
+
+$idViaggio = (int)($_POST['id_viaggio'] ?? 0);
+$idAlt = (int)($_POST['id_viaggio_alternativa'] ?? 0);
+
+if (!$idViaggio || !$idAlt) {
+    echo json_encode(['success' => false, 'error' => 'Dati mancanti']);
+    exit;
+}
+
+$checkStmt = $conn->prepare('SELECT 1 FROM viaggi_alternative WHERE id_viaggio_alternativa=? AND id_viaggio=?');
+$checkStmt->bind_param('ii', $idAlt, $idViaggio);
+$checkStmt->execute();
+$checkStmt->store_result();
+if ($checkStmt->num_rows === 0) {
+    $checkStmt->close();
+    echo json_encode(['success' => false, 'error' => 'Alternativa non trovata']);
+    exit;
+}
+$checkStmt->close();
+
+$transactionStarted = false;
+try {
+    if (!$conn->begin_transaction()) {
+        throw new Exception('Impossibile avviare la transazione');
+    }
+    $transactionStarted = true;
+
+    $tables = [
+        'viaggi_tratte' => 'DELETE FROM viaggi_tratte WHERE id_viaggio=? AND id_viaggio_alternativa=?',
+        'viaggi_alloggi' => 'DELETE FROM viaggi_alloggi WHERE id_viaggio=? AND id_viaggio_alternativa=?',
+        'viaggi_pasti' => 'DELETE FROM viaggi_pasti WHERE id_viaggio=? AND id_viaggio_alternativa=?',
+        'viaggi_altri_costi' => 'DELETE FROM viaggi_altri_costi WHERE id_viaggio=? AND id_viaggio_alternativa=?'
+    ];
+
+    foreach ($tables as $sql) {
+        $stmt = $conn->prepare($sql);
+        if (!$stmt) {
+            throw new Exception('Errore durante la preparazione della query');
+        }
+        $stmt->bind_param('ii', $idViaggio, $idAlt);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            throw new Exception('Errore durante l\'eliminazione dei dati collegati');
+        }
+        $stmt->close();
+    }
+
+    $delAlt = $conn->prepare('DELETE FROM viaggi_alternative WHERE id_viaggio_alternativa=? AND id_viaggio=?');
+    if (!$delAlt) {
+        throw new Exception('Errore durante la preparazione della query di eliminazione');
+    }
+    $delAlt->bind_param('ii', $idAlt, $idViaggio);
+    if (!$delAlt->execute()) {
+        $delAlt->close();
+        throw new Exception('Errore durante l\'eliminazione dell\'alternativa');
+    }
+    $delAlt->close();
+
+    $conn->commit();
+    echo json_encode(['success' => true]);
+} catch (Exception $ex) {
+    if (!empty($transactionStarted)) {
+        $conn->rollback();
+    }
+    echo json_encode(['success' => false, 'error' => $ex->getMessage()]);
+}

--- a/js/vacanze_tratte.js
+++ b/js/vacanze_tratte.js
@@ -25,6 +25,31 @@ document.addEventListener('DOMContentLoaded', () => {
       if (href) window.location.href = href;
     });
   });
+
+  const deleteBtn = document.getElementById('deleteAltBtn');
+  if(deleteBtn){
+    deleteBtn.addEventListener('click', () => {
+      if(!confirm('Confermi l\'eliminazione dell\'alternativa? Tutti i dati associati saranno rimossi.')) return;
+      deleteBtn.disabled = true;
+      const fd = new FormData();
+      fd.append('id_viaggio', viaggioId);
+      fd.append('id_viaggio_alternativa', altId);
+      fetch('ajax/delete_viaggi_alternativa.php', { method:'POST', body: fd })
+        .then(r => r.json())
+        .then(res => {
+          if(res.success){
+            window.location.href = `vacanze_view.php?id=${viaggioId}`;
+          } else {
+            alert(res.error || 'Errore');
+            deleteBtn.disabled = false;
+          }
+        })
+        .catch(() => {
+          alert('Errore di comunicazione');
+          deleteBtn.disabled = false;
+        });
+    });
+  }
 });
 
 function initMap(){

--- a/vacanze_tratte.php
+++ b/vacanze_tratte.php
@@ -60,6 +60,7 @@ $altri_costi = $coRes->fetch_all(MYSQLI_ASSOC);
 $canEditAlt = has_permission($conn, 'ajax:update_viaggi_alternativa', 'update');
 $canInsertTratta = has_permission($conn, 'table:viaggi_tratte', 'insert');
 $canUpdateTratta = has_permission($conn, 'table:viaggi_tratte', 'update');
+$canDeleteAlt = has_permission($conn, 'ajax:delete_viaggi_alternativa', 'delete');
 $canInsertAlloggio = has_permission($conn, 'table:viaggi_alloggi', 'insert');
 $canUpdateAlloggio = has_permission($conn, 'table:viaggi_alloggi', 'update');
 $canInsertPasto = has_permission($conn, 'table:viaggi_pasti', 'insert');
@@ -244,6 +245,14 @@ $canUpdateCosto = has_permission($conn, 'table:viaggi_altri_costi', 'update');
   <h4 class="mb-3 mt-4">Mappa</h4>
   <div id="map" style="height:500px"></div>
 
+  <?php if ($canDeleteAlt): ?>
+  <div class="mt-4">
+    <button type="button" id="deleteAltBtn" class="btn btn-danger w-100">
+      <i class="bi bi-trash me-1"></i> Elimina alternativa
+    </button>
+  </div>
+  <?php endif; ?>
+
   <?php if ($canEditAlt): ?>
   <div class="modal fade" id="altEditModal" tabindex="-1">
     <div class="modal-dialog">
@@ -268,6 +277,7 @@ $canUpdateCosto = has_permission($conn, 'table:viaggi_altri_costi', 'update');
   <?php endif; ?>
 
   <script>
+    const viaggioId = <?= $id ?>;
     const altId = <?= $alt ?>;
     const alloggi = <?= json_encode($alloggi) ?>;
     const tratte = <?= json_encode($tratte) ?>;


### PR DESCRIPTION
## Summary
- add permission-controlled delete button to the vacation routes page
- handle client-side deletion workflow and redirection after removing an alternative
- create an AJAX endpoint that removes the alternative and its related data inside a transaction

## Testing
- php -l vacanze_tratte.php
- php -l ajax/delete_viaggi_alternativa.php

------
https://chatgpt.com/codex/tasks/task_e_68ca77e9d93c8331a0ced91e7428f8b8