### PR TITLE
Enable editing salvadanaio due date

### DIFF
--- a/ajax/update_salvadanaio.php
+++ b/ajax/update_salvadanaio.php
@@ -6,6 +6,8 @@ include '../includes/db.php';
 $id_salvadanaio = (int)($_POST['id_salvadanaio'] ?? 0);
 $nome = $_POST['nome_salvadanaio'] ?? '';
 $importo = isset($_POST['importo_attuale']) ? (float)$_POST['importo_attuale'] : 0;
+$data_scadenza = $_POST['data_scadenza'] ?? null;
+$data_scadenza = $data_scadenza !== null && $data_scadenza !== '' ? $data_scadenza : null;
 $now = date('Y-m-d H:i:s');
 
 if(!$id_salvadanaio || $nome === ''){
@@ -13,8 +15,8 @@ if(!$id_salvadanaio || $nome === ''){
     exit;
 }
 
-$stmt = $conn->prepare('UPDATE salvadanai SET nome_salvadanaio=?, importo_attuale=?, data_aggiornamento_manuale=? WHERE id_salvadanaio=?');
-$stmt->bind_param('sdsi', $nome, $importo, $now, $id_salvadanaio);
+$stmt = $conn->prepare('UPDATE salvadanai SET nome_salvadanaio=?, importo_attuale=?, data_aggiornamento_manuale=?, data_scadenza=? WHERE id_salvadanaio=?');
+$stmt->bind_param('sdssi', $nome, $importo, $now, $data_scadenza, $id_salvadanaio);
 $success = $stmt->execute();
 $stmt->close();
 

--- a/js/salvadanaio_dettaglio.js
+++ b/js/salvadanaio_dettaglio.js
@@ -15,6 +15,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('salvadanaioForm');
     form.nome_salvadanaio.value = salvadanaioData.nome_salvadanaio || '';
     form.importo_attuale.value = salvadanaioData.importo_attuale || '';
+    if (form.data_scadenza) {
+      form.data_scadenza.value = salvadanaioData.data_scadenza || '';
+    }
     new bootstrap.Modal(document.getElementById('salvadanaioModal')).show();
   });
 

--- a/salvadanaio_dettaglio.php
+++ b/salvadanaio_dettaglio.php
@@ -34,6 +34,7 @@ $data = [
     'id_salvadanaio' => 0,
     'nome_salvadanaio' => '',
     'importo_attuale' => 0,
+    'data_scadenza' => null,
 ];
 $finanze = [];
 $eventiDisponibili = [];
@@ -166,6 +167,10 @@ if ($id > 0): ?>
         <div class="mb-3">
           <label class="form-label">Importo attuale</label>
           <input type="number" step="0.01" name="importo_attuale" class="form-control bg-secondary text-white">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Data scadenza</label>
+          <input type="date" name="data_scadenza" class="form-control bg-secondary text-white">
         </div>
       </div>
       <div class="modal-footer">
@@ -320,7 +325,8 @@ if ($id > 0): ?>
 const salvadanaioData = {
   id: <?= (int)$data['id_salvadanaio'] ?>,
   nome_salvadanaio: <?= json_encode($data['nome_salvadanaio']) ?>,
-  importo_attuale: <?= json_encode(number_format((float)$data['importo_attuale'], 2, '.', '')) ?>
+  importo_attuale: <?= json_encode(number_format((float)$data['importo_attuale'], 2, '.', '')) ?>,
+  data_scadenza: <?= json_encode($data['data_scadenza']) ?>
 };
 </script>
 <script src="js/salvadanaio_dettaglio.js"></script>


### PR DESCRIPTION
## Summary
- expose the salvadanaio due date in the edit modal with a date picker field
- preload the modal with the current deadline and persist it through the update endpoint

## Testing
- php -l salvadanaio_dettaglio.php
- php -l ajax/update_salvadanaio.php

------
https://chatgpt.com/codex/tasks/task_e_68ca7dbcd900833185d80ab470fb60a9