### PR TITLE
Include event description when creating Google rule

### DIFF
--- a/ajax/add_evento_google_rule.php
+++ b/ajax/add_evento_google_rule.php
@@ -37,7 +37,10 @@ if (!$idTipo && !$inv) {
 }
 $stmt = $conn->prepare('INSERT INTO eventi_google_rules (creator_email, description_keyword, id_tipo_evento, attiva) VALUES (?,?,?,1)');
 $creatorEmail = $ev['creator_email'];
-$descrizione = $ev['descrizione'];
+$descrizione = trim($_POST['descrizione'] ?? '');
+if ($descrizione === '') {
+    $descrizione = $ev['descrizione'];
+}
 $stmt->bind_param('ssi', $creatorEmail, $descrizione, $idTipo);
 $stmt->execute();
 $ruleId = $stmt->insert_id;

--- a/eventi_dettaglio.php
+++ b/eventi_dettaglio.php
@@ -166,7 +166,7 @@ include 'includes/header.php';
     <h4 class="mb-0" id="eventoTitolo"><?= htmlspecialchars($evento['titolo'] ?? '') ?></h4>
     <div>
       <?php if ($showAddRule): ?>
-        <i class="bi bi-star me-2" id="addRuleBtn" data-id="<?= $id ?>" style="cursor:pointer"></i>
+        <i class="bi bi-star me-2" id="addRuleBtn" data-id="<?= $id ?>" data-descrizione="<?= htmlspecialchars($evento['descrizione'] ?? '', ENT_QUOTES) ?>" style="cursor:pointer"></i>
       <?php endif; ?>
       <?php if ($canUpdate): ?>
         <i class="bi bi-pencil-square" id="editEventoBtn" style="cursor:pointer"></i>

--- a/js/eventi_dettaglio.js
+++ b/js/eventi_dettaglio.js
@@ -251,6 +251,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if(!confirm('Salvare regola per questo evento?')) return;
       const fd = new FormData();
       fd.append('id_evento', this.dataset.id);
+      if (this.dataset.descrizione !== undefined) {
+        fd.append('descrizione', this.dataset.descrizione ?? '');
+      }
     fetch('ajax/add_evento_google_rule.php', {method:'POST', body:fd})
       .then(r=>r.json())
       .then(res=>{


### PR DESCRIPTION
## Summary
- expose the event description on the rule creation button so it can be reused when generating Google rules
- send the description with the rule creation request and fall back to the stored text when missing on the server side

## Testing
- php -l eventi_dettaglio.php
- php -l ajax/add_evento_google_rule.php

------
https://chatgpt.com/codex/tasks/task_e_68d3e9d326dc8331b483507817a46459