### PR TITLE
Add ability to delete salvadanai from detail page

### DIFF
--- a/ajax/delete_salvadanaio.php
+++ b/ajax/delete_salvadanaio.php
@@ -1,0 +1,51 @@
+<?php
+header('Content-Type: application/json');
+include '../includes/session_check.php';
+include '../includes/db.php';
+require_once '../includes/permissions.php';
+
+if (!has_permission($conn, 'table:salvadanai', 'delete')) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Accesso negato']);
+    exit;
+}
+
+$id = (int)($_POST['id_salvadanaio'] ?? 0);
+if (!$id) {
+    echo json_encode(['success' => false, 'error' => 'ID non valido']);
+    exit;
+}
+
+$conn->begin_transaction();
+try {
+    $stmt = $conn->prepare('DELETE FROM budget WHERE id_salvadanaio = ?');
+    $stmt->bind_param('i', $id);
+    if (!$stmt->execute()) {
+        throw new Exception($stmt->error);
+    }
+    $stmt->close();
+
+    $stmt = $conn->prepare('DELETE FROM eventi_eventi2salvadanai_etichette WHERE id_salvadanaio = ?');
+    $stmt->bind_param('i', $id);
+    if (!$stmt->execute()) {
+        throw new Exception($stmt->error);
+    }
+    $stmt->close();
+
+    $stmt = $conn->prepare('DELETE FROM salvadanai WHERE id_salvadanaio = ?');
+    $stmt->bind_param('i', $id);
+    if (!$stmt->execute()) {
+        throw new Exception($stmt->error);
+    }
+    if ($stmt->affected_rows === 0) {
+        throw new Exception('Salvadanaio non trovato');
+    }
+    $stmt->close();
+
+    $conn->commit();
+    echo json_encode(['success' => true]);
+} catch (Throwable $e) {
+    $conn->rollback();
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}

--- a/js/salvadanaio_dettaglio.js
+++ b/js/salvadanaio_dettaglio.js
@@ -126,4 +126,20 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(r=>r.json())
       .then(res=>{ if(res.success) location.reload(); else alert(res.error||'Errore'); });
   });
+
+  document.getElementById('deleteSalvadanaioBtn')?.addEventListener('click', () => {
+    if(!salvadanaioData?.id || !confirm('Eliminare questo salvadanaio?')) return;
+    const fd = new FormData();
+    fd.append('id_salvadanaio', salvadanaioData.id);
+    fetch('ajax/delete_salvadanaio.php', {method:'POST', body:fd})
+      .then(r=>r.json())
+      .then(res=>{
+        if(res.success){
+          window.location.href = 'salvadanai.php';
+        } else {
+          alert(res.error || 'Errore');
+        }
+      })
+      .catch(() => alert('Errore'));
+  });
 });

--- a/salvadanaio_dettaglio.php
+++ b/salvadanaio_dettaglio.php
@@ -4,6 +4,7 @@ include 'includes/db.php';
 require_once 'includes/permissions.php';
 require_once 'includes/render_budget.php';
 if (!has_permission($conn, 'page:salvadanai.php', 'view')) { http_response_code(403); exit('Accesso negato'); }
+$canDeleteSalvadanaio = has_permission($conn, 'table:salvadanai', 'delete');
 
 function getEnumValues(mysqli $conn, string $table, string $field): array {
     $values = [];
@@ -149,6 +150,9 @@ if ($id > 0): ?>
       <?php render_budget($row); ?>
     <?php endforeach; ?>
   </div>
+  <?php if ($canDeleteSalvadanaio): ?>
+    <button type="button" class="btn btn-danger w-100 mt-4" id="deleteSalvadanaioBtn">Elimina</button>
+  <?php endif; ?>
 </div>
 
 <div class="modal fade" id="salvadanaioModal" tabindex="-1">


### PR DESCRIPTION
## Summary
- show a delete button on the salvadanaio detail page when the user has delete permissions
- wire the delete button to call a new AJAX endpoint and redirect back to the list on success
- implement the backend endpoint to remove the salvadanaio and related records safely

## Testing
- php -l salvadanaio_dettaglio.php
- php -l ajax/delete_salvadanaio.php

------
https://chatgpt.com/codex/tasks/task_e_68d3ed120b6c83318cc2dc6a496ff354