### PR TITLE
Show movimento group information

### DIFF
--- a/ajax/load_movimenti_mese.php
+++ b/ajax/load_movimenti_mese.php
@@ -17,8 +17,9 @@ if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette,
-                   bm.id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella, null as mezzo
+                   bm.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'revolut' AS source, 'movimenti_revolut' AS tabella, null as mezzo
             FROM v_movimenti_revolut_filtrati bm
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = bm.id_gruppo_transazione
             UNION ALL";
 }
 
@@ -30,8 +31,9 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
-                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
+                   be.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
             FROM bilancio_entrate be
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = be.id_gruppo_transazione
             WHERE be.id_utente = {$idUtente}
             UNION ALL
             SELECT bu.id_uscita AS id, COALESCE(NULLIF(bu.descrizione_extra,''), bu.descrizione_operazione) AS descrizione, bu.descrizione_extra,
@@ -40,8 +42,9 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
-                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
+                   bu.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
             FROM bilancio_uscite bu
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = bu.id_gruppo_transazione
             WHERE bu.id_utente = {$idUtente}
         ) t
         WHERE DATE_FORMAT(data_operazione, '%Y-%m') = ?

--- a/ajax/search_movimenti.php
+++ b/ajax/search_movimenti.php
@@ -16,8 +16,9 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette,
-                   bm.id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella, NULL AS mezzo
+                   bm.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'revolut' AS source, 'movimenti_revolut' AS tabella, NULL AS mezzo
             FROM v_movimenti_revolut_filtrati bm
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = bm.id_gruppo_transazione
             UNION ALL
             SELECT be.id_entrata AS id, COALESCE(NULLIF(be.descrizione_extra,''), be.descrizione_operazione) AS descrizione, be.descrizione_extra, be.descrizione_operazione as descrizione_operazione,
                    be.data_operazione, be.importo AS amount,
@@ -25,8 +26,9 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
-                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
+                   be.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
             FROM bilancio_entrate be
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = be.id_gruppo_transazione
             UNION ALL
             SELECT bu.id_uscita AS id, COALESCE(NULLIF(bu.descrizione_extra,''), bu.descrizione_operazione) AS descrizione, bu.descrizione_extra, bu.descrizione_operazione as descrizione_operazione,
                    bu.data_operazione, -bu.importo AS amount,
@@ -34,13 +36,14 @@ $sql = "SELECT * FROM (
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
-                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
+                   bu.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
             FROM bilancio_uscite bu
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = bu.id_gruppo_transazione
         ) t
-        WHERE descrizione LIKE ? OR descrizione_operazione LIKE ? OR descrizione_extra LIKE ? OR id_gruppo_transazione LIKE ? OR etichette LIKE ?
+        WHERE descrizione LIKE ? OR descrizione_operazione LIKE ? OR descrizione_extra LIKE ? OR id_gruppo_transazione LIKE ? OR gruppo_descrizione LIKE ? OR etichette LIKE ?
         ORDER BY data_operazione DESC LIMIT 50";
 $stmt = $conn->prepare($sql);
-$stmt->bind_param('sssss', $like, $like, $like, $like, $like);
+$stmt->bind_param('ssssss', $like, $like, $like, $like, $like, $like);
 $stmt->execute();
 $result = $stmt->get_result();
 

--- a/includes/render_movimento.php
+++ b/includes/render_movimento.php
@@ -19,8 +19,21 @@ function render_movimento(array $mov) {
     echo '<div class="movement d-flex justify-content-between align-items-start text-white text-decoration-none" data-id="' . (int)$mov['id'] . '" data-src="' . htmlspecialchars($mov['tabella'], ENT_QUOTES) . '" data-mese="' . htmlspecialchars($mese, ENT_QUOTES) . '" data-href="' . htmlspecialchars($url, ENT_QUOTES) . '" style="cursor:pointer">';
     echo '  <img src="' . htmlspecialchars($icon) . '" alt="src" class="me-2" style="width:24px;height:24px">';
     echo '  <div class="flex-grow-1 me-3">';
+    $gruppoDescrizione = trim($mov['gruppo_descrizione'] ?? '');
+    $haGruppo = !empty($mov['id_gruppo_transazione']);
+    $badgeClasse = $haGruppo ? 'bg-info text-dark' : 'bg-secondary';
+    if ($haGruppo) {
+        $descrizioneGruppo = $gruppoDescrizione !== ''
+            ? htmlspecialchars($gruppoDescrizione, ENT_QUOTES)
+            : 'ID ' . (int) $mov['id_gruppo_transazione'];
+        $badgeTesto = 'Gruppo: ' . $descrizioneGruppo;
+    } else {
+        $badgeTesto = 'Senza gruppo';
+    }
+
     echo '    <div class="descr fw-semibold">' . htmlspecialchars($mov['descrizione']) . '</div>';
     echo '    <div class="small">' . $dataOra . '</div>';
+    echo '    <div class="mt-1"><span class="badge ' . $badgeClasse . '">' . $badgeTesto . '</span></div>';
     echo '  </div>';
     echo '  <div class="text-end">';
     echo '    <div class="amount text-white">' . ($mov['amount'] >= 0 ? '+' : '') . $importo . ' €</div>';

--- a/index.php
+++ b/index.php
@@ -219,8 +219,9 @@ if (has_permission($conn, 'page:index.php-movimenti', 'view')): ?>
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette,
-                   bm.id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella, null as mezzo
-            FROM v_movimenti_revolut_filtrati bm            
+                   bm.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'revolut' AS source, 'movimenti_revolut' AS tabella, null as mezzo
+            FROM v_movimenti_revolut_filtrati bm
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = bm.id_gruppo_transazione
             UNION ALL";
   }
  $sql = "SELECT * FROM (
@@ -231,8 +232,9 @@ if (has_permission($conn, 'page:index.php-movimenti', 'view')): ?>
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
-                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
+                   be.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
             FROM bilancio_entrate be
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = be.id_gruppo_transazione
             WHERE be.id_utente = {$idUtente}
             UNION ALL
             SELECT bu.id_uscita AS id, COALESCE(NULLIF(bu.descrizione_extra,''), bu.descrizione_operazione) AS descrizione, bu.descrizione_extra,
@@ -241,8 +243,9 @@ if (has_permission($conn, 'page:index.php-movimenti', 'view')): ?>
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
-                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
+                   bu.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
             FROM bilancio_uscite bu
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = bu.id_gruppo_transazione
             WHERE bu.id_utente = {$idUtente}
         ) t
         ORDER BY data_operazione DESC LIMIT 3";
@@ -266,15 +269,16 @@ if ($result && $result->num_rows > 0): ?>
 $movimenti_revolut = "";
   if (isset($_SESSION['id_famiglia_gestione']) && $_SESSION['id_famiglia_gestione'] == 1)
   {
-    $movimenti_revolut = 
+    $movimenti_revolut =
       "SELECT id_movimento_revolut AS id, COALESCE(NULLIF(descrizione_extra,''), description) AS descrizione, bm.descrizione_extra,
                    started_date AS data_operazione, amount,
                    (SELECT GROUP_CONCAT(CONCAT(e.id_etichetta, ':', e.descrizione) SEPARATOR ',')
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bm.id_movimento_revolut AND eo.tabella_operazione='movimenti_revolut') AS etichette,
-                   bm.id_gruppo_transazione, 'revolut' AS source, 'movimenti_revolut' AS tabella, null as mezzo
-            FROM v_movimenti_revolut_filtrati bm            
+                   bm.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'revolut' AS source, 'movimenti_revolut' AS tabella, null as mezzo
+            FROM v_movimenti_revolut_filtrati bm
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = bm.id_gruppo_transazione
             UNION ALL";
   }
  $sql = "SELECT * FROM (
@@ -285,8 +289,9 @@ $movimenti_revolut = "";
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = be.id_entrata AND eo.tabella_operazione='bilancio_entrate') AS etichette,
-                   be.id_gruppo_transazione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
+                   be.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'ca' AS source, 'bilancio_entrate' AS tabella, be.mezzo
             FROM bilancio_entrate be
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = be.id_gruppo_transazione
             WHERE be.id_utente = {$idUtente}
             UNION ALL
             SELECT bu.id_uscita AS id, COALESCE(NULLIF(bu.descrizione_extra,''), bu.descrizione_operazione) AS descrizione, bu.descrizione_extra,
@@ -295,8 +300,9 @@ $movimenti_revolut = "";
                       FROM bilancio_etichette2operazioni eo
                       JOIN bilancio_etichette e ON e.id_etichetta = eo.id_etichetta
                      WHERE eo.id_tabella = bu.id_uscita AND eo.tabella_operazione='bilancio_uscite') AS etichette,
-                   bu.id_gruppo_transazione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
+                   bu.id_gruppo_transazione, g.descrizione AS gruppo_descrizione, 'ca' AS source, 'bilancio_uscite' AS tabella, bu.mezzo
             FROM bilancio_uscite bu
+            LEFT JOIN bilancio_gruppi_transazione g ON g.id_gruppo_transazione = bu.id_gruppo_transazione
             WHERE bu.id_utente = {$idUtente}
         ) t
         WHERE id_gruppo_transazione IS NULL AND data_operazione >= DATE_SUB(CURDATE(), INTERVAL 2 MONTH)


### PR DESCRIPTION
## Summary
- display movimento group badges so it is clear whether each movement belongs to a group
- join group descriptions into the dashboard, month loader, and search queries so the rendered list can show the group name
- enable the search endpoint to match against group descriptions as well

## Testing
- php -l index.php
- php -l includes/render_movimento.php
- php -l ajax/load_movimenti_mese.php
- php -l ajax/search_movimenti.php

------
https://chatgpt.com/codex/tasks/task_e_68d3f9133a808331aadb2ce3ac4558f4