### PR TITLE
Save extra description in quick save modal

### DIFF
--- a/ajax/add_descrizione2id.php
+++ b/ajax/add_descrizione2id.php
@@ -4,18 +4,23 @@ include '../includes/session_check.php';
 include '../includes/db.php';
 
 $descrizione = trim($_POST['descrizione'] ?? '');
+$descrizione_extra = trim($_POST['descrizione_extra'] ?? '');
 $id_gruppo = (int)($_POST['id_gruppo_transazione'] ?? 0);
 $conto = $_POST['conto'] ?? '';
 $id_etichetta = isset($_POST['id_etichetta']) && $_POST['id_etichetta'] !== '' ? (int)$_POST['id_etichetta'] : null;
 $id_metodo = (int)($_POST['id_metodo_pagamento'] ?? 0);
+
+if ($descrizione_extra === '') {
+    $descrizione_extra = null;
+}
 
 if ($descrizione === '' || !$id_gruppo || $conto === '') {
     echo json_encode(['success' => false]);
     exit;
 }
 
-$stmt = $conn->prepare('INSERT INTO bilancio_descrizione2id (id_utente, descrizione, id_gruppo_transazione, id_metodo_pagamento, id_etichetta, descrizione_extra, conto) VALUES (?, ?, ?, ?, ?, NULL, ?)');
-$stmt->bind_param('isiiis', $_SESSION['utente_id'], $descrizione, $id_gruppo, $id_metodo, $id_etichetta, $conto);
+$stmt = $conn->prepare('INSERT INTO bilancio_descrizione2id (id_utente, descrizione, id_gruppo_transazione, id_metodo_pagamento, id_etichetta, descrizione_extra, conto) VALUES (?, ?, ?, ?, ?, ?, ?)');
+$stmt->bind_param('isiiiss', $_SESSION['utente_id'], $descrizione, $id_gruppo, $id_metodo, $id_etichetta, $descrizione_extra, $conto);
 $ok = $stmt->execute();
 $stmt->close();
 

--- a/dettaglio.php
+++ b/dettaglio.php
@@ -400,6 +400,10 @@ include 'includes/header.php';
           <input type="text" class="form-control bg-secondary text-white" name="descrizione" value="<?= htmlspecialchars($movimento['description']) ?>" required>
         </div>
         <div class="mb-3">
+          <label class="form-label">Descrizione extra</label>
+          <input type="text" class="form-control bg-secondary text-white" name="descrizione_extra" value="<?= htmlspecialchars($movimento['descrizione_extra'] ?? '') ?>">
+        </div>
+        <div class="mb-3">
           <label class="form-label">Gruppo</label>
           <select class="form-select bg-secondary text-white" name="id_gruppo_transazione" required>
             <?php foreach ($gruppi as $g): ?>


### PR DESCRIPTION
## Summary
- add support for editing and sending the extra description from the quick save modal on movimento details
- persist the optional extra description value when creating bilancio_descrizione2id entries via the AJAX endpoint

## Testing
- php -l dettaglio.php
- php -l ajax/add_descrizione2id.php

------
https://chatgpt.com/codex/tasks/task_e_68d3fcd9e2388331b46e74f3c396ca22