### PR TITLE
Mostra campo descrizione extra nelle descrizioni

### DIFF
--- a/includes/table_config.php
+++ b/includes/table_config.php
@@ -2,7 +2,7 @@
 return [
     'bilancio_descrizione2id' => [
         'primary_key' => 'id_d2id',
-        'columns' => ['id_d2id','id_utente','descrizione','id_gruppo_transazione','id_metodo_pagamento','id_etichetta','conto']
+        'columns' => ['id_d2id','id_utente','descrizione','id_gruppo_transazione','id_metodo_pagamento','id_etichetta','descrizione_extra','conto']
     ],
     'bilancio_entrate' => [
         'primary_key' => 'id_entrata',


### PR DESCRIPTION
## Summary
- include il campo `descrizione_extra` nella configurazione della tabella `bilancio_descrizione2id` per mostrarlo e renderlo modificabile da Configurazione > Descrizioni

## Testing
- php -l includes/table_config.php

------
https://chatgpt.com/codex/tasks/task_e_68d3fd12cf1c8331b730bdeb4fe9a2e5