### PR TITLE
Parse quantity and notes during shopping list import

### DIFF
--- a/ajax/import_lista_spesa.php
+++ b/ajax/import_lista_spesa.php
@@ -9,11 +9,37 @@ $idFamiglia = $_SESSION['id_famiglia_gestione'] ?? 0;
 if ($itemsRaw === '' || !$idFamiglia) { echo json_encode(['success'=>false,'error'=>'Dati non validi']); exit; }
 $lines = array_filter(array_map('trim', preg_split("/[\r\n]+/", $itemsRaw)));
 if (empty($lines)) { echo json_encode(['success'=>false,'error'=>'Nessun elemento']); exit; }
-$stmt = $conn->prepare('INSERT INTO lista_spesa (id_famiglia, nome) VALUES (?, ?)');
-$stmt->bind_param('is', $idFamiglia, $nome);
+$stmt = $conn->prepare('INSERT INTO lista_spesa (id_famiglia, nome, quantita, note) VALUES (?, ?, ?, ?)');
+$nome = '';
+$quantita = null;
+$note = null;
+$stmt->bind_param('isss', $idFamiglia, $nome, $quantita, $note);
 $ok = true;
 foreach ($lines as $line) {
-    $nome = $line;
+    $nome = trim($line);
+    $quantita = null;
+    $note = null;
+
+    if ($nome === '') { continue; }
+
+    if (preg_match('/\[(.*?)\]\s*$/', $nome, $noteMatch)) {
+        $note = trim($noteMatch[1]);
+        $nome = trim(substr($nome, 0, -strlen($noteMatch[0])));
+    }
+
+    if (preg_match('/\(([^()]*)\)\s*$/', $nome, $qtyMatch)) {
+        $quantita = trim($qtyMatch[1]);
+        $nome = trim(substr($nome, 0, -strlen($qtyMatch[0])));
+    }
+
+    if (($note === null || $note === '') && preg_match('/\[(.*?)\]\s*$/', $nome, $noteMatch)) {
+        $note = trim($noteMatch[1]);
+        $nome = trim(substr($nome, 0, -strlen($noteMatch[0])));
+    }
+
+    if ($quantita === '') { $quantita = null; }
+    if ($note === '') { $note = null; }
+
     if ($nome === '') { continue; }
     if (!$stmt->execute()) { $ok = false; break; }
 }


### PR DESCRIPTION
## Summary
- parse optional quantity in parentheses and notes in square brackets when importing shopping list entries
- store parsed quantity and note fields while keeping the remaining text as the item name

## Testing
- php -l ajax/import_lista_spesa.php

------
https://chatgpt.com/codex/tasks/task_e_68e237efbb488331940fd15d4240e83d