### PR TITLE
Fix salvadanaio modal for names with special characters

### DIFF
--- a/salvadanaio_dettaglio.php
+++ b/salvadanaio_dettaglio.php
@@ -334,7 +334,10 @@ $salvadanaioData = [
 ];
 ?>
 <script>
-const salvadanaioData = <?= json_encode($salvadanaioData, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
+const salvadanaioData = <?= json_encode(
+    $salvadanaioData,
+    JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_INVALID_UTF8_SUBSTITUTE
+) ?>;
 </script>
 <script src="js/salvadanaio_dettaglio.js"></script>
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- ensure salvadanaio data JSON encoding substitutes invalid UTF-8 sequences so the edit modal script always loads

## Testing
- php -l salvadanaio_dettaglio.php

------
https://chatgpt.com/codex/tasks/task_e_68e238b2e6e083318c309e5e7dd02092